### PR TITLE
refactor(db): postgres repo constructors take *pgxpool.Pool

### DIFF
--- a/internal/db/aggregated_stats_repo.go
+++ b/internal/db/aggregated_stats_repo.go
@@ -5,21 +5,23 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/kannon-email/kannon/internal/stats"
 )
 
 // AggregatedStatsRepository implements stats.AggregatedStatsRepository using sqlc queries.
 type AggregatedStatsRepository struct {
-	q *Queries
+	db *pgxpool.Pool
 }
 
 // NewAggregatedStatsRepository creates a new AggregatedStatsRepository.
-func NewAggregatedStatsRepository(q *Queries) *AggregatedStatsRepository {
-	return &AggregatedStatsRepository{q: q}
+func NewAggregatedStatsRepository(db *pgxpool.Pool) *AggregatedStatsRepository {
+	return &AggregatedStatsRepository{db: db}
 }
 
 func (r *AggregatedStatsRepository) Increment(ctx context.Context, domain string, timestamp time.Time, statType stats.Type) error {
-	return r.q.IncrementAggregatedStat(ctx, IncrementAggregatedStatParams{
+	q := New(r.db)
+	return q.IncrementAggregatedStat(ctx, IncrementAggregatedStatParams{
 		Domain:    domain,
 		Timestamp: pgtype.Timestamp{Time: timestamp, Valid: true},
 		Type:      StatsType(statType),
@@ -27,7 +29,8 @@ func (r *AggregatedStatsRepository) Increment(ctx context.Context, domain string
 }
 
 func (r *AggregatedStatsRepository) Query(ctx context.Context, domain string, timeRange stats.TimeRange) ([]*stats.AggregatedStat, error) {
-	rows, err := r.q.QueryAggregatedStats(ctx, QueryAggregatedStatsParams{
+	q := New(r.db)
+	rows, err := q.QueryAggregatedStats(ctx, QueryAggregatedStatsParams{
 		Domain: domain,
 		Start:  pgtype.Timestamp{Time: timeRange.Start, Valid: true},
 		Stop:   pgtype.Timestamp{Time: timeRange.Stop, Valid: true},

--- a/internal/db/aggregated_stats_repo_test.go
+++ b/internal/db/aggregated_stats_repo_test.go
@@ -7,6 +7,6 @@ import (
 )
 
 func TestAggregatedStatsRepository(t *testing.T) {
-	repo := NewAggregatedStatsRepository(q)
+	repo := NewAggregatedStatsRepository(db)
 	stats.RunAggregatedRepoSpec(t, repo)
 }

--- a/internal/db/batch_repo.go
+++ b/internal/db/batch_repo.go
@@ -5,22 +5,24 @@ import (
 	"errors"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/kannon-email/kannon/internal/batch"
 )
 
 type batchRepository struct {
-	q *Queries
+	db *pgxpool.Pool
 }
 
 // NewBatchRepository creates a new PostgreSQL-backed Batch repository.
 // It writes to and reads from the messages table.
-func NewBatchRepository(q *Queries) batch.Repository {
-	return &batchRepository{q: q}
+func NewBatchRepository(db *pgxpool.Pool) batch.Repository {
+	return &batchRepository{db: db}
 }
 
 func (r *batchRepository) Create(ctx context.Context, b *batch.Batch) error {
-	_, err := r.q.CreateMessage(ctx, CreateMessageParams{
+	q := New(r.db)
+	_, err := q.CreateMessage(ctx, CreateMessageParams{
 		MessageID:   b.ID().String(),
 		Subject:     b.Subject(),
 		SenderEmail: b.Sender().Email,
@@ -34,7 +36,8 @@ func (r *batchRepository) Create(ctx context.Context, b *batch.Batch) error {
 }
 
 func (r *batchRepository) GetByID(ctx context.Context, id batch.ID) (*batch.Batch, error) {
-	row, err := r.q.GetMessage(ctx, id.String())
+	q := New(r.db)
+	row, err := q.GetMessage(ctx, id.String())
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, batch.ErrBatchNotFound

--- a/internal/db/batch_repo_test.go
+++ b/internal/db/batch_repo_test.go
@@ -44,6 +44,6 @@ func (h batchTestHelper) CreateTemplate(t *testing.T, domain string) string {
 }
 
 func TestBatchRepository(t *testing.T) {
-	repo := NewBatchRepository(q)
+	repo := NewBatchRepository(db)
 	batch.RunRepoSpec(t, repo, batchTestHelper{})
 }

--- a/internal/db/delivery_repo.go
+++ b/internal/db/delivery_repo.go
@@ -12,7 +12,7 @@ import (
 )
 
 type deliveryRepository struct {
-	q       *Queries
+	db      *pgxpool.Pool
 	backoff delivery.BackoffPolicy
 }
 
@@ -22,7 +22,7 @@ type deliveryRepository struct {
 // repository's reschedule path uses the canonical curve threaded through the
 // Container (see x/container.Container.BackoffPolicy).
 func NewDeliveryRepository(db *pgxpool.Pool, backoff delivery.BackoffPolicy) delivery.Repository {
-	return &deliveryRepository{q: New(db), backoff: backoff}
+	return &deliveryRepository{db: db, backoff: backoff}
 }
 
 func (r *deliveryRepository) Schedule(ctx context.Context, ds ...*delivery.Delivery) error {
@@ -44,14 +44,16 @@ func (r *deliveryRepository) Schedule(ctx context.Context, ds ...*delivery.Deliv
 		}
 	}
 
-	if _, err := r.q.CreatePool(ctx, rows); err != nil {
+	q := New(r.db)
+	if _, err := q.CreatePool(ctx, rows); err != nil {
 		return err
 	}
 	return nil
 }
 
 func (r *deliveryRepository) PrepareForSend(ctx context.Context, max int) ([]*delivery.Delivery, error) {
-	rows, err := r.q.PrepareForSend(ctx, int32(max))
+	q := New(r.db)
+	rows, err := q.PrepareForSend(ctx, int32(max))
 	if err != nil {
 		return nil, err
 	}
@@ -59,7 +61,8 @@ func (r *deliveryRepository) PrepareForSend(ctx context.Context, max int) ([]*de
 }
 
 func (r *deliveryRepository) PrepareForValidate(ctx context.Context, max int) ([]*delivery.Delivery, error) {
-	rows, err := r.q.PrepareForValidate(ctx, int32(max))
+	q := New(r.db)
+	rows, err := q.PrepareForValidate(ctx, int32(max))
 	if err != nil {
 		return nil, err
 	}
@@ -67,7 +70,8 @@ func (r *deliveryRepository) PrepareForValidate(ctx context.Context, max int) ([
 }
 
 func (r *deliveryRepository) Get(ctx context.Context, batchID batch.ID, email string) (*delivery.Delivery, error) {
-	row, err := r.q.GetPool(ctx, GetPoolParams{
+	q := New(r.db)
+	row, err := q.GetPool(ctx, GetPoolParams{
 		Email:     email,
 		MessageID: batchID.String(),
 	})
@@ -81,7 +85,8 @@ func (r *deliveryRepository) Get(ctx context.Context, batchID batch.ID, email st
 }
 
 func (r *deliveryRepository) SetScheduled(ctx context.Context, batchID batch.ID, email string) error {
-	return r.q.SetSendingPoolScheduled(ctx, SetSendingPoolScheduledParams{
+	q := New(r.db)
+	return q.SetSendingPoolScheduled(ctx, SetSendingPoolScheduledParams{
 		Email:     email,
 		MessageID: batchID.String(),
 	})
@@ -92,7 +97,8 @@ func (r *deliveryRepository) Reschedule(ctx context.Context, batchID batch.ID, e
 	if err != nil {
 		return err
 	}
-	return r.q.ReschedulePool(ctx, ReschedulePoolParams{
+	q := New(r.db)
+	return q.ReschedulePool(ctx, ReschedulePoolParams{
 		Email:         email,
 		MessageID:     batchID.String(),
 		ScheduledTime: PgTimestampFromTime(d.NextRetryAt()),
@@ -100,7 +106,8 @@ func (r *deliveryRepository) Reschedule(ctx context.Context, batchID batch.ID, e
 }
 
 func (r *deliveryRepository) Clean(ctx context.Context, batchID batch.ID, email string) error {
-	return r.q.CleanPool(ctx, CleanPoolParams{
+	q := New(r.db)
+	return q.CleanPool(ctx, CleanPoolParams{
 		Email:     email,
 		MessageID: batchID.String(),
 	})

--- a/internal/db/domains_repo.go
+++ b/internal/db/domains_repo.go
@@ -5,21 +5,23 @@ import (
 	"errors"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/kannon-email/kannon/internal/domains"
 )
 
 type domainsRepository struct {
-	q *Queries
+	db *pgxpool.Pool
 }
 
 // NewDomainsRepository creates a new PostgreSQL-backed SenderDomain repository.
-func NewDomainsRepository(q *Queries) domains.Repository {
-	return &domainsRepository{q: q}
+func NewDomainsRepository(db *pgxpool.Pool) domains.Repository {
+	return &domainsRepository{db: db}
 }
 
 func (r *domainsRepository) Create(ctx context.Context, d *domains.Domain) error {
-	row, err := r.q.CreateDomain(ctx, CreateDomainParams{
+	q := New(r.db)
+	row, err := q.CreateDomain(ctx, CreateDomainParams{
 		Domain:         d.Domain(),
 		DkimPrivateKey: d.DkimPrivateKey(),
 		DkimPublicKey:  d.DkimPublicKey(),
@@ -32,7 +34,8 @@ func (r *domainsRepository) Create(ctx context.Context, d *domains.Domain) error
 }
 
 func (r *domainsRepository) FindByName(ctx context.Context, fqdn string) (*domains.Domain, error) {
-	row, err := r.q.FindDomain(ctx, fqdn)
+	q := New(r.db)
+	row, err := q.FindDomain(ctx, fqdn)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, domains.ErrDomainNotFound
@@ -43,7 +46,8 @@ func (r *domainsRepository) FindByName(ctx context.Context, fqdn string) (*domai
 }
 
 func (r *domainsRepository) List(ctx context.Context) ([]*domains.Domain, error) {
-	rows, err := r.q.GetAllDomains(ctx)
+	q := New(r.db)
+	rows, err := q.GetAllDomains(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/db/domains_repo_test.go
+++ b/internal/db/domains_repo_test.go
@@ -15,6 +15,6 @@ func TestDomainsRepository(t *testing.T) {
 	_, err := db.Exec(context.Background(), "DELETE FROM domains CASCADE")
 	require.NoError(t, err)
 
-	repo := NewDomainsRepository(q)
+	repo := NewDomainsRepository(db)
 	domains.RunRepoSpec(t, repo)
 }

--- a/internal/db/key_repo.go
+++ b/internal/db/key_repo.go
@@ -12,22 +12,23 @@ import (
 )
 
 type apiKeysRepository struct {
-	q    *Queries
-	pool *pgxpool.Pool
+	db *pgxpool.Pool
 }
 
 // NewAPIKeysRepository creates a new PostgreSQL-backed API keys repository
-func NewAPIKeysRepository(q *Queries, pool *pgxpool.Pool) apikeys.Repository {
-	return &apiKeysRepository{q: q, pool: pool}
+func NewAPIKeysRepository(db *pgxpool.Pool) apikeys.Repository {
+	return &apiKeysRepository{db: db}
 }
 
 func (r *apiKeysRepository) Create(ctx context.Context, key *apikeys.APIKey) error {
+	q := New(r.db)
+
 	var expiresAt pgtype.Timestamp
 	if key.ExpiresAt() != nil {
 		expiresAt = pgtype.Timestamp{Time: *key.ExpiresAt(), Valid: true}
 	}
 
-	_, err := r.q.CreateAPIKey(ctx, CreateAPIKeyParams{
+	_, err := q.CreateAPIKey(ctx, CreateAPIKeyParams{
 		ID:        key.ID().String(),
 		Domain:    key.Domain(),
 		KeyHash:   key.KeyHash(),
@@ -44,7 +45,7 @@ func (r *apiKeysRepository) Create(ctx context.Context, key *apikeys.APIKey) err
 
 func (r *apiKeysRepository) Update(ctx context.Context, ref apikeys.KeyRef, updateFn apikeys.UpdateFunc) (*apikeys.APIKey, error) {
 	// Start transaction
-	tx, err := r.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := r.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -53,7 +54,7 @@ func (r *apiKeysRepository) Update(ctx context.Context, ref apikeys.KeyRef, upda
 	defer tx.Rollback(ctx)
 
 	// Create transactional queries
-	txq := r.q.WithTx(tx)
+	txq := New(r.db).WithTx(tx)
 
 	// Get with row lock
 	row, err := txq.GetAPIKeyByIDForUpdate(ctx, GetAPIKeyByIDForUpdateParams{
@@ -108,8 +109,10 @@ func (r *apiKeysRepository) Update(ctx context.Context, ref apikeys.KeyRef, upda
 }
 
 func (r *apiKeysRepository) GetByKeyHash(ctx context.Context, domain, keyHash string) (*apikeys.APIKey, error) {
+	q := New(r.db)
+
 	// Always perform database lookup to prevent timing attacks
-	row, err := r.q.GetAPIKeyByHash(ctx, GetAPIKeyByHashParams{
+	row, err := q.GetAPIKeyByHash(ctx, GetAPIKeyByHashParams{
 		KeyHash: keyHash,
 		Domain:  domain,
 	})
@@ -125,7 +128,9 @@ func (r *apiKeysRepository) GetByKeyHash(ctx context.Context, domain, keyHash st
 }
 
 func (r *apiKeysRepository) GetByID(ctx context.Context, ref apikeys.KeyRef) (*apikeys.APIKey, error) {
-	row, err := r.q.GetAPIKeyByID(ctx, GetAPIKeyByIDParams{
+	q := New(r.db)
+
+	row, err := q.GetAPIKeyByID(ctx, GetAPIKeyByIDParams{
 		ID:     ref.KeyID().String(),
 		Domain: ref.Domain(),
 	})
@@ -140,7 +145,9 @@ func (r *apiKeysRepository) GetByID(ctx context.Context, ref apikeys.KeyRef) (*a
 }
 
 func (r *apiKeysRepository) List(ctx context.Context, domain string, filters apikeys.ListFilters, page apikeys.Pagination) ([]*apikeys.APIKey, error) {
-	rows, err := r.q.ListAPIKeysByDomain(ctx, ListAPIKeysByDomainParams{
+	q := New(r.db)
+
+	rows, err := q.ListAPIKeysByDomain(ctx, ListAPIKeysByDomainParams{
 		Domain:  domain,
 		Column2: filters.OnlyActive,
 		Limit:   int32(page.Limit),
@@ -159,7 +166,9 @@ func (r *apiKeysRepository) List(ctx context.Context, domain string, filters api
 }
 
 func (r *apiKeysRepository) Count(ctx context.Context, domain string, filters apikeys.ListFilters) (int, error) {
-	count, err := r.q.CountAPIKeysByDomain(ctx, CountAPIKeysByDomainParams{
+	q := New(r.db)
+
+	count, err := q.CountAPIKeysByDomain(ctx, CountAPIKeysByDomainParams{
 		Domain:  domain,
 		Column2: filters.OnlyActive,
 	})

--- a/internal/db/key_repo_test.go
+++ b/internal/db/key_repo_test.go
@@ -27,7 +27,7 @@ func (h testHelper) CreateDomain(t *testing.T) string {
 }
 
 func TestAPIKeysRepository(t *testing.T) {
-	repo := NewAPIKeysRepository(q, db)
+	repo := NewAPIKeysRepository(db)
 	helper := testHelper{}
 	apikeys.RunRepoSpec(t, repo, helper)
 }

--- a/internal/db/stats_repo.go
+++ b/internal/db/stats_repo.go
@@ -5,21 +5,23 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/kannon-email/kannon/internal/stats"
 )
 
 // StatsRepository implements stats.Repository using sqlc queries.
 type StatsRepository struct {
-	q *Queries
+	db *pgxpool.Pool
 }
 
 // NewStatsRepository creates a new StatsRepository.
-func NewStatsRepository(q *Queries) *StatsRepository {
-	return &StatsRepository{q: q}
+func NewStatsRepository(db *pgxpool.Pool) *StatsRepository {
+	return &StatsRepository{db: db}
 }
 
 func (r *StatsRepository) Insert(ctx context.Context, stat *stats.Stat) error {
-	return r.q.InsertStat(ctx, InsertStatParams{
+	q := New(r.db)
+	return q.InsertStat(ctx, InsertStatParams{
 		Email:     stat.Email,
 		MessageID: stat.MessageID,
 		Type:      StatsType(stat.Type),
@@ -30,7 +32,8 @@ func (r *StatsRepository) Insert(ctx context.Context, stat *stats.Stat) error {
 }
 
 func (r *StatsRepository) Query(ctx context.Context, domain string, timeRange stats.TimeRange, page stats.Pagination) ([]*stats.Stat, error) {
-	rows, err := r.q.QueryStats(ctx, QueryStatsParams{
+	q := New(r.db)
+	rows, err := q.QueryStats(ctx, QueryStatsParams{
 		Domain: domain,
 		Start:  toPgTimestamp(timeRange.Start),
 		Stop:   toPgTimestamp(timeRange.Stop),
@@ -49,7 +52,8 @@ func (r *StatsRepository) Query(ctx context.Context, domain string, timeRange st
 }
 
 func (r *StatsRepository) Count(ctx context.Context, domain string, timeRange stats.TimeRange) (int64, error) {
-	return r.q.CountQueryStats(ctx, CountQueryStatsParams{
+	q := New(r.db)
+	return q.CountQueryStats(ctx, CountQueryStatsParams{
 		Domain: domain,
 		Start:  toPgTimestamp(timeRange.Start),
 		Stop:   toPgTimestamp(timeRange.Stop),
@@ -57,7 +61,8 @@ func (r *StatsRepository) Count(ctx context.Context, domain string, timeRange st
 }
 
 func (r *StatsRepository) QueryTimeline(ctx context.Context, domain string, timeRange stats.TimeRange) ([]*stats.AggregatedStat, error) {
-	rows, err := r.q.QueryStatsTimeline(ctx, QueryStatsTimelineParams{
+	q := New(r.db)
+	rows, err := q.QueryStatsTimeline(ctx, QueryStatsTimelineParams{
 		Domain: domain,
 		Start:  toPgTimestamp(timeRange.Start),
 		Stop:   toPgTimestamp(timeRange.Stop),
@@ -78,7 +83,8 @@ func (r *StatsRepository) QueryTimeline(ctx context.Context, domain string, time
 }
 
 func (r *StatsRepository) DeleteOlderThan(ctx context.Context, before time.Time) (int64, error) {
-	return r.q.DeleteStatsOlderThan(ctx, toPgTimestamp(before))
+	q := New(r.db)
+	return q.DeleteStatsOlderThan(ctx, toPgTimestamp(before))
 }
 
 func toPgTimestamp(t time.Time) pgtype.Timestamp {

--- a/internal/db/stats_repo_test.go
+++ b/internal/db/stats_repo_test.go
@@ -7,6 +7,6 @@ import (
 )
 
 func TestStatsRepository(t *testing.T) {
-	repo := NewStatsRepository(q)
+	repo := NewStatsRepository(db)
 	stats.RunRepoSpec(t, repo)
 }

--- a/internal/db/templates.go
+++ b/internal/db/templates.go
@@ -5,21 +5,23 @@ import (
 	"errors"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/kannon-email/kannon/internal/templates"
 )
 
 type templatesRepository struct {
-	q *Queries
+	db *pgxpool.Pool
 }
 
 // NewTemplatesRepository creates a new PostgreSQL-backed Template repository.
-func NewTemplatesRepository(q *Queries) templates.Repository {
-	return &templatesRepository{q: q}
+func NewTemplatesRepository(db *pgxpool.Pool) templates.Repository {
+	return &templatesRepository{db: db}
 }
 
 func (r *templatesRepository) Create(ctx context.Context, t *templates.Template) error {
-	row, err := r.q.CreateTemplate(ctx, CreateTemplateParams{
+	q := New(r.db)
+	row, err := q.CreateTemplate(ctx, CreateTemplateParams{
 		TemplateID: t.TemplateID(),
 		Html:       t.Html(),
 		Title:      t.Title(),
@@ -41,7 +43,8 @@ func (r *templatesRepository) Update(ctx context.Context, templateID string, fn 
 	if err := fn(current); err != nil {
 		return nil, err
 	}
-	row, err := r.q.UpdateTemplate(ctx, UpdateTemplateParams{
+	q := New(r.db)
+	row, err := q.UpdateTemplate(ctx, UpdateTemplateParams{
 		TemplateID: current.TemplateID(),
 		Html:       current.Html(),
 		Title:      current.Title(),
@@ -56,7 +59,8 @@ func (r *templatesRepository) Update(ctx context.Context, templateID string, fn 
 }
 
 func (r *templatesRepository) Delete(ctx context.Context, templateID string) (*templates.Template, error) {
-	row, err := r.q.DeleteTemplate(ctx, templateID)
+	q := New(r.db)
+	row, err := q.DeleteTemplate(ctx, templateID)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, templates.ErrTemplateNotFound
@@ -67,7 +71,8 @@ func (r *templatesRepository) Delete(ctx context.Context, templateID string) (*t
 }
 
 func (r *templatesRepository) GetByID(ctx context.Context, templateID string) (*templates.Template, error) {
-	row, err := r.q.GetTemplate(ctx, templateID)
+	q := New(r.db)
+	row, err := q.GetTemplate(ctx, templateID)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, templates.ErrTemplateNotFound
@@ -78,7 +83,8 @@ func (r *templatesRepository) GetByID(ctx context.Context, templateID string) (*
 }
 
 func (r *templatesRepository) FindByDomain(ctx context.Context, domain, templateID string) (*templates.Template, error) {
-	row, err := r.q.FindTemplate(ctx, FindTemplateParams{
+	q := New(r.db)
+	row, err := q.FindTemplate(ctx, FindTemplateParams{
 		TemplateID: templateID,
 		Domain:     domain,
 	})
@@ -92,7 +98,8 @@ func (r *templatesRepository) FindByDomain(ctx context.Context, domain, template
 }
 
 func (r *templatesRepository) List(ctx context.Context, domain string, page templates.Pagination) ([]*templates.Template, error) {
-	rows, err := r.q.GetTemplates(ctx, GetTemplatesParams{
+	q := New(r.db)
+	rows, err := q.GetTemplates(ctx, GetTemplatesParams{
 		Domain: domain,
 		Skip:   int32(page.Skip),
 		Take:   int32(page.Take),
@@ -108,7 +115,8 @@ func (r *templatesRepository) List(ctx context.Context, domain string, page temp
 }
 
 func (r *templatesRepository) Count(ctx context.Context, domain string) (int, error) {
-	n, err := r.q.CountTemplates(ctx, domain)
+	q := New(r.db)
+	n, err := q.CountTemplates(ctx, domain)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/db/templates_repo_test.go
+++ b/internal/db/templates_repo_test.go
@@ -30,6 +30,6 @@ func (h templatesTestHelper) CreateDomain(t *testing.T) string {
 }
 
 func TestTemplatesRepository(t *testing.T) {
-	repo := NewTemplatesRepository(q)
+	repo := NewTemplatesRepository(db)
 	templates.RunRepoSpec(t, repo, templatesTestHelper{})
 }

--- a/internal/envelope/envelope_integration_test.go
+++ b/internal/envelope/envelope_integration_test.go
@@ -54,8 +54,8 @@ func TestMain(m *testing.M) {
 	q = sqlc.New(db)
 
 	eb = envelope.NewBuilder(q, statssec.NewStatsService(q))
-	ma = mailapi.NewMailerAPIV1(q, db, delivery.DefaultBackoff)
-	adminAPI = adminapi.CreateAdminAPIService(q, db)
+	ma = mailapi.NewMailerAPIV1(db, delivery.DefaultBackoff)
+	adminAPI = adminapi.CreateAdminAPIService(db)
 	claimer = pool.NewClaimer(sqlc.NewDeliveryRepository(db, delivery.DefaultBackoff))
 
 	code := m.Run()

--- a/pkg/api/adminapi/adminapi.go
+++ b/pkg/api/adminapi/adminapi.go
@@ -114,17 +114,16 @@ func (a *adminAPIConnectAdapter) DeactivateAPIKey(ctx context.Context, req *conn
 	return connect.NewResponse(resp), nil
 }
 
-func CreateAdminAPIService(q *sqlc.Queries, pool *pgxpool.Pool) adminv1connect.ApiHandler {
-	domainsRepo := sqlc.NewDomainsRepository(q)
-	tm := sqlc.NewTemplatesRepository(q)
-	apiKeysRepo := sqlc.NewAPIKeysRepository(q, pool)
+func CreateAdminAPIService(db *pgxpool.Pool) adminv1connect.ApiHandler {
+	domainsRepo := sqlc.NewDomainsRepository(db)
+	tm := sqlc.NewTemplatesRepository(db)
+	apiKeysRepo := sqlc.NewAPIKeysRepository(db)
 	apiKeysService := apikeys.NewService(apiKeysRepo)
 	return &adminAPIConnectAdapter{
 		impl: &adminAPIService{
 			domains:   domainsRepo,
 			templates: tm,
 			apiKeys:   apiKeysService,
-			q:         q,
 		},
 	}
 }

--- a/pkg/api/adminapi/adminapi_test.go
+++ b/pkg/api/adminapi/adminapi_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/go-faker/faker/v4"
 	"github.com/jackc/pgx/v5/pgxpool"
 	schema "github.com/kannon-email/kannon/db"
-	sqlc "github.com/kannon-email/kannon/internal/db"
 	"github.com/kannon-email/kannon/internal/tests"
 	"github.com/kannon-email/kannon/pkg/api/adminapi"
 	pb "github.com/kannon-email/kannon/proto/kannon/admin/apiv1"
@@ -21,7 +20,6 @@ import (
 )
 
 var db *pgxpool.Pool
-var q *sqlc.Queries
 var testservice adminv1connect.ApiHandler
 
 func TestMain(m *testing.M) {
@@ -33,8 +31,7 @@ func TestMain(m *testing.M) {
 		logrus.Fatalf("Could not start resource: %s", err)
 	}
 
-	q = sqlc.New(db)
-	testservice = adminapi.CreateAdminAPIService(q, db)
+	testservice = adminapi.CreateAdminAPIService(db)
 
 	code := m.Run()
 

--- a/pkg/api/adminapi/impl.go
+++ b/pkg/api/adminapi/impl.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/kannon-email/kannon/internal/apikeys"
-	sqlc "github.com/kannon-email/kannon/internal/db"
 	"github.com/kannon-email/kannon/internal/domains"
 	"github.com/kannon-email/kannon/internal/templates"
 
@@ -15,7 +14,6 @@ type adminAPIService struct {
 	domains   domains.Repository
 	templates templates.Repository
 	apiKeys   *apikeys.Service
-	q         *sqlc.Queries
 }
 
 func (s *adminAPIService) GetDomains(ctx context.Context, in *pb.GetDomainsReq) (*pb.GetDomainsResponse, error) {

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -52,14 +52,14 @@ func run(ctx context.Context, config Config, cnt *container.Container) error {
 
 	logrus.Infof("Starting API Service on port %d", port)
 
-	q := cnt.Queries()
+	db := cnt.DB()
 
-	statsRepo := sq.NewStatsRepository(q)
-	aggregatedRepo := sq.NewAggregatedStatsRepository(q)
+	statsRepo := sq.NewStatsRepository(db)
+	aggregatedRepo := sq.NewAggregatedStatsRepository(db)
 	statsService := stats.NewService(statsRepo, stats.WithAggregatedStatsRepository(aggregatedRepo))
 
-	adminAPIService := adminapi.CreateAdminAPIService(q, cnt.DB())
-	mailAPIService := mailapi.NewMailerAPIV1(q, cnt.DB(), cnt.BackoffPolicy())
+	adminAPIService := adminapi.CreateAdminAPIService(db)
+	mailAPIService := mailapi.NewMailerAPIV1(db, cnt.BackoffPolicy())
 	statsAPIService := statsv1.NewStatsAPIService(statsService)
 	statsV2APIService := statsv2.NewStatsAPIService(statsService)
 	hzAPIService := hzapi.CreateHZAPIService(cnt)

--- a/pkg/api/mailapi/base_test.go
+++ b/pkg/api/mailapi/base_test.go
@@ -38,8 +38,8 @@ func TestMain(m *testing.M) {
 	}
 
 	q = sqlc.New(db)
-	ts = mailapi.NewMailerAPIV1(q, db, delivery.DefaultBackoff)
-	adminAPI = adminapi.CreateAdminAPIService(q, db)
+	ts = mailapi.NewMailerAPIV1(db, delivery.DefaultBackoff)
+	adminAPI = adminapi.CreateAdminAPIService(db)
 
 	code := m.Run()
 

--- a/pkg/api/mailapi/mailer.go
+++ b/pkg/api/mailapi/mailer.go
@@ -236,13 +236,13 @@ func validateHeaders(h *mailertypes.Headers) (batch.Headers, error) {
 	return batch.Headers{To: h.To, Cc: h.Cc}, nil
 }
 
-func NewMailerAPIV1(q *sqlc.Queries, db *pgxpool.Pool, backoff delivery.BackoffPolicy) mailerv1connect.MailerHandler {
-	domainsCli := sqlc.NewDomainsRepository(q)
-	apiKeysRepo := sqlc.NewAPIKeysRepository(q, db)
+func NewMailerAPIV1(db *pgxpool.Pool, backoff delivery.BackoffPolicy) mailerv1connect.MailerHandler {
+	domainsCli := sqlc.NewDomainsRepository(db)
+	apiKeysRepo := sqlc.NewAPIKeysRepository(db)
 	apiKeysService := apikeys.NewService(apiKeysRepo)
-	batchRepo := sqlc.NewBatchRepository(q)
+	batchRepo := sqlc.NewBatchRepository(db)
 	deliveryRepo := sqlc.NewDeliveryRepository(db, backoff)
-	templatesRepo := sqlc.NewTemplatesRepository(q)
+	templatesRepo := sqlc.NewTemplatesRepository(db)
 
 	return &mailAPIService{
 		domains:    domainsCli,

--- a/pkg/stats/cleanup_test.go
+++ b/pkg/stats/cleanup_test.go
@@ -47,7 +47,7 @@ func TestMain(m *testing.M) {
 const testRetention = 365 * 24 * time.Hour
 
 func newTestHandler() statsHandler {
-	repo := sq.NewStatsRepository(q)
+	repo := sq.NewStatsRepository(db)
 	service := stats.NewService(repo)
 	return statsHandler{
 		service:   service,

--- a/pkg/stats/stats.go
+++ b/pkg/stats/stats.go
@@ -54,8 +54,9 @@ func run(ctx context.Context, cnt *container.Container, cfg Config) error {
 	q := cnt.Queries()
 	js := cnt.NatsJetStream()
 
-	repo := sq.NewStatsRepository(q)
-	aggregatedRepo := sq.NewAggregatedStatsRepository(q)
+	db := cnt.DB()
+	repo := sq.NewStatsRepository(db)
+	aggregatedRepo := sq.NewAggregatedStatsRepository(db)
 	service := stats.NewService(repo, stats.WithAggregatedStatsRepository(aggregatedRepo))
 
 	h := statsHandler{

--- a/pkg/validator/validator_test.go
+++ b/pkg/validator/validator_test.go
@@ -50,8 +50,8 @@ func TestMain(m *testing.M) {
 	claimer := pool.NewClaimer(sqlc.NewDeliveryRepository(db, delivery.DefaultBackoff))
 	vt = validator.NewValidator(claimer, &mp)
 
-	ts = mailapi.NewMailerAPIV1(q, db, delivery.DefaultBackoff)
-	adminAPI = adminapi.CreateAdminAPIService(q, db)
+	ts = mailapi.NewMailerAPIV1(db, delivery.DefaultBackoff)
+	adminAPI = adminapi.CreateAdminAPIService(db)
 
 	code := m.Run()
 


### PR DESCRIPTION
## Summary
- `internal/db` repository constructors now take `db *pgxpool.Pool` and build a fresh `*Queries` per method via `New(r.db)`; the precomputed `q` field is gone.
- `NewAPIKeysRepository` drops its separate `pool` argument — `db` serves both queries and `BeginTx`.
- Cascades to `CreateAdminAPIService(db)` and `NewMailerAPIV1(db, backoff)`; the unused `q` field on `adminAPIService` is removed.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/db/... ./pkg/api/... ./pkg/stats/... ./pkg/validator/... ./internal/envelope/...`