### PR TITLE
fix: apply deprecated aliases before reading run flags

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/kannon-email/kannon/x/container"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -55,6 +56,8 @@ func readViperConfig() error {
 			return fmt.Errorf("cannot read config file: %v", err)
 		}
 	}
+
+	container.ApplyDeprecatedAliases()
 
 	if viper.GetBool("debug") {
 		logrus.SetLevel(logrus.DebugLevel)

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -1,0 +1,43 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+// Regression: --run-bounce / K_RUN_BOUNCE must promote to run-tracker before
+// runFlagsFromViper reads it. Otherwise the deprecated alias fires too late,
+// the registry is empty, and the process exits immediately after logging
+// "Starting Kannon runnables: []".
+func TestReadViperConfig_PromotesRunBounceBeforeFlagsAreRead(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+
+	viper.Set("run-bounce", true)
+
+	if err := readViperConfig(); err != nil {
+		t.Fatalf("readViperConfig: %v", err)
+	}
+
+	flags := runFlagsFromViper()
+	if !flags.Tracker {
+		t.Errorf("expected Tracker=true after run-bounce alias promotion, got %+v", flags)
+	}
+}
+
+func TestReadViperConfig_PromotesRunVerifierBeforeFlagsAreRead(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+
+	viper.Set("run-verifier", true)
+
+	if err := readViperConfig(); err != nil {
+		t.Fatalf("readViperConfig: %v", err)
+	}
+
+	flags := runFlagsFromViper()
+	if !flags.Validator {
+		t.Errorf("expected Validator=true after run-verifier alias promotion, got %+v", flags)
+	}
+}


### PR DESCRIPTION
## Summary
- `--run-bounce` / `K_RUN_BOUNCE=true` no longer caused the process to exit immediately with `Starting Kannon runnables: []`.
- `ApplyDeprecatedAliases()` now runs inside `readViperConfig()`, before `runFlagsFromViper()` collects the flag struct. The duplicate call still living in `container.New` is a harmless no-op.
- Same fix covers `--run-verifier` → `--run-validator` and `bump.port` → `tracker.port` for any other call site that reads viper before constructing the container.

## Root cause
`bootstrap` reads flags first, then builds the container — but the alias promotion only happened inside `container.New`. So when an operator set the deprecated key, `runFlagsFromViper` saw `run-tracker=false`, no runnables got registered, and the registry exited cleanly. The deprecation warning still printed (because the alias did run, just too late to matter).

Regressed in #339.

## Test plan
- [x] `go build ./...`
- [x] `go test ./cmd/... ./x/container/...`
- [x] New tests in `cmd/config_test.go` reproduce the bug — both fail on `main`, pass with the fix.