### PR TITLE
refactor: enhance E2E email tests with structured assertions

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -162,14 +162,15 @@ func testSingleRecipientEmail(t *testing.T, clientFactory *clientFactory, sender
 
 	client.SendEmail(t, sendReq)
 
-	// Assert that email is eventually received by SMTP server
-	assert.EventuallyWithT(t, func(t *assert.CollectT) {
-		email := senderMock.GetEmail(testEmail)
-		require.NotNil(t, email)
+	msg := requireGetEmail(t, senderMock, testEmail)
 
-		assert.Contains(t, string(email.Body), "Hello Test User!")
-		assert.Contains(t, string(email.Body), "This is a test email from Test Corp.")
-	}, 60*time.Second, 2*time.Second, "Email should be received within 60 seconds")
+	t.Run("EmailContent", func(t *testing.T) {
+		assert.Contains(t, msg.Body, "Hello Test User!")
+		assert.Contains(t, msg.Body, "This is a test email from Test Corp.")
+		assert.Equal(t, "Test Sender <sender@test.example.com>", msg.From)
+		assert.Equal(t, testEmail, msg.To)
+		assert.Equal(t, "Test Email from E2E Test", msg.Subject)
+	})
 
 	assert.EventuallyWithT(t, func(tt *assert.CollectT) {
 		stats := client.GetStats(t)
@@ -217,16 +218,17 @@ func testMultipleRecipientsEmail(t *testing.T, clientFactory *clientFactory, smt
 
 	client.SendEmail(t, sendReq)
 
-	// Assert that all emails are eventually received by SMTP server
-	assert.EventuallyWithT(t, func(t *assert.CollectT) {
-		for _, email := range testEmails {
-			msg := smtpServer.GetEmail(email)
-			require.NotNil(t, msg)
-
-			assert.Contains(t, string(msg.Body), "Hello Test User")
-			assert.Contains(t, string(msg.Body), "Your ID is: ID-")
-		}
-	}, 90*time.Second, 3*time.Second, "All emails should be received within 90 seconds")
+	for id, email := range testEmails {
+		t.Run(fmt.Sprintf("Email %d", id), func(t *testing.T) {
+			t.Parallel()
+			msg := requireGetEmail(t, smtpServer, email)
+			assert.Contains(t, msg.Body, fmt.Sprintf("Hello Test User %d", id+1))
+			assert.Contains(t, msg.Body, fmt.Sprintf("Your ID is: ID-%d", id+1))
+			assert.Equal(t, "Test Sender <sender@test.example.com>", msg.From)
+			assert.Equal(t, email, msg.To)
+			assert.Equal(t, fmt.Sprintf("Bulk Email Test - Test User %d", id+1), msg.Subject)
+		})
+	}
 
 	assert.EventuallyWithT(t, func(tt *assert.CollectT) {
 		stats := client.GetStats(t)
@@ -268,17 +270,34 @@ func testEmailWithAttachments(t *testing.T, clientFactory *clientFactory, smtpSe
 
 	client.SendEmail(t, sendReq)
 
-	// Assert that email with attachment is eventually received by SMTP server
-	assert.EventuallyWithT(t, func(t *assert.CollectT) {
-		msg := smtpServer.GetEmail(email)
-		require.NotNil(t, msg)
+	msg := requireGetEmail(t, smtpServer, email)
 
-		assert.Contains(t, string(msg.Body), "Hello Attachment Test User!")
-		assert.Contains(t, string(msg.Body), "Please find the attachment below.")
-		assert.Contains(t, string(msg.Body), "test-document.txt")
-	}, 60*time.Second, 2*time.Second, "Email with attachment")
+	t.Run("EmailContent", func(t *testing.T) {
+		assert.Contains(t, msg.Body, "Hello Attachment Test User!")
+		assert.Contains(t, msg.Body, "Please find the attachment below.")
+	})
+
+	t.Run("Attachment", func(t *testing.T) {
+		assert.Equal(t, 1, len(msg.Attachments))
+
+		att := msg.Attachments[0]
+		assert.Equal(t, "test-document.txt", att.Filename)
+		assert.Equal(t, attachmentData, att.Content)
+	})
 }
 
 func makeFakeEmail() string {
 	return strings.ToLower(faker.Email())
+}
+
+func requireGetEmail(t *testing.T, s *senderMock, email string) ParsedEmail {
+	var msg ParsedEmail
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		email := s.GetEmail(email)
+		require.NotNil(t, email)
+
+		msg = parseEmail(t, email.Body)
+	}, 60*time.Second, 2*time.Second, "Email should be received within 60 seconds")
+
+	return msg
 }

--- a/e2e/mail_test.go
+++ b/e2e/mail_test.go
@@ -1,0 +1,143 @@
+package e2e_test
+
+import (
+	"bytes"
+	"encoding/base64"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/mail"
+	"strings"
+
+	"mime/quotedprintable"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type ParsedEmail struct {
+	From        string
+	To          string
+	Subject     string
+	Body        string
+	Attachments []Attachment
+}
+
+func parseEmail(t *assert.CollectT, body []byte) ParsedEmail {
+	msg, err := mail.ReadMessage(bytes.NewReader(body))
+	require.NoError(t, err)
+
+	mediaType, params, err := mime.ParseMediaType(msg.Header.Get("Content-Type"))
+	require.NoError(t, err)
+
+	from := msg.Header.Get("From")
+	to := msg.Header.Get("To")
+	subject := msg.Header.Get("Subject")
+
+	if strings.HasPrefix(mediaType, "multipart/") {
+		emailBody, attachments := parseMultipartEmail(t, msg.Body, params["boundary"])
+		return ParsedEmail{
+			From:        from,
+			To:          to,
+			Subject:     subject,
+			Body:        emailBody,
+			Attachments: attachments,
+		}
+	}
+
+	emailBody := parseSimpleEmailBody(t, msg.Body)
+	return ParsedEmail{
+		From:        from,
+		To:          to,
+		Subject:     subject,
+		Body:        emailBody,
+		Attachments: nil,
+	}
+}
+
+type Attachment struct {
+	Filename string
+	Content  []byte
+}
+
+// readDecodedPartContent reads and decodes the content of a MIME part based on its encoding.
+func readDecodedPartContent(p *multipart.Part, t *assert.CollectT) ([]byte, string, string) {
+	contentType := p.Header.Get("Content-Type")
+	disposition := p.Header.Get("Content-Disposition")
+	contentEncoding := strings.ToLower(p.Header.Get("Content-Transfer-Encoding"))
+
+	var content []byte
+	var err error
+	switch contentEncoding {
+	case "base64":
+		content, err = parseBase64Content(p)
+		require.NoError(t, err)
+		return content, contentType, disposition
+	case "quoted-printable":
+		content, err = parseQuotedPrintableContent(p)
+		require.NoError(t, err)
+		return content, contentType, disposition
+	default:
+		slurp, err := io.ReadAll(p)
+		require.NoError(t, err)
+		content = slurp
+		return content, contentType, disposition
+	}
+}
+
+func parseQuotedPrintableContent(p *multipart.Part) ([]byte, error) {
+	qpReader := quotedprintable.NewReader(p)
+	decoded, err := io.ReadAll(qpReader)
+	if err != nil {
+		return nil, err
+	}
+	return decoded, nil
+}
+func parseBase64Content(p *multipart.Part) ([]byte, error) {
+	decoded, err := io.ReadAll(p)
+	if err != nil {
+		return nil, err
+	}
+	decodedBuf := make([]byte, base64.StdEncoding.DecodedLen(len(decoded)))
+	n, err := base64.StdEncoding.Decode(decodedBuf, decoded)
+	if err != nil {
+		return nil, err
+	}
+	return decodedBuf[:n], nil
+}
+
+// parseMultipartEmail parses the body and attachments from a multipart email.
+func parseMultipartEmail(t *assert.CollectT, body io.Reader, boundary string) (string, []Attachment) {
+	mr := multipart.NewReader(body, boundary)
+	var attachments []Attachment
+	var emailBody string
+
+	for {
+		p, err := mr.NextPart()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+
+		content, contentType, disposition := readDecodedPartContent(p, t)
+
+		if strings.HasPrefix(disposition, "attachment") {
+			filename := p.FileName()
+			attachments = append(attachments, Attachment{
+				Filename: filename,
+				Content:  content,
+			})
+		} else if strings.HasPrefix(contentType, "text/plain") ||
+			strings.HasPrefix(contentType, "text/html") {
+			emailBody = string(content)
+		}
+	}
+	return emailBody, attachments
+}
+
+// parseSimpleEmailBody reads the body from a non-multipart email.
+func parseSimpleEmailBody(t *assert.CollectT, body io.Reader) string {
+	b, err := io.ReadAll(body)
+	require.NoError(t, err)
+	return string(b)
+}


### PR DESCRIPTION
- Refactored email assertions in E2E tests to improve clarity and structure by introducing sub-tests for email content and attachments.
- Created a new utility function, requireGetEmail, to streamline email retrieval and parsing, ensuring consistent handling of email messages.
- Improved test coverage for email attributes including sender, recipient, subject, and body content across single and multiple recipient scenarios.

<!-- please add a icon to the title of this PR -->
<!-- the icon will be either 💥 (major or breaking changes), ✨ (feature additions), 🐛 (patch and bugfixes), 📖 (documentation or proposals), or 🛠️ (other things) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**  <!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #
