### PR TITLE
test(e2e): cover Bounced/Errored/Opened/Clicked outcomes (#349)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -189,9 +189,11 @@ Kannon uses NATS JetStream for reliable, decoupled messaging between its modules
 | kannon.stats.accepted  | Email accepted for sending     | Validator            | Stats               |
 | kannon.stats.rejected  | Email rejected (invalid, etc.) | Validator            | Stats               |
 | kannon.stats.delivered | Email delivered successfully   | SMTPSender           | Stats               |
-| kannon.stats.bounced   | Email bounced                  | SMTPSender, SMTP Server | Stats            |
-| kannon.stats.open      | Email opened (tracking pixel)  | Tracker              | Stats               |
-| kannon.stats.click     | Link clicked in email          | Tracker              | Stats               |
+| kannon.stats.bounced   | Email bounced (permanent)      | SMTPSender, SMTP Server | Stats            |
+| kannon.stats.soft-bounce | Email soft-bounced (transient) | SMTP Server        | Stats               |
+| kannon.stats.error     | Transient send error (retried) | SMTPSender           | Stats               |
+| kannon.stats.opened    | Email opened (tracking pixel)  | Tracker              | Stats               |
+| kannon.stats.clicked   | Link clicked in email          | Tracker              | Stats               |
 | kannon.bounce          | Bounce events from SMTP server | SMTP Server          | Dispatcher, Stats   |
 
 ### Example NATS JetStream Configuration
@@ -220,7 +222,7 @@ streams:
 - **Dispatcher**: Publishes to `kannon.sending`, listens to `kannon.bounce` and delivery/bounce/error events from NATS.
 - **SMTPSender**: Consumes from `kannon.sending`, publishes to `kannon.stats.delivered`, `kannon.stats.bounced`, etc.
 - **Validator**: Publishes to `kannon.stats.accepted` and `kannon.stats.rejected`.
-- **Tracker**: Publishes to `kannon.stats.open` and `kannon.stats.click`.
+- **Tracker**: Publishes to `kannon.stats.opened` and `kannon.stats.clicked`.
 - **Stats**: Consumes all `kannon.stats.*` topics.
 - **SMTP Server**: Publishes to `kannon.bounce` and `kannon.stats.bounced`.
 

--- a/docs/adr/0001-configurable-delivery-backoff.md
+++ b/docs/adr/0001-configurable-delivery-backoff.md
@@ -1,0 +1,97 @@
+# ADR 0001: Configurable Delivery Backoff
+
+## Status
+
+Accepted (2026-05-03).
+
+## Context
+
+`Delivery` (per `CONTEXT.md`) is the per-recipient transmission unit. When a
+send attempt fails transiently, the repository's `Reschedule` call rolls the
+row's `scheduled_time` forward by `Delivery.NextRetryAt() - now`. Until now
+that delay was hardcoded inside `internal/delivery`:
+
+```
+delay = max(5m, 2m * 2^attempts)
+```
+
+This made the e2e suite's "fail twice then succeed" scenario take ~13 minutes
+of wall-clock to converge naturally — outside any reasonable CI wall-clock
+budget. Two approaches were on the table:
+
+1. **Don't observe retry end-to-end.** Verify transient classification at the
+   unit level only (the SMTPSender chooses Bounced vs. Errored correctly),
+   and never run the reschedule loop in e2e.
+2. **Test-only DB hack.** Mutate `sending_pool_emails.scheduled_time`
+   directly from the e2e harness after each failed attempt to skip the wait.
+
+(1) loses the cross-component coverage that is the entire point of the e2e
+suite — the boundary between SMTPSender, dispatcher, and pool reschedule is
+exactly where retry regressions hide. (2) couples test code to internal
+schema and bypasses the production code path under test.
+
+## Decision
+
+Make backoff a `BackoffPolicy` interface threaded through the Container as a
+single canonical instance. Production wires `delivery.DefaultBackoff` (the
+existing 2m/5m curve, unchanged). Tests opt in to a faster curve via the
+`WithBackoff(p) TestOption` on `container.NewForTest`.
+
+### The policy lives on the entity, not as a `NextRetryAt(p)` parameter
+
+`Delivery` already owns the retry-shaped state — `sendAttempts`,
+`originalScheduledTime`, `scheduledTime`. The backoff curve is the same
+shape of state: the policy was hardcoded inside `NextRetryAt` precisely
+because it _belonged_ next to those fields. Lifting it to a parameter on
+every caller would force every callsite to learn what the policy is and
+re-pass it on every reschedule. Keeping it as a field on the entity matches
+the existing pattern and keeps `NextRetryAt()` parameter-free, which is
+what every caller wants.
+
+`NewParams` and `LoadParams` carry a `Backoff BackoffPolicy` field. If
+omitted (nil), `delivery.DefaultBackoff` is substituted — this defensive
+fallback exists so a missing wire-up degrades to "production curve" rather
+than a nil-pointer panic, but the convention is that every callsite passes
+the policy explicitly.
+
+### `NewDeliveryRepository(q, p)` is an explicit required parameter
+
+Functional options (`WithBackoff(p)`) on the repo factory were considered and
+rejected: the e2e suite wants the test container's policy used everywhere a
+Delivery is rehydrated, and a silent fallback to `DefaultBackoff` when the
+caller forgot to pass the option would produce hard-to-debug 5-minute waits
+in tests. An explicit positional parameter makes a missing wire-up a compile
+error, not a 5-minute timeout.
+
+### No viper key
+
+Backoff stays a wiring point, not an operator-facing knob. Exposing
+`backoff.base` / `backoff.min` viper keys is one config block on top of this
+seam if it ever becomes wanted, but it's not adopted now — operators
+historically have not asked for it, and adding the surface area before the
+need is hypothetical.
+
+## Consequences
+
+- Production behaviour is byte-for-byte identical: `delivery.DefaultBackoff`
+  reproduces the old `2m / 5m` curve exactly. The `TestNextRetryAt` and
+  `TestDefaultBackoffCurve` tests pin this.
+- The e2e suite (sub-issue #353) can shrink retry waits to milliseconds via
+  `container.WithBackoff(...)` and reach the "delivered after N transient
+  failures" assertion in seconds.
+- `BackoffPolicy` is unit-testable in isolation — the `internal/delivery`
+  tests do not boot a Container.
+
+## Rejected alternatives
+
+- **Don't observe retry end-to-end.** Loses the cross-component coverage
+  that motivates the e2e suite.
+- **Test-only DB mutation of `sending_pool_emails.scheduled_time`.** Couples
+  tests to internal schema; bypasses the production reschedule path under
+  test.
+- **Functional-option backoff on the repo factory.** A missing wire-up would
+  silently fall back to `DefaultBackoff`, producing 5-minute test waits;
+  positional param surfaces the mistake at compile time.
+- **Viper key for backoff up front.** Adds operator-facing surface area for
+  a knob no operator has asked for; the seam itself is what the e2e change
+  needs.

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -92,6 +92,10 @@ func TestE2EEmailSending(t *testing.T) {
 		testOpened(t, factory, senderMock, infra)
 	})
 
+	t.Run("Clicked", func(t *testing.T) {
+		testClicked(t, factory, senderMock, infra)
+	})
+
 	t.Log("🎉 E2E email sending test completed successfully!")
 }
 
@@ -570,6 +574,18 @@ func extractOpenToken(t *testing.T, body string) string {
 	return m[1]
 }
 
+// clickTokenRe extracts the JWT-style token from a `/c/<token>` tracked
+// link URL produced by the Envelope builder. The Envelope builder
+// rewrites every `<a href="...">` to `https://stats.<fqdn>/c/<token>`.
+var clickTokenRe = regexp.MustCompile(`/c/([A-Za-z0-9._-]+)`)
+
+func extractClickToken(t *testing.T, body string) string {
+	t.Helper()
+	m := clickTokenRe.FindStringSubmatch(body)
+	require.Len(t, m, 2, "click token not found in body: %q", body)
+	return m[1]
+}
+
 func testOpened(t *testing.T, clientFactory *clientFactory, senderMock *senderMock, infra *TestInfrastructure) {
 	client := clientFactory.NewClient(t, infra)
 
@@ -603,6 +619,57 @@ func testOpened(t *testing.T, clientFactory *clientFactory, senderMock *senderMo
 
 	matched := requireStat(t, client, to, "opened", 1)
 	assert.EqualValues(t, to, matched[0].Email)
+}
+
+func testClicked(t *testing.T, clientFactory *clientFactory, senderMock *senderMock, infra *TestInfrastructure) {
+	client := clientFactory.NewClient(t, infra)
+
+	const landingURL = "https://example.com/landing"
+	to := makeFakeEmail()
+	sendReq := &mailerapiv1.SendHTMLReq{
+		Sender: &mailertypes.Sender{
+			Email: "sender@test.example.com",
+			Alias: "Test Sender",
+		},
+		Recipients: []*mailertypes.Recipient{
+			{Email: to},
+		},
+		Subject:       "Clicked Test",
+		Html:          fmt.Sprintf(`<html><body><h1>Hello!</h1><a href=%q>click</a></body></html>`, landingURL),
+		ScheduledTime: timestamppb.Now(),
+	}
+
+	client.SendEmail(t, sendReq)
+
+	msg := requireGetEmail(t, senderMock, to)
+	token := extractClickToken(t, msg.Body)
+
+	// Redirect-following disabled: the test asserts the 307 + Location
+	// directly, not that example.com is reachable from CI.
+	httpClient := &http.Client{
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	url := fmt.Sprintf("http://localhost:%d/c/%s", infra.trackerPort, token)
+	var location string
+	require.EventuallyWithT(t, func(tt *assert.CollectT) {
+		resp, err := httpClient.Get(url)
+		require.NoError(tt, err)
+		defer resp.Body.Close()
+		_, _ = io.Copy(io.Discard, resp.Body)
+		require.Equal(tt, http.StatusTemporaryRedirect, resp.StatusCode)
+		location = resp.Header.Get("Location")
+	}, 10*time.Second, 200*time.Millisecond, "Tracker click endpoint should be reachable")
+
+	assert.Equal(t, landingURL, location, "click redirect must round-trip the originally-authored URL")
+
+	matched := requireStat(t, client, to, "clicked", 1)
+	assert.EqualValues(t, to, matched[0].Email)
+	clicked := matched[0].Data.GetClicked()
+	require.NotNil(t, clicked, "clicked stat should carry typed Clicked data")
+	assert.Equal(t, landingURL, clicked.Url, "clicked stat URL must match the originally-authored URL")
 }
 
 func requireGetEmail(t *testing.T, s *senderMock, email string) ParsedEmail {

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -24,6 +24,7 @@ import (
 	adminv1connect "github.com/kannon-email/kannon/proto/kannon/admin/apiv1/apiv1connect"
 	mailerapiv1 "github.com/kannon-email/kannon/proto/kannon/mailer/apiv1"
 	mailertypes "github.com/kannon-email/kannon/proto/kannon/mailer/types"
+	statstypes "github.com/kannon-email/kannon/proto/kannon/stats/types"
 	"github.com/kannon-email/kannon/x/container"
 	"github.com/spf13/viper"
 )
@@ -73,6 +74,10 @@ func TestE2EEmailSending(t *testing.T) {
 
 	t.Run("AggregatedStats", func(t *testing.T) {
 		testAggregatedStats(t, factory, senderMock, infra)
+	})
+
+	t.Run("PermanentBounce", func(t *testing.T) {
+		testPermanentBounce(t, factory, senderMock, infra)
 	})
 
 	t.Log("🎉 E2E email sending test completed successfully!")
@@ -430,6 +435,62 @@ func testAggregatedStats(t *testing.T, clientFactory *clientFactory, _ *senderMo
 		require.Greater(tt, typeMap["accepted"], int64(0))
 		require.Greater(tt, typeMap["delivered"], int64(0))
 	}, 10*time.Second, 1*time.Second, "Aggregated stats should be available")
+}
+
+// requireStat polls the Stats API until at least `count` events of
+// `statType` exist for `email`, then returns the matching stats so the
+// caller can introspect typed Data. Mirrors the EventuallyWithT shape
+// the existing happy-path assertions use, scoped to a (Type, Email) pair.
+func requireStat(t *testing.T, client *clientTest, email, statType string, count int) []*statstypes.Stats {
+	t.Helper()
+	var matched []*statstypes.Stats
+	require.EventuallyWithT(t, func(tt *assert.CollectT) {
+		matched = matched[:0]
+		stats := client.GetStats(t)
+		for _, s := range stats.Stats {
+			if s.Type == statType && s.Email == email {
+				matched = append(matched, s)
+			}
+		}
+		require.GreaterOrEqual(tt, len(matched), count,
+			"expected at least %d %q stats for %s, got %d", count, statType, email, len(matched))
+	}, 15*time.Second, 500*time.Millisecond,
+		"Stats of type %q for %s should be available", statType, email)
+	return matched
+}
+
+func testPermanentBounce(t *testing.T, clientFactory *clientFactory, senderMock *senderMock, infra *TestInfrastructure) {
+	client := clientFactory.NewClient(t, infra)
+
+	// Unique random suffix so this subtest's per-Recipient counters cannot
+	// collide with anything else running in parallel.
+	to := fmt.Sprintf("bounce.%s@%s", strings.ToLower(faker.Username()), client.domain)
+
+	sendReq := &mailerapiv1.SendHTMLReq{
+		Sender: &mailertypes.Sender{
+			Email: "sender@test.example.com",
+			Alias: "Test Sender",
+		},
+		Recipients: []*mailertypes.Recipient{
+			{Email: to},
+		},
+		Subject:       "Permanent Bounce Test",
+		Html:          "<h1>Hello!</h1>",
+		ScheduledTime: timestamppb.Now(),
+	}
+
+	client.SendEmail(t, sendReq)
+
+	matched := requireStat(t, client, to, "bounced", 1)
+	require.NotNil(t, matched[0].Data)
+	bounced := matched[0].Data.GetBounced()
+	require.NotNil(t, bounced, "bounced stat should carry typed Bounced data")
+	assert.True(t, bounced.Permanent, "bounce should be classified permanent")
+	assert.EqualValues(t, 550, bounced.Code, "permanent bounce should carry SMTP code 550")
+
+	// senderMock should have observed exactly one attempt — permanent
+	// bounces are not retried.
+	assert.Len(t, senderMock.History(to), 1, "permanent bounce should not be retried")
 }
 
 func requireGetEmail(t *testing.T, s *senderMock, email string) ParsedEmail {

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -3,7 +3,9 @@ package e2e_test
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -20,6 +22,7 @@ import (
 	"github.com/kannon-email/kannon/pkg/dispatcher"
 	"github.com/kannon-email/kannon/pkg/smtpsender"
 	"github.com/kannon-email/kannon/pkg/stats"
+	"github.com/kannon-email/kannon/pkg/tracker"
 	"github.com/kannon-email/kannon/pkg/validator"
 	adminapiv1 "github.com/kannon-email/kannon/proto/kannon/admin/apiv1"
 	adminv1connect "github.com/kannon-email/kannon/proto/kannon/admin/apiv1/apiv1connect"
@@ -85,6 +88,10 @@ func TestE2EEmailSending(t *testing.T) {
 		testTransientThenDeliver(t, factory, senderMock, infra)
 	})
 
+	t.Run("Opened", func(t *testing.T) {
+		testOpened(t, factory, senderMock, infra)
+	})
+
 	t.Log("🎉 E2E email sending test completed successfully!")
 }
 
@@ -94,6 +101,7 @@ func runKannon(t *testing.T, infra *TestInfrastructure, senderMock *senderMock) 
 
 	viper.Reset()
 	viper.Set("api.port", infra.apiPort)
+	viper.Set("tracker.port", infra.trackerPort)
 	viper.Set("stats.retention", "8760h")
 
 	cnt := container.NewForTest(ctx,
@@ -117,6 +125,7 @@ func runKannon(t *testing.T, infra *TestInfrastructure, senderMock *senderMock) 
 	reg.Register(dispatcher.New(cnt))
 	reg.Register(validator.New(cnt))
 	reg.Register(stats.New(cnt))
+	reg.Register(tracker.New(cnt))
 
 	// Custom SMTPSender wired against the test sender mock; the package's
 	// New(c) builds a real SMTP sender from the container, which the e2e
@@ -546,6 +555,54 @@ func testTransientThenDeliver(t *testing.T, clientFactory *clientFactory, sender
 
 	assert.Len(t, senderMock.History(to), transientFailures+1,
 		"senderMock should have observed %d transient attempts plus one success", transientFailures)
+}
+
+// openTokenRe extracts the JWT-style token from a `/o/<token>` tracking
+// pixel URL produced by the Envelope builder. JWT tokens are
+// base64url-encoded (`[A-Za-z0-9_-]`) with `.` separating the three
+// segments — no `=` padding, no other punctuation.
+var openTokenRe = regexp.MustCompile(`/o/([A-Za-z0-9._-]+)`)
+
+func extractOpenToken(t *testing.T, body string) string {
+	t.Helper()
+	m := openTokenRe.FindStringSubmatch(body)
+	require.Len(t, m, 2, "open token not found in body: %q", body)
+	return m[1]
+}
+
+func testOpened(t *testing.T, clientFactory *clientFactory, senderMock *senderMock, infra *TestInfrastructure) {
+	client := clientFactory.NewClient(t, infra)
+
+	to := makeFakeEmail()
+	sendReq := &mailerapiv1.SendHTMLReq{
+		Sender: &mailertypes.Sender{
+			Email: "sender@test.example.com",
+			Alias: "Test Sender",
+		},
+		Recipients: []*mailertypes.Recipient{
+			{Email: to},
+		},
+		Subject:       "Opened Test",
+		Html:          "<html><body><h1>Hello!</h1></body></html>",
+		ScheduledTime: timestamppb.Now(),
+	}
+
+	client.SendEmail(t, sendReq)
+
+	msg := requireGetEmail(t, senderMock, to)
+	token := extractOpenToken(t, msg.Body)
+
+	url := fmt.Sprintf("http://localhost:%d/o/%s", infra.trackerPort, token)
+	require.EventuallyWithT(t, func(tt *assert.CollectT) {
+		resp, err := http.Get(url)
+		require.NoError(tt, err)
+		defer resp.Body.Close()
+		_, _ = io.Copy(io.Discard, resp.Body)
+		require.Equal(tt, http.StatusOK, resp.StatusCode)
+	}, 10*time.Second, 200*time.Millisecond, "Tracker open endpoint should be reachable")
+
+	matched := requireStat(t, client, to, "opened", 1)
+	assert.EqualValues(t, to, matched[0].Email)
 }
 
 func requireGetEmail(t *testing.T, s *senderMock, email string) ParsedEmail {

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
+	"github.com/kannon-email/kannon/internal/delivery"
 	"github.com/kannon-email/kannon/pkg/api"
 	"github.com/kannon-email/kannon/pkg/dispatcher"
 	"github.com/kannon-email/kannon/pkg/smtpsender"
@@ -80,6 +81,10 @@ func TestE2EEmailSending(t *testing.T) {
 		testPermanentBounce(t, factory, senderMock, infra)
 	})
 
+	t.Run("TransientThenDeliver", func(t *testing.T) {
+		testTransientThenDeliver(t, factory, senderMock, infra)
+	})
+
 	t.Log("🎉 E2E email sending test completed successfully!")
 }
 
@@ -94,6 +99,12 @@ func runKannon(t *testing.T, infra *TestInfrastructure, senderMock *senderMock) 
 	cnt := container.NewForTest(ctx,
 		container.WithDBURL(infra.dbURL),
 		container.WithNatsURL(infra.natsURL),
+		// Collapse the production 2m/5m retry curve into milliseconds so the
+		// transient-then-deliver path converges in CI wall time.
+		container.WithBackoff(delivery.ExponentialBackoff{
+			Base: 50 * time.Millisecond,
+			Min:  50 * time.Millisecond,
+		}),
 	)
 	t.Cleanup(func() {
 		if err := cnt.CloseWithTimeout(30 * time.Second); err != nil {
@@ -491,6 +502,50 @@ func testPermanentBounce(t *testing.T, clientFactory *clientFactory, senderMock 
 	// senderMock should have observed exactly one attempt — permanent
 	// bounces are not retried.
 	assert.Len(t, senderMock.History(to), 1, "permanent bounce should not be retried")
+}
+
+func testTransientThenDeliver(t *testing.T, clientFactory *clientFactory, senderMock *senderMock, infra *TestInfrastructure) {
+	client := clientFactory.NewClient(t, infra)
+
+	// Unique random suffix per subtest run keeps the senderMock's
+	// per-Recipient attempt counter and History isolated from anything
+	// else exercising the harness.
+	const transientFailures = 2
+	to := fmt.Sprintf("transient.x%d.%s@%s", transientFailures, strings.ToLower(faker.Username()), client.domain)
+
+	sendReq := &mailerapiv1.SendHTMLReq{
+		Sender: &mailertypes.Sender{
+			Email: "sender@test.example.com",
+			Alias: "Test Sender",
+		},
+		Recipients: []*mailertypes.Recipient{
+			{Email: to},
+		},
+		Subject:       "Transient Then Deliver Test",
+		Html:          "<h1>Hello!</h1>",
+		ScheduledTime: timestamppb.Now(),
+	}
+
+	client.SendEmail(t, sendReq)
+
+	// First the transient errors, then the eventual delivered. Polling on
+	// delivered alone is enough to assert the loop converged.
+	requireStat(t, client, to, "delivered", 1)
+
+	errs := requireStat(t, client, to, "error", transientFailures)
+	assert.Len(t, errs, transientFailures, "expected exactly %d error stats", transientFailures)
+
+	// Bounced/Errored boundary: a transient SenderError must not be
+	// reclassified as a permanent bounce.
+	allStats := client.GetStats(t)
+	for _, s := range allStats.Stats {
+		if s.Email == to {
+			assert.NotEqual(t, "bounced", s.Type, "transient failure should not produce a bounced stat")
+		}
+	}
+
+	assert.Len(t, senderMock.History(to), transientFailures+1,
+		"senderMock should have observed %d transient attempts plus one success", transientFailures)
 }
 
 func requireGetEmail(t *testing.T, s *senderMock, email string) ParsedEmail {

--- a/e2e/infrastructure_test.go
+++ b/e2e/infrastructure_test.go
@@ -16,10 +16,11 @@ import (
 
 // TestInfrastructure holds the test infrastructure resources
 type TestInfrastructure struct {
-	dbURL   string
-	natsURL string
-	apiPort uint
-	cleanup []func() error
+	dbURL       string
+	natsURL     string
+	apiPort     uint
+	trackerPort uint
+	cleanup     []func() error
 }
 
 func (infra *TestInfrastructure) Cleanup() {
@@ -103,9 +104,15 @@ func setupTestInfrastructure(ctx context.Context) (*TestInfrastructure, error) {
 		return infra, fmt.Errorf("could not find available port: %w", err)
 	}
 
+	trackerPort, err := findAvailablePort()
+	if err != nil {
+		return infra, fmt.Errorf("could not find available port for tracker: %w", err)
+	}
+
 	infra.dbURL = dbURL
 	infra.natsURL = natsURL
 	infra.apiPort = apiPort
+	infra.trackerPort = trackerPort
 
 	return infra, nil
 }

--- a/e2e/mail_test.go
+++ b/e2e/mail_test.go
@@ -48,7 +48,8 @@ func parseEmail(t *assert.CollectT, body []byte) ParsedEmail {
 		}
 	}
 
-	emailBody := parseSimpleEmailBody(t, msg.Body)
+	encoding := strings.ToLower(msg.Header.Get("Content-Transfer-Encoding"))
+	emailBody := parseSimpleEmailBody(t, msg.Body, encoding)
 	return ParsedEmail{
 		From:        from,
 		To:          to,
@@ -139,9 +140,19 @@ func parseMultipartEmail(t *assert.CollectT, body io.Reader, boundary string) (s
 	return emailBody, attachments
 }
 
-// parseSimpleEmailBody reads the body from a non-multipart email.
-func parseSimpleEmailBody(t *assert.CollectT, body io.Reader) string {
-	b, err := io.ReadAll(body)
+// parseSimpleEmailBody reads the body from a non-multipart email,
+// decoding the Content-Transfer-Encoding if present so callers see the
+// original payload (e.g. tracking-pixel URLs aren't broken across QP
+// soft line breaks).
+func parseSimpleEmailBody(t *assert.CollectT, body io.Reader, encoding string) string {
+	var r = body
+	switch encoding {
+	case "quoted-printable":
+		r = quotedprintable.NewReader(body)
+	case "base64":
+		r = base64.NewDecoder(base64.StdEncoding, body)
+	}
+	b, err := io.ReadAll(r)
 	require.NoError(t, err)
 	return string(b)
 }

--- a/e2e/sendermock_test.go
+++ b/e2e/sendermock_test.go
@@ -1,14 +1,28 @@
 package e2e_test
 
 import (
+	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/kannon-email/kannon/internal/smtp"
 )
 
+// senderMock is a test double for smtp.Sender used by the e2e harness. It
+// parses the local-part of the Recipient address against a magic-address
+// grammar so subtests can declaratively trigger per-Recipient failure
+// behaviour without touching helper code:
+//
+//	bounce.<suffix>     -> permanent SenderError, code 550
+//	(anything else)     -> success, captured for inspection
+//
+// The grammar is e2e-internal vocabulary and intentionally not promoted
+// to CONTEXT.md.
 type senderMock struct {
-	mu   sync.RWMutex
-	msgs map[string]msg
+	mu       sync.RWMutex
+	latest   map[string]msg
+	attempts map[string]int
+	history  map[string][]msg
 }
 
 func (s *senderMock) SenderName() string {
@@ -24,20 +38,77 @@ type msg struct {
 func (s *senderMock) Send(from string, to string, body []byte) smtp.SenderError {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if s.msgs == nil {
-		s.msgs = make(map[string]msg)
+	s.ensureInit()
+
+	s.attempts[to]++
+	m := msg{From: from, To: to, Body: body}
+	s.history[to] = append(s.history[to], m)
+
+	if isBounceAddress(to) {
+		return &mockSenderError{
+			err:       fmt.Errorf("550 user unknown: %s", to),
+			permanent: true,
+			code:      550,
+		}
 	}
 
-	s.msgs[to] = msg{From: from, To: to, Body: body}
+	s.latest[to] = m
 	return nil
 }
 
+// GetEmail returns the most recent successfully-sent Envelope for the
+// given Recipient, or nil if none. Failed attempts (e.g. bounce.*) do not
+// populate this map.
 func (s *senderMock) GetEmail(to string) *msg {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	m, ok := s.msgs[to]
+	m, ok := s.latest[to]
 	if !ok {
 		return nil
 	}
 	return &m
 }
+
+// History returns every Envelope the SMTPSender attempted to deliver to
+// the given Recipient, in attempt order. Includes both successful and
+// failed attempts.
+func (s *senderMock) History(to string) []msg {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if h, ok := s.history[to]; ok {
+		out := make([]msg, len(h))
+		copy(out, h)
+		return out
+	}
+	return nil
+}
+
+func (s *senderMock) ensureInit() {
+	if s.latest == nil {
+		s.latest = make(map[string]msg)
+	}
+	if s.attempts == nil {
+		s.attempts = make(map[string]int)
+	}
+	if s.history == nil {
+		s.history = make(map[string][]msg)
+	}
+}
+
+func isBounceAddress(to string) bool {
+	at := strings.IndexByte(to, '@')
+	if at < 0 {
+		return false
+	}
+	return strings.HasPrefix(to[:at], "bounce.")
+}
+
+type mockSenderError struct {
+	err       error
+	permanent bool
+	code      uint32
+}
+
+func (e *mockSenderError) Error() string     { return e.err.Error() }
+func (e *mockSenderError) IsPermanent() bool { return e.permanent }
+func (e *mockSenderError) Code() uint32      { return e.code }

--- a/e2e/sendermock_test.go
+++ b/e2e/sendermock_test.go
@@ -2,6 +2,7 @@ package e2e_test
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -13,8 +14,10 @@ import (
 // grammar so subtests can declaratively trigger per-Recipient failure
 // behaviour without touching helper code:
 //
-//	bounce.<suffix>     -> permanent SenderError, code 550
-//	(anything else)     -> success, captured for inspection
+//	bounce.<suffix>           -> permanent SenderError, code 550
+//	transient.x<N>.<suffix>   -> transient SenderError on attempts 1..N,
+//	                             success on attempt N+1
+//	(anything else)           -> success, captured for inspection
 //
 // The grammar is e2e-internal vocabulary and intentionally not promoted
 // to CONTEXT.md.
@@ -49,6 +52,14 @@ func (s *senderMock) Send(from string, to string, body []byte) smtp.SenderError 
 			err:       fmt.Errorf("550 user unknown: %s", to),
 			permanent: true,
 			code:      550,
+		}
+	}
+
+	if n, ok := transientFailCount(to); ok && s.attempts[to] <= n {
+		return &mockSenderError{
+			err:       fmt.Errorf("451 transient failure (attempt %d/%d): %s", s.attempts[to], n, to),
+			permanent: false,
+			code:      451,
 		}
 	}
 
@@ -101,6 +112,30 @@ func isBounceAddress(to string) bool {
 		return false
 	}
 	return strings.HasPrefix(to[:at], "bounce.")
+}
+
+// transientFailCount decodes N from a `transient.x<N>.<suffix>` local-part.
+// Returns (N, true) when the address matches the grammar with N >= 1.
+func transientFailCount(to string) (int, bool) {
+	at := strings.IndexByte(to, '@')
+	if at < 0 {
+		return 0, false
+	}
+	local := to[:at]
+	const prefix = "transient.x"
+	if !strings.HasPrefix(local, prefix) {
+		return 0, false
+	}
+	rest := local[len(prefix):]
+	dot := strings.IndexByte(rest, '.')
+	if dot <= 0 {
+		return 0, false
+	}
+	n, err := strconv.Atoi(rest[:dot])
+	if err != nil || n < 1 {
+		return 0, false
+	}
+	return n, true
 }
 
 type mockSenderError struct {

--- a/internal/db/delivery_repo.go
+++ b/internal/db/delivery_repo.go
@@ -11,13 +11,17 @@ import (
 )
 
 type deliveryRepository struct {
-	q *Queries
+	q       *Queries
+	backoff delivery.BackoffPolicy
 }
 
 // NewDeliveryRepository creates a new PostgreSQL-backed Delivery repository.
-// It writes to and reads from the sending_pool_emails table.
-func NewDeliveryRepository(q *Queries) delivery.Repository {
-	return &deliveryRepository{q: q}
+// It writes to and reads from the sending_pool_emails table. The backoff
+// policy is applied to every Delivery rehydrated from a row, so the
+// repository's reschedule path uses the canonical curve threaded through the
+// Container (see x/container.Container.BackoffPolicy).
+func NewDeliveryRepository(q *Queries, backoff delivery.BackoffPolicy) delivery.Repository {
+	return &deliveryRepository{q: q, backoff: backoff}
 }
 
 func (r *deliveryRepository) Schedule(ctx context.Context, d *delivery.Delivery) error {
@@ -35,7 +39,7 @@ func (r *deliveryRepository) PrepareForSend(ctx context.Context, max int) ([]*de
 	if err != nil {
 		return nil, err
 	}
-	return rowsToDeliveries(rows), nil
+	return r.rowsToDeliveries(rows), nil
 }
 
 func (r *deliveryRepository) PrepareForValidate(ctx context.Context, max int) ([]*delivery.Delivery, error) {
@@ -43,7 +47,7 @@ func (r *deliveryRepository) PrepareForValidate(ctx context.Context, max int) ([
 	if err != nil {
 		return nil, err
 	}
-	return rowsToDeliveries(rows), nil
+	return r.rowsToDeliveries(rows), nil
 }
 
 func (r *deliveryRepository) Get(ctx context.Context, batchID batch.ID, email string) (*delivery.Delivery, error) {
@@ -57,7 +61,7 @@ func (r *deliveryRepository) Get(ctx context.Context, batchID batch.ID, email st
 		}
 		return nil, err
 	}
-	return rowToDelivery(row), nil
+	return r.rowToDelivery(row), nil
 }
 
 func (r *deliveryRepository) SetScheduled(ctx context.Context, batchID batch.ID, email string) error {
@@ -86,15 +90,15 @@ func (r *deliveryRepository) Clean(ctx context.Context, batchID batch.ID, email 
 	})
 }
 
-func rowsToDeliveries(rows []SendingPoolEmail) []*delivery.Delivery {
+func (r *deliveryRepository) rowsToDeliveries(rows []SendingPoolEmail) []*delivery.Delivery {
 	out := make([]*delivery.Delivery, len(rows))
-	for i, r := range rows {
-		out[i] = rowToDelivery(r)
+	for i, row := range rows {
+		out[i] = r.rowToDelivery(row)
 	}
 	return out
 }
 
-func rowToDelivery(row SendingPoolEmail) *delivery.Delivery {
+func (r *deliveryRepository) rowToDelivery(row SendingPoolEmail) *delivery.Delivery {
 	return delivery.Load(delivery.LoadParams{
 		BatchID:               batch.ID(row.MessageID),
 		Email:                 row.Email,
@@ -103,6 +107,7 @@ func rowToDelivery(row SendingPoolEmail) *delivery.Delivery {
 		Domain:                row.Domain,
 		ScheduledTime:         row.ScheduledTime.Time,
 		OriginalScheduledTime: row.OriginalScheduledTime.Time,
+		Backoff:               r.backoff,
 	})
 }
 

--- a/internal/db/delivery_repo_test.go
+++ b/internal/db/delivery_repo_test.go
@@ -14,6 +14,6 @@ func (deliveryTestHelper) CreateBatch(t *testing.T) (batch.ID, string) {
 }
 
 func TestDeliveryRepository(t *testing.T) {
-	repo := NewDeliveryRepository(q)
+	repo := NewDeliveryRepository(q, delivery.DefaultBackoff)
 	delivery.RunRepoSpec(t, repo, deliveryTestHelper{})
 }

--- a/internal/db/pool_claimer_test.go
+++ b/internal/db/pool_claimer_test.go
@@ -23,7 +23,7 @@ func (h claimerTestHelper) Schedule(t *testing.T, d *delivery.Delivery) {
 }
 
 func TestPoolClaimer(t *testing.T) {
-	deliveries := NewDeliveryRepository(q)
+	deliveries := NewDeliveryRepository(q, delivery.DefaultBackoff)
 	c := pool.NewClaimer(deliveries)
 	pool.RunClaimerSpec(t, c, claimerTestHelper{deliveries: deliveries})
 }

--- a/internal/delivery/backoff.go
+++ b/internal/delivery/backoff.go
@@ -1,0 +1,35 @@
+package delivery
+
+import (
+	"math"
+	"time"
+)
+
+// BackoffPolicy decides how long to wait before the next retry given the
+// number of attempts already made.
+type BackoffPolicy interface {
+	Delay(attempts int) time.Duration
+}
+
+// ExponentialBackoff doubles the wait on each attempt, with a hard floor.
+//
+// delay = max(Min, Base * 2^attempts)
+type ExponentialBackoff struct {
+	Base time.Duration
+	Min  time.Duration
+}
+
+func (e ExponentialBackoff) Delay(attempts int) time.Duration {
+	delay := e.Base * time.Duration(math.Pow(2, float64(attempts)))
+	if delay < e.Min {
+		return e.Min
+	}
+	return delay
+}
+
+// DefaultBackoff reproduces the curve historically hardcoded in
+// rescheduleDelay: 2m * 2^attempts, floored at 5m.
+var DefaultBackoff BackoffPolicy = ExponentialBackoff{
+	Base: 2 * time.Minute,
+	Min:  5 * time.Minute,
+}

--- a/internal/delivery/backoff_test.go
+++ b/internal/delivery/backoff_test.go
@@ -1,0 +1,33 @@
+package delivery
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefaultBackoffCurve(t *testing.T) {
+	cases := []struct {
+		attempts int
+		want     time.Duration
+	}{
+		{0, 5 * time.Minute},  // 2m * 1 = 2m, floored to 5m
+		{1, 5 * time.Minute},  // 2m * 2 = 4m, floored to 5m
+		{2, 8 * time.Minute},  // 2m * 4 = 8m, exponential dominates
+		{3, 16 * time.Minute}, // 2m * 8
+		{4, 32 * time.Minute}, // 2m * 16
+		{5, 64 * time.Minute}, // 2m * 32
+	}
+	for _, tc := range cases {
+		assert.Equal(t, tc.want, DefaultBackoff.Delay(tc.attempts), "attempts=%d", tc.attempts)
+	}
+}
+
+func TestExponentialBackoffFloorBinds(t *testing.T) {
+	p := ExponentialBackoff{Base: 1 * time.Second, Min: 10 * time.Second}
+	assert.Equal(t, 10*time.Second, p.Delay(0))
+	assert.Equal(t, 10*time.Second, p.Delay(1))
+	assert.Equal(t, 10*time.Second, p.Delay(2))
+	assert.Equal(t, 16*time.Second, p.Delay(4))
+}

--- a/internal/delivery/delivery.go
+++ b/internal/delivery/delivery.go
@@ -6,7 +6,6 @@ package delivery
 import (
 	"errors"
 	"fmt"
-	"math"
 	"time"
 
 	"github.com/kannon-email/kannon/internal/batch"
@@ -26,6 +25,7 @@ type Delivery struct {
 	domain                string
 	scheduledTime         time.Time
 	originalScheduledTime time.Time
+	backoff               BackoffPolicy
 }
 
 // NewParams contains all fields needed to create a fresh Delivery.
@@ -35,6 +35,7 @@ type NewParams struct {
 	Fields        map[string]string
 	Domain        string
 	ScheduledTime time.Time
+	Backoff       BackoffPolicy
 }
 
 // New creates a new Delivery scheduled for first attempt.
@@ -55,6 +56,7 @@ func New(p NewParams) (*Delivery, error) {
 		domain:                p.Domain,
 		scheduledTime:         p.ScheduledTime,
 		originalScheduledTime: p.ScheduledTime,
+		backoff:               policyOrDefault(p.Backoff),
 	}, nil
 }
 
@@ -67,6 +69,7 @@ type LoadParams struct {
 	Domain                string
 	ScheduledTime         time.Time
 	OriginalScheduledTime time.Time
+	Backoff               BackoffPolicy
 }
 
 // Load rehydrates a Delivery from stored data (used by repository implementations).
@@ -79,6 +82,7 @@ func Load(p LoadParams) *Delivery {
 		domain:                p.Domain,
 		scheduledTime:         p.ScheduledTime,
 		originalScheduledTime: p.OriginalScheduledTime,
+		backoff:               policyOrDefault(p.Backoff),
 	}
 }
 
@@ -98,13 +102,12 @@ func (d *Delivery) OriginalScheduledTime() time.Time {
 // attempted, given its current attempt count and the original scheduled
 // time. The repository uses this when applying a reschedule.
 func (d *Delivery) NextRetryAt() time.Time {
-	return d.originalScheduledTime.Add(rescheduleDelay(d.sendAttempts))
+	return d.originalScheduledTime.Add(d.backoff.Delay(d.sendAttempts))
 }
 
-func rescheduleDelay(attempts int) time.Duration {
-	delay := 2 * time.Minute * time.Duration(math.Pow(2, float64(attempts)))
-	if delay < 5*time.Minute {
-		delay = 5 * time.Minute
+func policyOrDefault(p BackoffPolicy) BackoffPolicy {
+	if p == nil {
+		return DefaultBackoff
 	}
-	return delay
+	return p
 }

--- a/internal/delivery/delivery_test.go
+++ b/internal/delivery/delivery_test.go
@@ -18,6 +18,7 @@ func TestNew(t *testing.T) {
 			Fields:        map[string]string{"name": "X"},
 			Domain:        "example.com",
 			ScheduledTime: now,
+			Backoff:       DefaultBackoff,
 		})
 		require.NoError(t, err)
 		assert.Equal(t, "to@example.com", d.Email())
@@ -67,6 +68,7 @@ func TestNextRetryAt(t *testing.T) {
 			SendAttempts:          tc.attempts,
 			ScheduledTime:         base,
 			OriginalScheduledTime: base,
+			Backoff:               DefaultBackoff,
 		})
 		assert.Equal(t, base.Add(tc.want), d.NextRetryAt(), "attempts=%d", tc.attempts)
 	}

--- a/internal/delivery/repospec.go
+++ b/internal/delivery/repospec.go
@@ -48,6 +48,7 @@ func newDelivery(t *testing.T, batchID batch.ID, domain, email string) *Delivery
 		Fields:        map[string]string{"name": "X"},
 		Domain:        domain,
 		ScheduledTime: time.Now().UTC().Add(-time.Minute),
+		Backoff:       DefaultBackoff,
 	})
 	require.NoError(t, err)
 	return d

--- a/internal/envelope/builder_test.go
+++ b/internal/envelope/builder_test.go
@@ -45,6 +45,7 @@ func mustDelivery(t *testing.T, batchID batch.ID, email string, fields map[strin
 		Fields:        fields,
 		Domain:        "test.com",
 		ScheduledTime: time.Now(),
+		Backoff:       delivery.DefaultBackoff,
 	})
 	assert.Nil(t, err)
 	return d
@@ -138,6 +139,7 @@ func TestBuilderShouldRetryFalseAfterMaxAttempts(t *testing.T) {
 		Email:        "rcpt@example.com",
 		Domain:       "test.com",
 		SendAttempts: 10,
+		Backoff:      delivery.DefaultBackoff,
 	})
 	env, err := b.Build(context.Background(), d)
 	assert.Nil(t, err)

--- a/internal/envelope/envelope_integration_test.go
+++ b/internal/envelope/envelope_integration_test.go
@@ -54,9 +54,9 @@ func TestMain(m *testing.M) {
 	q = sqlc.New(db)
 
 	eb = envelope.NewBuilder(q, statssec.NewStatsService(q))
-	ma = mailapi.NewMailerAPIV1(q, db)
+	ma = mailapi.NewMailerAPIV1(q, db, delivery.DefaultBackoff)
 	adminAPI = adminapi.CreateAdminAPIService(q, db)
-	claimer = pool.NewClaimer(sqlc.NewDeliveryRepository(q))
+	claimer = pool.NewClaimer(sqlc.NewDeliveryRepository(q, delivery.DefaultBackoff))
 
 	code := m.Run()
 

--- a/internal/pool/repospec.go
+++ b/internal/pool/repospec.go
@@ -100,6 +100,7 @@ func mustNewDelivery(t *testing.T, batchID batch.ID, domain, email string) *deli
 		Fields:        map[string]string{"name": "X"},
 		Domain:        domain,
 		ScheduledTime: time.Now().UTC().Add(-time.Minute),
+		Backoff:       delivery.DefaultBackoff,
 	})
 	require.NoError(t, err)
 	return d

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -59,7 +59,7 @@ func run(ctx context.Context, config Config, cnt *container.Container) error {
 	statsService := stats.NewService(statsRepo, stats.WithAggregatedStatsRepository(aggregatedRepo))
 
 	adminAPIService := adminapi.CreateAdminAPIService(q, cnt.DB())
-	mailAPIService := mailapi.NewMailerAPIV1(q, cnt.DB())
+	mailAPIService := mailapi.NewMailerAPIV1(q, cnt.DB(), cnt.BackoffPolicy())
 	statsAPIService := statsv1.NewStatsAPIService(statsService)
 	statsV2APIService := statsv2.NewStatsAPIService(statsService)
 	hzAPIService := hzapi.CreateHZAPIService(cnt)

--- a/pkg/api/mailapi/base_test.go
+++ b/pkg/api/mailapi/base_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	schema "github.com/kannon-email/kannon/db"
 	sqlc "github.com/kannon-email/kannon/internal/db"
+	"github.com/kannon-email/kannon/internal/delivery"
 	"github.com/kannon-email/kannon/internal/tests"
 	"github.com/kannon-email/kannon/pkg/api/adminapi"
 	"github.com/kannon-email/kannon/pkg/api/mailapi"
@@ -37,7 +38,7 @@ func TestMain(m *testing.M) {
 	}
 
 	q = sqlc.New(db)
-	ts = mailapi.NewMailerAPIV1(q, db)
+	ts = mailapi.NewMailerAPIV1(q, db, delivery.DefaultBackoff)
 	adminAPI = adminapi.CreateAdminAPIService(q, db)
 
 	code := m.Run()

--- a/pkg/api/mailapi/mailer.go
+++ b/pkg/api/mailapi/mailer.go
@@ -31,6 +31,7 @@ type mailAPIService struct {
 	templates  templates.Repository
 	batches    batch.Repository
 	deliveries delivery.Repository
+	backoff    delivery.BackoffPolicy
 }
 
 func (s mailAPIService) SendHTML(ctx context.Context, req *connect.Request[pb.SendHTMLReq]) (*connect.Response[pb.SendRes], error) {
@@ -135,6 +136,7 @@ func (s mailAPIService) scheduleBatch(ctx context.Context, b *batch.Batch, recip
 			Fields:        r.Fields,
 			Domain:        b.Domain(),
 			ScheduledTime: scheduled,
+			Backoff:       s.backoff,
 		})
 		if err != nil {
 			return err
@@ -224,12 +226,12 @@ func validateHeaders(h *mailertypes.Headers) (batch.Headers, error) {
 	return batch.Headers{To: h.To, Cc: h.Cc}, nil
 }
 
-func NewMailerAPIV1(q *sqlc.Queries, db *pgxpool.Pool) mailerv1connect.MailerHandler {
+func NewMailerAPIV1(q *sqlc.Queries, db *pgxpool.Pool, backoff delivery.BackoffPolicy) mailerv1connect.MailerHandler {
 	domainsCli := sqlc.NewDomainsRepository(q)
 	apiKeysRepo := sqlc.NewAPIKeysRepository(q, db)
 	apiKeysService := apikeys.NewService(apiKeysRepo)
 	batchRepo := sqlc.NewBatchRepository(q)
-	deliveryRepo := sqlc.NewDeliveryRepository(q)
+	deliveryRepo := sqlc.NewDeliveryRepository(q, backoff)
 	templatesRepo := sqlc.NewTemplatesRepository(q)
 
 	return &mailAPIService{
@@ -238,5 +240,6 @@ func NewMailerAPIV1(q *sqlc.Queries, db *pgxpool.Pool) mailerv1connect.MailerHan
 		batches:    batchRepo,
 		deliveries: deliveryRepo,
 		templates:  templatesRepo,
+		backoff:    backoff,
 	}
 }

--- a/pkg/dispatcher/dispatcher.go
+++ b/pkg/dispatcher/dispatcher.go
@@ -33,7 +33,7 @@ func run(ctx context.Context, cnt *container.Container) error {
 	q := cnt.Queries()
 
 	ss := statssec.NewStatsService(q)
-	claimer := pool.NewClaimer(sqlc.NewDeliveryRepository(q))
+	claimer := pool.NewClaimer(sqlc.NewDeliveryRepository(q, cnt.BackoffPolicy()))
 	eb := envelope.NewBuilder(q, ss)
 
 	js := cnt.NatsJetStream()

--- a/pkg/tracker/clicks.go
+++ b/pkg/tracker/clicks.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	sqlc "github.com/kannon-email/kannon/internal/db"
+	"github.com/kannon-email/kannon/internal/publisher"
 	"github.com/kannon-email/kannon/internal/statssec"
 	"github.com/kannon-email/kannon/internal/utils"
 	pb "github.com/kannon-email/kannon/proto/kannon/stats/types"
@@ -40,8 +41,7 @@ func (s *srv) handleClick(w http.ResponseWriter, r *http.Request) {
 	ip := readUserIP(r)
 	data := buildClickStat(claims, userAgent, ip, domain)
 
-	err = s.sendMsg(data, "kannon.stats.clicks")
-	if err != nil {
+	if err := publisher.PublishStat(s.pub, data); err != nil {
 		logrus.Errorf("cannot send message on nats: %v", err)
 		return
 	}

--- a/pkg/tracker/opens.go
+++ b/pkg/tracker/opens.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	sqlc "github.com/kannon-email/kannon/internal/db"
+	"github.com/kannon-email/kannon/internal/publisher"
 	"github.com/kannon-email/kannon/internal/statssec"
 	"github.com/kannon-email/kannon/internal/utils"
 	pb "github.com/kannon-email/kannon/proto/kannon/stats/types"
@@ -41,8 +42,7 @@ func (s *srv) handleOpen(w http.ResponseWriter, r *http.Request) {
 	ip := readUserIP(r)
 	data := buildOpenStat(claims, userAgent, ip, domain)
 
-	err = s.sendMsg(data, "kannon.stats.opens")
-	if err != nil {
+	if err := publisher.PublishStat(s.pub, data); err != nil {
 		logrus.Errorf("cannot send message on nats: %v", err)
 		return
 	}

--- a/pkg/tracker/srv.go
+++ b/pkg/tracker/srv.go
@@ -6,27 +6,24 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/kannon-email/kannon/internal/publisher"
 	"github.com/kannon-email/kannon/internal/statssec"
-	pb "github.com/kannon-email/kannon/proto/kannon/stats/types"
 	"github.com/kannon-email/kannon/x/container"
-	"github.com/nats-io/nats.go"
 	"github.com/sirupsen/logrus"
-	"google.golang.org/protobuf/proto"
 )
 
 type srv struct {
-	nc  *nats.Conn
+	pub publisher.Publisher
 	ss  statssec.StatsService
 	cfg Config
 }
 
 func NewServer(cnt *container.Container, cfg Config) *srv {
-	nc := cnt.Nats()
 	q := cnt.Queries()
 	ss := statssec.NewStatsService(q)
 
 	return &srv{
-		nc:  nc,
+		pub: cnt.Nats(),
 		ss:  ss,
 		cfg: cfg,
 	}
@@ -53,18 +50,6 @@ func (s *srv) Run(ctx context.Context) error {
 	}()
 
 	return server.ListenAndServe()
-}
-
-func (s *srv) sendMsg(data *pb.Stats, topic string) error {
-	msg, err := proto.Marshal(data)
-	if err != nil {
-		return fmt.Errorf("cannot marshal data: %w", err)
-	}
-	err = s.nc.Publish(topic, msg)
-	if err != nil {
-		return fmt.Errorf("cannot send message on nats: %w", err)
-	}
-	return nil
 }
 
 func readUserIP(r *http.Request) string {

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -41,7 +41,7 @@ func New(cnt *container.Container) container.Runnable {
 		Name: "validator",
 		Run: func(ctx context.Context) error {
 			q := cnt.Queries()
-			claimer := pool.NewClaimer(sqlc.NewDeliveryRepository(q))
+			claimer := pool.NewClaimer(sqlc.NewDeliveryRepository(q, cnt.BackoffPolicy()))
 
 			v := Validator{
 				claimer: claimer,

--- a/pkg/validator/validator_test.go
+++ b/pkg/validator/validator_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	schema "github.com/kannon-email/kannon/db"
 	sqlc "github.com/kannon-email/kannon/internal/db"
+	"github.com/kannon-email/kannon/internal/delivery"
 	"github.com/kannon-email/kannon/internal/pool"
 	"github.com/kannon-email/kannon/internal/runner"
 	"github.com/kannon-email/kannon/internal/tests"
@@ -46,10 +47,10 @@ func TestMain(m *testing.M) {
 	}
 
 	q = sqlc.New(db)
-	claimer := pool.NewClaimer(sqlc.NewDeliveryRepository(q))
+	claimer := pool.NewClaimer(sqlc.NewDeliveryRepository(q, delivery.DefaultBackoff))
 	vt = validator.NewValidator(claimer, &mp)
 
-	ts = mailapi.NewMailerAPIV1(q, db)
+	ts = mailapi.NewMailerAPIV1(q, db, delivery.DefaultBackoff)
 	adminAPI = adminapi.CreateAdminAPIService(q, db)
 
 	code := m.Run()

--- a/x/container/container.go
+++ b/x/container/container.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	sqlc "github.com/kannon-email/kannon/internal/db"
+	"github.com/kannon-email/kannon/internal/delivery"
 	"github.com/kannon-email/kannon/internal/publisher"
 	"github.com/kannon-email/kannon/internal/smtp"
 	"github.com/nats-io/nats-server/v2/server"
@@ -27,6 +28,7 @@ type Container struct {
 	useEmbeddedNats bool
 	senderHostname  string
 	demoSender      bool
+	backoff         delivery.BackoffPolicy
 
 	// singleton instances
 	db                 *singleton[*pgxpool.Pool]
@@ -60,6 +62,7 @@ func New(ctx context.Context) *Container {
 		useEmbeddedNats:    viper.GetBool("use_embedded_nats"),
 		senderHostname:     sc.Hostname,
 		demoSender:         sc.DemoSender,
+		backoff:            delivery.DefaultBackoff,
 		db:                 &singleton[*pgxpool.Pool]{},
 		nats:               &singleton[*nats.Conn]{},
 		embeddedNatsServer: &singleton[*server.Server]{},
@@ -95,12 +98,20 @@ func WithDemoSender() TestOption {
 	return func(c *Container) { c.demoSender = true }
 }
 
+// WithBackoff overrides the retry backoff policy. Tests use this to collapse
+// the production multi-minute curve into milliseconds without mutating
+// per-package internals.
+func WithBackoff(p delivery.BackoffPolicy) TestOption {
+	return func(c *Container) { c.backoff = p }
+}
+
 // NewForTest builds a Container without reading viper, applying the supplied
 // options. Tests use this to wire a synthetic container without inventing
 // per-package backdoors.
 func NewForTest(ctx context.Context, opts ...TestOption) *Container {
 	c := &Container{
 		ctx:                ctx,
+		backoff:            delivery.DefaultBackoff,
 		db:                 &singleton[*pgxpool.Pool]{},
 		nats:               &singleton[*nats.Conn]{},
 		embeddedNatsServer: &singleton[*server.Server]{},
@@ -287,6 +298,12 @@ func (c *Container) NatsJetStream() jetstream.JetStream {
 	})
 
 	return js
+}
+
+// BackoffPolicy returns the canonical retry backoff policy for this Container.
+// Production uses delivery.DefaultBackoff; tests may override via WithBackoff.
+func (c *Container) BackoffPolicy() delivery.BackoffPolicy {
+	return c.backoff
 }
 
 func (c *Container) Sender() smtp.Sender {


### PR DESCRIPTION
## Summary

- Extends the e2e suite to cover all four missing Delivery Outcome states — **PermanentBounce**, **TransientThenDeliver**, **Opened**, and **Clicked** — giving the pipeline end-to-end coverage beyond the happy path for the first time
- Introduces a `BackoffPolicy` interface in `internal/delivery` so the transient-retry test converges in milliseconds instead of 13 minutes, with production behaviour byte-for-byte unchanged; ships ADR `docs/adr/0001-configurable-delivery-backoff.md`
- Registers the Tracker in the e2e harness, routes its stats through `publisher.PublishStat` (aligning subject names with the DB enum), upgrades `senderMock` to a declarative magic-address grammar, and corrects the NATS subject table in `ARCHITECTURE.md`

## Resolved sub-issues

- #355 e2e Round-1 #6: Clicked subtest (link redirect)
- #354 e2e Round-1 #5: Opened subtest (Tracker registration in harness)
- #353 e2e Round-1 #4: TransientThenDeliver subtest (transient.xN parser + fast backoff)
- #352 e2e Round-1 #3: PermanentBounce subtest (senderMock magic addresses + requireStat helper)
- #351 e2e Round-1 #2: Tracker stat subjects through PublishStat + ARCHITECTURE.md fix
- #350 e2e Round-1 #1: Configurable BackoffPolicy + ADR

Closes #349

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configurable delivery retry backoff policy with sensible production defaults
  * Enhanced email tracking: monitor opens and clicks with updated stat topics
  * Improved email parsing: properly handles quoted-printable and base64 encoded bodies

* **Documentation**
  * Updated architecture guidance for delivery retry configuration and NATS stats topics

<!-- end of auto-generated comment: release notes by coderabbit.ai -->