### PR TITLE
perf(db): index sending_pool_emails on (status, scheduled_time)

### DIFF
--- a/db/migrations/20260509102644_add_sending_pool_emails_indexes.sql
+++ b/db/migrations/20260509102644_add_sending_pool_emails_indexes.sql
@@ -1,0 +1,7 @@
+-- migrate:up
+CREATE INDEX sending_pool_emails_status_scheduled_time_idx
+  ON sending_pool_emails (status, scheduled_time)
+  WHERE status IN ('to_validate', 'scheduled');
+
+-- migrate:down
+DROP INDEX sending_pool_emails_status_scheduled_time_idx;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -603,6 +603,13 @@ CREATE INDEX messages_message_id_idx ON public.messages USING btree (message_id)
 
 
 --
+-- Name: sending_pool_emails_status_scheduled_time_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX sending_pool_emails_status_scheduled_time_idx ON public.sending_pool_emails USING btree (status, scheduled_time) WHERE ((status)::text = ANY ((ARRAY['to_validate'::character varying, 'scheduled'::character varying])::text[]));
+
+
+--
 -- Name: stats_email_message_id_type_timestamp_idx; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -721,4 +728,5 @@ INSERT INTO public.schema_migrations (version) VALUES
     ('20260124120000'),
     ('20260214120000'),
     ('20260214120001'),
-    ('20260214120002');
+    ('20260214120002'),
+    ('20260509102644');


### PR DESCRIPTION
## Summary
- Adds a partial index `sending_pool_emails_status_scheduled_time_idx ON (status, scheduled_time) WHERE status IN ('to_validate', 'scheduled')` so the dispatcher's `PrepareForSend` and validator's `PrepareForValidate` claim loops use an Index Scan instead of full-scanning the queue every cycle.
- Dropped the second index proposed in #360 on `(email, message_id)`: the existing `unique_emails_message_id_idx` already covers `GetPool`, `SetSendingPoolDelivered`, `CleanPool`, and `ReschedulePool`, so adding it would be a redundant duplicate.

Closes #360.

## Test plan
- [x] `EXPLAIN` on `PrepareForSend` filter shows `Index Scan using sending_pool_emails_status_scheduled_time_idx` (was Seq Scan).
- [x] `EXPLAIN` on `PrepareForValidate` filter shows `Index Scan using sending_pool_emails_status_scheduled_time_idx` (was Seq Scan).
- [x] `go test ./... -short` — green.
- [x] `go test ./e2e -timeout 10m` — green (32.6s).