### PR TITLE
feat: migrate to goreleaser with release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,18 @@
+name: Release Please
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: googleapis/release-please-action@v4
+        with:
+          release-type: go
+          token: ${{ secrets.RELEASE_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,22 +1,25 @@
-name: Release Drafter
+name: Release
 
 on:
   push:
-    branches:
-      - main
-  pull_request:
-    types: [opened, reopened, synchronize]
+    tags:
+      - "v*"
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+permissions:
+  contents: write
 
 jobs:
-    update_release_draft:
-      runs-on: ubuntu-latest
-      permissions:
-        contents: read
-      steps:
-        - uses: release-drafter/release-drafter@v7
-          env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v6
+        with:
+          go-version: stable
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,23 @@
+version: 2
+
+builds:
+  - main: .
+    binary: kannon
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w
+      - -X github.com/kannon-email/kannon/cmd.Version={{.Version}}
+      - -X github.com/kannon-email/kannon/cmd.Commit={{.Commit}}
+      - -X github.com/kannon-email/kannon/cmd.Date={{.Date}}
+
+archives:
+  - formats:
+      - tar.gz
+    files:
+      - LICENSE
+      - README.md

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	Version = "dev"
+	Commit  = "none"
+	Date    = "unknown"
+)
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print version information",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Printf("kannon %s (commit: %s, built: %s)\n", Version, Commit, Date)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}


### PR DESCRIPTION
## Summary

- Replace release-drafter with release-please for automated changelog and versioning PRs on pushes to main
- Add goreleaser to build and publish `kannon` binaries (linux/darwin × amd64/arm64) on tag push
- Add `cmd/version.go` with `Version`, `Commit`, `Date` vars injected via ldflags + `kannon version` subcommand

## Test plan

- [ ] Merge PR and verify release-please opens a version bump PR on next push to main
- [ ] Push a `v*` tag and verify goreleaser builds and publishes binaries to the GitHub release
- [ ] Run `kannon version` and confirm it prints version/commit/date
- [ ] Ensure `RELEASE_TOKEN` secret is set in repo settings (PAT with `repo` + `pull-requests` scopes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a `version` command to display application version information, including commit hash and build date.

* **Chores**
  * Enhanced release automation and build pipeline configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->