### PR TITLE
build(ci): tighten golangci-lint config

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -6,6 +6,7 @@ linters:
     - dogsled
     - dupl
     - errcheck
+    - errorlint
     - goconst
     - gocritic
     - goprintffuncname
@@ -13,6 +14,8 @@ linters:
     - ineffassign
     - misspell
     - nolintlint
+    - perfsprint
+    - sloglint
     - staticcheck
     - unconvert
     - unparam
@@ -21,6 +24,9 @@ linters:
   settings:
     dupl:
       threshold: 100
+    errcheck:
+      check-type-assertions: true
+      check-blank: true
     goconst:
       min-len: 3
       min-occurrences: 3

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -60,8 +61,9 @@ func readViperConfig() error {
 	viper.BindEnv("debug")
 
 	if err := viper.ReadInConfig(); err != nil {
-		if _, ok := err.(viper.ConfigFileNotFoundError); !ok {
-			return fmt.Errorf("cannot read config file: %v", err)
+		var configFileNotFoundError viper.ConfigFileNotFoundError
+		if !errors.As(err, &configFileNotFoundError) {
+			return fmt.Errorf("cannot read config file: %w", err)
 		}
 	}
 

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -608,7 +608,7 @@ func testOpened(t *testing.T, clientFactory *clientFactory, senderMock *senderMo
 		resp, err := http.Get(url)
 		require.NoError(tt, err)
 		defer resp.Body.Close()
-		_, _ = io.Copy(io.Discard, resp.Body)
+		_, _ = io.Copy(io.Discard, resp.Body) //nolint:errcheck // draining body before close
 		require.Equal(tt, http.StatusOK, resp.StatusCode)
 	}, 10*time.Second, 200*time.Millisecond, "Tracker open endpoint should be reachable")
 
@@ -653,7 +653,7 @@ func testClicked(t *testing.T, clientFactory *clientFactory, senderMock *senderM
 		resp, err := httpClient.Get(url)
 		require.NoError(tt, err)
 		defer resp.Body.Close()
-		_, _ = io.Copy(io.Discard, resp.Body)
+		_, _ = io.Copy(io.Discard, resp.Body) //nolint:errcheck // draining body before close
 		require.Equal(tt, http.StatusTemporaryRedirect, resp.StatusCode)
 		location = resp.Header.Get("Location")
 	}, 10*time.Second, 200*time.Millisecond, "Tracker click endpoint should be reachable")

--- a/e2e/infrastructure_test.go
+++ b/e2e/infrastructure_test.go
@@ -63,7 +63,7 @@ func setupTestInfrastructure(ctx context.Context) (*TestInfrastructure, error) {
 
 	// Get connection URLs
 	dbURL := fmt.Sprintf("postgresql://test:test@localhost:%s/test?sslmode=disable", pgRes.GetPort("5432/tcp"))
-	natsURL := fmt.Sprintf("nats://localhost:%s", natsRes.GetPort("4222/tcp"))
+	natsURL := "nats://localhost:" + natsRes.GetPort("4222/tcp")
 
 	// Wait for PostgreSQL to be ready
 	var db *pgxpool.Pool
@@ -192,6 +192,6 @@ func findAvailablePort() (uint, error) {
 	}
 	defer listener.Close()
 
-	port := listener.Addr().(*net.TCPAddr).Port
+	port := listener.Addr().(*net.TCPAddr).Port //nolint:errcheck // net.Listen("tcp") always yields *net.TCPAddr
 	return uint(port), nil
 }

--- a/internal/apikeys/id.go
+++ b/internal/apikeys/id.go
@@ -1,6 +1,7 @@
 package apikeys
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -20,7 +21,7 @@ func NewID() ID {
 // ParseID validates and parses a string into an ID
 func ParseID(s string) (ID, error) {
 	if s == "" {
-		return "", fmt.Errorf("API key ID is required")
+		return "", errors.New("API key ID is required")
 	}
 	if !strings.HasPrefix(s, IDPrefix) {
 		return "", fmt.Errorf("invalid API key ID format: must start with %s", IDPrefix)

--- a/internal/apikeys/repospec.go
+++ b/internal/apikeys/repospec.go
@@ -1,6 +1,7 @@
 package apikeys
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -109,7 +110,7 @@ func testUpdate(t *testing.T, repo Repository, helper RepoTestHelper) {
 		assert.Nil(t, initial.DeactivatedAt(), "deactivatedAt should be nil initially")
 
 		// Attempt update that mutates key then returns error
-		testErr := fmt.Errorf("intentional test error")
+		testErr := errors.New("intentional test error")
 		_, err = repo.Update(ctx, ref, func(k *APIKey) error {
 			k.Deactivate() // Mutates the key
 			return testErr // But then fails
@@ -185,9 +186,10 @@ func testGetByID(t *testing.T, repo Repository, helper RepoTestHelper) {
 		ctx := t.Context()
 		domain := helper.CreateDomain(t)
 
-		nonExistentID, _ := ParseID("key_nonexistent")
+		nonExistentID, err := ParseID("key_nonexistent")
+		require.NoError(t, err)
 		ref := NewKeyRef(domain, nonExistentID)
-		_, err := repo.GetByID(ctx, ref)
+		_, err = repo.GetByID(ctx, ref)
 		assert.ErrorIs(t, err, ErrKeyNotFound)
 	})
 }

--- a/internal/apikeys/service_test.go
+++ b/internal/apikeys/service_test.go
@@ -90,10 +90,11 @@ func TestService_GetKey(t *testing.T) {
 		service := apikeys.NewService(repo)
 
 		domain := testDomain
-		nonExistentID, _ := apikeys.ParseID("key_nonexistent")
+		nonExistentID, err := apikeys.ParseID("key_nonexistent")
+		require.NoError(t, err)
 		ref := apikeys.NewKeyRef(domain, nonExistentID)
 
-		_, err := service.GetKey(ctx, ref)
+		_, err = service.GetKey(ctx, ref)
 		assert.ErrorIs(t, err, apikeys.ErrKeyNotFound)
 	})
 }
@@ -227,10 +228,11 @@ func TestService_DeactivateKey(t *testing.T) {
 		service := apikeys.NewService(repo)
 
 		domain := testDomain
-		nonExistentID, _ := apikeys.ParseID("key_nonexistent")
+		nonExistentID, err := apikeys.ParseID("key_nonexistent")
+		require.NoError(t, err)
 		ref := apikeys.NewKeyRef(domain, nonExistentID)
 
-		_, err := service.DeactivateKey(ctx, ref)
+		_, err = service.DeactivateKey(ctx, ref)
 		assert.ErrorIs(t, err, apikeys.ErrKeyNotFound)
 	})
 }

--- a/internal/batch/batch.go
+++ b/internal/batch/batch.go
@@ -6,7 +6,6 @@ package batch
 
 import (
 	"errors"
-	"fmt"
 )
 
 // Domain errors.
@@ -47,16 +46,16 @@ type Batch struct {
 // New creates a new Batch with a freshly generated ID for the given domain.
 func New(domain, subject string, sender Sender, templateID string, attachments Attachments, headers Headers) (*Batch, error) {
 	if domain == "" {
-		return nil, fmt.Errorf("domain is required")
+		return nil, errors.New("domain is required")
 	}
 	if subject == "" {
-		return nil, fmt.Errorf("subject is required")
+		return nil, errors.New("subject is required")
 	}
 	if templateID == "" {
-		return nil, fmt.Errorf("template ID is required")
+		return nil, errors.New("template ID is required")
 	}
 	if sender.Email == "" {
-		return nil, fmt.Errorf("sender email is required")
+		return nil, errors.New("sender email is required")
 	}
 	return &Batch{
 		id:          NewID(domain),

--- a/internal/batch/id.go
+++ b/internal/batch/id.go
@@ -1,6 +1,7 @@
 package batch
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -20,13 +21,13 @@ func NewID(domain string) ID {
 // ParseID validates and parses a string into an ID.
 func ParseID(s string) (ID, error) {
 	if s == "" {
-		return "", fmt.Errorf("batch ID is required")
+		return "", errors.New("batch ID is required")
 	}
 	if !strings.HasPrefix(s, IDPrefix) {
 		return "", fmt.Errorf("invalid batch ID format: must start with %s", IDPrefix)
 	}
 	if !strings.Contains(s, "@") {
-		return "", fmt.Errorf("invalid batch ID format: missing domain")
+		return "", errors.New("invalid batch ID format: missing domain")
 	}
 	return ID(s), nil
 }

--- a/internal/db/attachment.go
+++ b/internal/db/attachment.go
@@ -3,10 +3,11 @@ package sqlc
 import (
 	"database/sql/driver"
 	"encoding/json"
+	"errors"
 	"fmt"
 )
 
-var ErrInvalidAttachment = fmt.Errorf("invalid attachment")
+var ErrInvalidAttachment = errors.New("invalid attachment")
 
 type Attachments map[string][]byte
 

--- a/internal/db/batch_repo_test.go
+++ b/internal/db/batch_repo_test.go
@@ -23,9 +23,12 @@ func (h batchTestHelper) CreateDomain(t *testing.T) string {
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		cleanupCtx := context.Background()
-		_, _ = db.Exec(cleanupCtx, "DELETE FROM messages WHERE domain = $1", domainName)
-		_, _ = db.Exec(cleanupCtx, "DELETE FROM templates WHERE domain = $1", domainName)
-		_, _ = db.Exec(cleanupCtx, "DELETE FROM domains WHERE domain = $1", domainName)
+		//nolint:errcheck // best-effort test cleanup
+		db.Exec(cleanupCtx, "DELETE FROM messages WHERE domain = $1", domainName)
+		//nolint:errcheck // best-effort test cleanup
+		db.Exec(cleanupCtx, "DELETE FROM templates WHERE domain = $1", domainName)
+		//nolint:errcheck // best-effort test cleanup
+		db.Exec(cleanupCtx, "DELETE FROM domains WHERE domain = $1", domainName)
 	})
 	return domainName
 }

--- a/internal/db/domains_repo_test.go
+++ b/internal/db/domains_repo_test.go
@@ -10,7 +10,8 @@ import (
 
 func TestDomainsRepository(t *testing.T) {
 	t.Cleanup(func() {
-		_, _ = db.Exec(context.Background(), "DELETE FROM domains CASCADE")
+		//nolint:errcheck // best-effort test cleanup
+		db.Exec(context.Background(), "DELETE FROM domains CASCADE")
 	})
 	_, err := db.Exec(context.Background(), "DELETE FROM domains CASCADE")
 	require.NoError(t, err)

--- a/internal/db/pool_helper_test.go
+++ b/internal/db/pool_helper_test.go
@@ -49,10 +49,14 @@ func seedBatchFixture(tb testing.TB) (batch.ID, string) {
 
 	tb.Cleanup(func() {
 		cleanupCtx := context.Background()
-		_, _ = db.Exec(cleanupCtx, "DELETE FROM sending_pool_emails WHERE domain = $1", domainName)
-		_, _ = db.Exec(cleanupCtx, "DELETE FROM messages WHERE domain = $1", domainName)
-		_, _ = db.Exec(cleanupCtx, "DELETE FROM templates WHERE domain = $1", domainName)
-		_, _ = db.Exec(cleanupCtx, "DELETE FROM domains WHERE domain = $1", domainName)
+		//nolint:errcheck // best-effort test cleanup
+		db.Exec(cleanupCtx, "DELETE FROM sending_pool_emails WHERE domain = $1", domainName)
+		//nolint:errcheck // best-effort test cleanup
+		db.Exec(cleanupCtx, "DELETE FROM messages WHERE domain = $1", domainName)
+		//nolint:errcheck // best-effort test cleanup
+		db.Exec(cleanupCtx, "DELETE FROM templates WHERE domain = $1", domainName)
+		//nolint:errcheck // best-effort test cleanup
+		db.Exec(cleanupCtx, "DELETE FROM domains WHERE domain = $1", domainName)
 	})
 
 	return bID, domainName

--- a/internal/db/templates_repo_test.go
+++ b/internal/db/templates_repo_test.go
@@ -23,8 +23,10 @@ func (h templatesTestHelper) CreateDomain(t *testing.T) string {
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		cleanupCtx := context.Background()
-		_, _ = db.Exec(cleanupCtx, "DELETE FROM templates WHERE domain = $1", domainName)
-		_, _ = db.Exec(cleanupCtx, "DELETE FROM domains WHERE domain = $1", domainName)
+		//nolint:errcheck // best-effort test cleanup
+		db.Exec(cleanupCtx, "DELETE FROM templates WHERE domain = $1", domainName)
+		//nolint:errcheck // best-effort test cleanup
+		db.Exec(cleanupCtx, "DELETE FROM domains WHERE domain = $1", domainName)
 	})
 	return domainName
 }

--- a/internal/delivery/delivery.go
+++ b/internal/delivery/delivery.go
@@ -5,7 +5,6 @@ package delivery
 
 import (
 	"errors"
-	"fmt"
 	"time"
 
 	"github.com/kannon-email/kannon/internal/batch"
@@ -41,13 +40,13 @@ type NewParams struct {
 // New creates a new Delivery scheduled for first attempt.
 func New(p NewParams) (*Delivery, error) {
 	if p.BatchID.IsZero() {
-		return nil, fmt.Errorf("batch ID is required")
+		return nil, errors.New("batch ID is required")
 	}
 	if p.Email == "" {
-		return nil, fmt.Errorf("email is required")
+		return nil, errors.New("email is required")
 	}
 	if p.Domain == "" {
-		return nil, fmt.Errorf("domain is required")
+		return nil, errors.New("domain is required")
 	}
 	return &Delivery{
 		batchID:               p.BatchID,

--- a/internal/domains/domains.go
+++ b/internal/domains/domains.go
@@ -11,7 +11,6 @@ package domains
 
 import (
 	"errors"
-	"fmt"
 	"time"
 
 	"github.com/kannon-email/kannon/internal/dkim"
@@ -37,7 +36,7 @@ type Domain struct {
 // The numeric id and createdAt are populated by the repository on Create.
 func New(fqdn string) (*Domain, error) {
 	if fqdn == "" {
-		return nil, fmt.Errorf("domain is required")
+		return nil, errors.New("domain is required")
 	}
 	keys, err := dkim.GenerateDKIMKeysPair()
 	if err != nil {

--- a/internal/envelope/envelope_integration_test.go
+++ b/internal/envelope/envelope_integration_test.go
@@ -105,7 +105,8 @@ func TestPrepareMail(t *testing.T) {
 	assert.Equal(t, "Test <test@test.com>", parsed.Header.Get("From"))
 	assert.Equal(t, "Test Test", parsed.Header.Get("Subject"))
 
-	html, _ := io.ReadAll(parsed.Body)
+	html, err := io.ReadAll(parsed.Body)
+	assert.Nil(t, err)
 	assert.Equal(t, "test Test", string(html))
 }
 

--- a/internal/envelope/message_test.go
+++ b/internal/envelope/message_test.go
@@ -3,6 +3,7 @@ package envelope
 import (
 	"bytes"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"io"
 	"mime"
@@ -197,12 +198,13 @@ func TestRenderMsgWithSingleAttachment(t *testing.T) {
 	gotAttachments := map[string][]byte{}
 	for {
 		part, err := mr.NextPart()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		assert.Nil(t, err)
 
 		ct := part.Header.Get("Content-Type")
+		//nolint:errcheck // attachment parts may omit Content-Type
 		mt, _, _ := mime.ParseMediaType(ct)
 		raw, err := io.ReadAll(part)
 		assert.Nil(t, err)
@@ -246,10 +248,11 @@ func TestRenderMsgWithMultipleAttachments(t *testing.T) {
 	got := map[string][]byte{}
 	for {
 		part, err := mr.NextPart()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		assert.Nil(t, err)
+		//nolint:errcheck // attachment parts may omit Content-Type
 		mt, _, _ := mime.ParseMediaType(part.Header.Get("Content-Type"))
 		if mt == "text/html" {
 			continue

--- a/internal/publisher/publisher.go
+++ b/internal/publisher/publisher.go
@@ -37,7 +37,7 @@ func PublishStat(p Publisher, s *types.Stats) error {
 
 	data, err := proto.Marshal(s)
 	if err != nil {
-		return fmt.Errorf("cannot marshal protoc: %v", err)
+		return fmt.Errorf("cannot marshal protoc: %w", err)
 	}
 	return p.Publish(subj, data)
 }

--- a/internal/smtp/sender.go
+++ b/internal/smtp/sender.go
@@ -7,6 +7,7 @@ package smtp
 
 import (
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -89,7 +90,7 @@ func (s *sender) Send(from, to string, msg []byte) SenderError {
 
 		lastErr = err
 	}
-	err = fmt.Errorf("all MXs failed, last error: %v", lastErr)
+	err = fmt.Errorf("all MXs failed, last error: %w", lastErr)
 	return newSMTPError(err, false, lastErr.Code())
 }
 
@@ -188,7 +189,8 @@ func lookupMXs(domain string) ([]string, *smtpError) {
 	mxRecords, err := net.LookupMX(domain)
 	if err != nil {
 		// TODO: Better handle Temporary errors.
-		dnsErr, ok := err.(*net.DNSError)
+		dnsErr := &net.DNSError{}
+		ok := errors.As(err, &dnsErr)
 		if !ok || !dnsErr.IsNotFound {
 			slog.Debug(fmt.Sprintf("MX lookup error: %v", err))
 			// TODO: add error code
@@ -220,7 +222,8 @@ func lookupMXs(domain string) ([]string, *smtpError) {
 }
 
 func newSMTPErrorFromSTMP(err error) *smtpError {
-	terr, ok := err.(*textproto.Error)
+	terr := &textproto.Error{}
+	ok := errors.As(err, &terr)
 	if !ok {
 		// unknown error
 		return newSMTPError(err, false, 0)

--- a/internal/smtp/utils_test.go
+++ b/internal/smtp/utils_test.go
@@ -52,6 +52,7 @@ func TestSplitEmail_InvalidEmail(t *testing.T) {
 
 func TestGetEmailDomain(t *testing.T) {
 	input := "test@email.com"
-	domain, _ := GetEmailDomain(input)
+	domain, err := GetEmailDomain(input)
+	assert.Nil(t, err)
 	assert.Equal(t, domain, "email.com")
 }

--- a/internal/stats/aggregated_repospec.go
+++ b/internal/stats/aggregated_repospec.go
@@ -2,6 +2,7 @@ package stats
 
 import (
 	"fmt"
+	"strconv"
 	"testing"
 	"time"
 
@@ -92,7 +93,7 @@ func testIncrementSeparateEntries(t *testing.T, repo AggregatedStatsRepository) 
 
 func testAggregatedQueryFiltersByDomain(t *testing.T, repo AggregatedStatsRepository) {
 	ctx := t.Context()
-	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+	suffix := strconv.FormatInt(time.Now().UnixNano(), 10)
 	domainA := fmt.Sprintf("agg-a-%s.test", suffix)
 	domainB := fmt.Sprintf("agg-b-%s.test", suffix)
 	day := time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC)

--- a/internal/stats/inmem_repo.go
+++ b/internal/stats/inmem_repo.go
@@ -32,7 +32,8 @@ func (r *InMemRepository) Insert(_ context.Context, stat *Stat) error {
 	// Store a deep copy to avoid external mutation.
 	cp := *stat
 	if stat.Data != nil {
-		cp.Data = proto.Clone(stat.Data).(*types.StatsData)
+		// proto.Clone preserves the concrete type of its input.
+		cp.Data = proto.Clone(stat.Data).(*types.StatsData) //nolint:errcheck // assertion cannot fail
 	}
 	r.stats = append(r.stats, &cp)
 	return nil

--- a/internal/stats/repospec.go
+++ b/internal/stats/repospec.go
@@ -2,6 +2,7 @@ package stats
 
 import (
 	"fmt"
+	"strconv"
 	"testing"
 	"time"
 
@@ -104,7 +105,7 @@ func testQueryPagination(t *testing.T, repo Repository) {
 
 func testQueryFiltersByDomain(t *testing.T, repo Repository) {
 	ctx := t.Context()
-	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+	suffix := strconv.FormatInt(time.Now().UnixNano(), 10)
 	domainA := fmt.Sprintf("domain-a-%s.test", suffix)
 	domainB := fmt.Sprintf("domain-b-%s.test", suffix)
 	now := time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC)

--- a/internal/statssec/keys.go
+++ b/internal/statssec/keys.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"time"
 
@@ -35,7 +36,7 @@ func generateKeyPair() (*rsa.PrivateKey, *rsa.PublicKey, error) {
 	}
 
 	publickey := privatekey.Public()
-	return privatekey, publickey.(*rsa.PublicKey), nil
+	return privatekey, publickey.(*rsa.PublicKey), nil //nolint:errcheck // RSA private key always returns *rsa.PublicKey
 }
 
 func createOpenToken(privateKey *rsa.PrivateKey, kid string, now time.Time, messageID string, email string) (string, error) {
@@ -125,12 +126,12 @@ func verifyOpenToken(ctx context.Context, tokenString string, q *sqlc.Queries) (
 	}
 
 	if !token.Valid {
-		return nil, fmt.Errorf("invalit token")
+		return nil, errors.New("invalit token")
 	}
 
 	claims, ok := token.Claims.(*OpenClaims)
 	if !ok {
-		return nil, fmt.Errorf("cannot unstructure claims")
+		return nil, errors.New("cannot unstructure claims")
 	}
 	return claims, nil
 }
@@ -142,12 +143,12 @@ func verifyLinkToken(ctx context.Context, tokenString string, q *sqlc.Queries) (
 	}
 
 	if !token.Valid {
-		return nil, fmt.Errorf("invalit token")
+		return nil, errors.New("invalit token")
 	}
 
 	claims, ok := token.Claims.(*LinkClaims)
 	if !ok {
-		return nil, fmt.Errorf("cannot unstructure claims")
+		return nil, errors.New("cannot unstructure claims")
 	}
 	return claims, nil
 }

--- a/internal/templates/templates.go
+++ b/internal/templates/templates.go
@@ -53,7 +53,7 @@ type Template struct {
 // ID. createdAt/updatedAt are populated by the repository on Create.
 func NewPersistent(domain, html, title string) (*Template, error) {
 	if domain == "" {
-		return nil, fmt.Errorf("domain is required")
+		return nil, errors.New("domain is required")
 	}
 	return &Template{
 		templateID: newTemplateID(domain),
@@ -67,7 +67,7 @@ func NewPersistent(domain, html, title string) (*Template, error) {
 // NewTransient creates a new transient Template with a freshly generated ID.
 func NewTransient(domain, html string) (*Template, error) {
 	if domain == "" {
-		return nil, fmt.Errorf("domain is required")
+		return nil, errors.New("domain is required")
 	}
 	return &Template{
 		templateID: newTemplateID(domain),

--- a/internal/utils/message.go
+++ b/internal/utils/message.go
@@ -48,7 +48,7 @@ func ParseBounceReturnPath(returnPath string) (email string, messageID string, d
 
 	emailBytes, err := base64.StdEncoding.DecodeString(emailHash)
 	if err != nil {
-		return "", "", "", false, fmt.Errorf("invalid returnPath: %v", err)
+		return "", "", "", false, fmt.Errorf("invalid returnPath: %w", err)
 	}
 	email = string(emailBytes)
 

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -96,6 +96,6 @@ func startAPIServer(ctx context.Context, port uint, adminServer adminv1connect.A
 		}
 	}()
 
-	slog.Info(fmt.Sprintf("Connect API server listening on %s", addr))
+	slog.Info("Connect API server listening on " + addr)
 	return server.ListenAndServe()
 }

--- a/pkg/api/mailapi/mailer.go
+++ b/pkg/api/mailapi/mailer.go
@@ -3,6 +3,7 @@ package mailapi
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -37,7 +38,7 @@ type mailAPIService struct {
 func (s mailAPIService) SendHTML(ctx context.Context, req *connect.Request[pb.SendHTMLReq]) (*connect.Response[pb.SendRes], error) {
 	domain, err := s.getCallDomainFromHeaders(ctx, req.Header())
 	if err != nil {
-		return nil, fmt.Errorf("invalid or wrong auth")
+		return nil, errors.New("invalid or wrong auth")
 	}
 
 	req.Msg.Html = utils.ReplaceCustomFields(req.Msg.Html, req.Msg.GlobalFields)
@@ -45,7 +46,7 @@ func (s mailAPIService) SendHTML(ctx context.Context, req *connect.Request[pb.Se
 	template, err := s.createTransientTemplate(ctx, domain.Domain(), req.Msg.Html)
 	if err != nil {
 		slog.Error("cannot create template", "err", err)
-		return nil, fmt.Errorf("cannot create template %v", err)
+		return nil, fmt.Errorf("cannot create template %w", err)
 	}
 
 	res := &pb.SendTemplateReq{
@@ -65,7 +66,7 @@ func (s mailAPIService) SendHTML(ctx context.Context, req *connect.Request[pb.Se
 func (s mailAPIService) SendTemplate(ctx context.Context, req *connect.Request[pb.SendTemplateReq]) (*connect.Response[pb.SendRes], error) {
 	domain, err := s.getCallDomainFromHeaders(ctx, req.Header())
 	if err != nil {
-		return nil, fmt.Errorf("invalid or wrong auth")
+		return nil, errors.New("invalid or wrong auth")
 	}
 
 	return s.sendTemplate(ctx, domain, req)
@@ -81,7 +82,7 @@ func (s mailAPIService) sendTemplate(ctx context.Context, domain *domains.Domain
 	template, err = s.createTemplateWithGlobalFields(ctx, template, req.Msg.GlobalFields)
 	if err != nil {
 		slog.Error("cannot create transient template", "err", err)
-		return nil, fmt.Errorf("cannot create template %v", err)
+		return nil, fmt.Errorf("cannot create template %w", err)
 	}
 
 	sender := batch.Sender{
@@ -132,7 +133,7 @@ func (s mailAPIService) scheduleBatch(ctx context.Context, b *batch.Batch, recip
 	ds := make([]*delivery.Delivery, 0, len(recipients))
 	for _, r := range recipients {
 		if strings.TrimSpace(r.Email) == "" {
-			slog.Warn(fmt.Sprintf("skipping recipient with empty email in batch %s", b.ID().String()))
+			slog.Warn("skipping recipient with empty email in batch " + b.ID().String())
 			continue
 		}
 		d, err := delivery.New(delivery.NewParams{
@@ -186,20 +187,20 @@ func (s mailAPIService) getCallDomainFromHeaders(ctx context.Context, headers ht
 	auth := headers.Get("Authorization")
 
 	if !strings.HasPrefix(auth, "Basic ") {
-		return nil, fmt.Errorf("invalid auth")
+		return nil, errors.New("invalid auth")
 	}
 
 	token := strings.Replace(auth, "Basic ", "", 1)
 	data, err := base64.StdEncoding.DecodeString(token)
 	if err != nil {
-		return nil, fmt.Errorf("invalid auth")
+		return nil, errors.New("invalid auth")
 	}
 
 	authData := string(data)
 
 	parts := strings.Split(authData, ":")
 	if len(parts) != 2 {
-		return nil, fmt.Errorf("invalid auth")
+		return nil, errors.New("invalid auth")
 	}
 	domainName, key := parts[0], parts[1]
 
@@ -207,13 +208,13 @@ func (s mailAPIService) getCallDomainFromHeaders(ctx context.Context, headers ht
 	apiKey, err := s.apiKeys.ValidateForAuth(ctx, domainName, key)
 	if err != nil {
 		// Always return generic error (security requirement)
-		return nil, fmt.Errorf("invalid auth")
+		return nil, errors.New("invalid auth")
 	}
 
 	// Fetch full domain info
 	domain, err := s.domains.FindByName(ctx, apiKey.Domain())
 	if err != nil {
-		return nil, fmt.Errorf("invalid auth")
+		return nil, errors.New("invalid auth")
 	}
 
 	return domain, nil

--- a/pkg/dispatcher/disp.go
+++ b/pkg/dispatcher/disp.go
@@ -2,6 +2,7 @@ package dispatcher
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
@@ -34,7 +35,7 @@ func (d *disp) DispatchCycle(ctx context.Context) error {
 	defer cancel()
 	emails, err := d.claimer.ClaimForDispatch(ctx, 20)
 	if err != nil {
-		return fmt.Errorf("cannot prepare emails for send: %v", err)
+		return fmt.Errorf("cannot prepare emails for send: %w", err)
 	}
 
 	d.log().Debug(fmt.Sprintf("seding %d emails", len(emails)))
@@ -71,7 +72,7 @@ func (d *disp) handleErrors(ctx context.Context) error {
 func (d *disp) parseErrorsFunc(ctx context.Context, m *statstypes.Stats) error {
 	bounceErr := m.Data.GetError()
 	if bounceErr == nil {
-		return fmt.Errorf("stats is not of type error")
+		return errors.New("stats is not of type error")
 	}
 
 	dlv, err := d.claimer.Lookup(ctx, batch.ID(m.MessageId), m.Email)

--- a/pkg/smtp/smtp.go
+++ b/pkg/smtp/smtp.go
@@ -40,7 +40,7 @@ func (s *Session) AuthPlain(username, password string) error {
 }
 
 func (s *Session) Mail(from string, opts *smtp.MailOptions) error {
-	slog.Debug(fmt.Sprintf("Mail from: %s", from))
+	slog.Debug("Mail from: " + from)
 	s.From = from
 	return nil
 }

--- a/pkg/tracker/srv.go
+++ b/pkg/tracker/srv.go
@@ -36,7 +36,7 @@ func (s *srv) Run(ctx context.Context) error {
 	mux.HandleFunc("/c/", s.handleClick)
 
 	addr := fmt.Sprintf("0.0.0.0:%d", s.cfg.Port)
-	slog.Info(fmt.Sprintf("running tracker on %s", addr))
+	slog.Info("running tracker on " + addr)
 
 	server := &http.Server{Addr: addr, Handler: mux}
 

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -2,6 +2,7 @@ package validator
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"regexp"
@@ -59,7 +60,7 @@ func (d *Validator) Cycle(pctx context.Context) error {
 	defer cancel()
 	emails, err := d.claimer.ClaimForValidation(ctx, 100)
 	if err != nil {
-		return fmt.Errorf("cannot prepare emails for send: %v", err)
+		return fmt.Errorf("cannot prepare emails for send: %w", err)
 	}
 
 	d.log().Debug(fmt.Sprintf("validating %d emails", len(emails)))
@@ -133,4 +134,4 @@ func validateEmail(email string) error {
 	return ErrInvalidEmailAddress
 }
 
-var ErrInvalidEmailAddress = fmt.Errorf(" is not a valid email")
+var ErrInvalidEmailAddress = errors.New(" is not a valid email")

--- a/x/container/container.go
+++ b/x/container/container.go
@@ -2,6 +2,7 @@ package container
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -169,10 +170,10 @@ func (c *Container) EmbeddedNatsServer() *server.Server {
 
 		if !ns.ReadyForConnections(10 * time.Second) {
 			ns.Shutdown()
-			return nil, fmt.Errorf("NATS server not ready after 10 seconds")
+			return nil, errors.New("NATS server not ready after 10 seconds")
 		}
 
-		slog.Info(fmt.Sprintf("Embedded NATS server started at %s", ns.ClientURL()))
+		slog.Info("Embedded NATS server started at " + ns.ClientURL())
 
 		c.addClosers(func(ctx context.Context) error {
 			slog.Info("Shutting down embedded NATS server...")
@@ -183,7 +184,7 @@ func (c *Container) EmbeddedNatsServer() *server.Server {
 
 		c.addHZ("embedded-nats", func(ctx context.Context) error {
 			if !ns.ReadyForConnections(100 * time.Millisecond) {
-				return fmt.Errorf("embedded NATS server not ready")
+				return errors.New("embedded NATS server not ready")
 			}
 			return nil
 		})
@@ -200,7 +201,7 @@ func (c *Container) Nats() *nats.Conn {
 			natsURL = ns.ClientURL()
 		}
 
-		slog.Debug(fmt.Sprintf("connecting to NATS: %s", natsURL))
+		slog.Debug("connecting to NATS: " + natsURL)
 		nc, err := nats.Connect(natsURL)
 		if err != nil {
 			return nil, err
@@ -328,10 +329,10 @@ func provisionEmbeddedJetStreams(nc *nats.Conn) error {
 
 	for _, s := range streams {
 		if _, err := js.StreamInfo(s.name); err == nil {
-			slog.Debug(fmt.Sprintf("JetStream stream already exists: %s", s.name))
+			slog.Debug("JetStream stream already exists: " + s.name)
 			continue
 		}
-		slog.Info(fmt.Sprintf("Creating JetStream stream: %s", s.name))
+		slog.Info("Creating JetStream stream: " + s.name)
 		if _, err := js.AddStream(&nats.StreamConfig{
 			Name:     s.name,
 			Subjects: s.subjects,


### PR DESCRIPTION
## Summary

Closes #367.

- Enable `errorlint`, `perfsprint`, `sloglint`, and `errcheck` strict mode (`check-blank`, `check-type-assertions`).
- Fix all surfaced issues so `make lint` passes cleanly.

## Notable behavioral fix

`cmd/config.go`: `golangci-lint --fix` mistakenly inverted the `viper.ConfigFileNotFoundError` branch (`if !ok { return }` became `if errors.As(...) { return }`). Restored the original behavior — config-file-not-found is silently tolerated, every other read error propagates. Without this fix every successful run on a host that has a config file would return an error.

## Linter fixes

- `errorlint`: switch error type assertions to `errors.As`, `err == io.EOF` to `errors.Is`, and `%v` to `%w` in `fmt.Errorf` wraps.
- `perfsprint`: `fmt.Errorf("static string")` → `errors.New`, `fmt.Sprintf("%d", x)` → `strconv.FormatInt`, single-format `slog.Info(fmt.Sprintf(...))` → string concatenation.
- `errcheck` strict: tests now use `require.NoError`/`assert.Nil` or explicit `//nolint:errcheck` where the assertion is provably safe (`*rsa.PublicKey` from RSA key, `proto.Clone` preserving concrete type, `*net.TCPAddr` from `net.Listen("tcp")`) or the error is intentionally ignored (best-effort `t.Cleanup` DELETEs, attachment parts without Content-Type, response-body draining before close).

## Test plan

- [x] `make lint` reports `0 issues.`
- [x] `go tool deadcode -test ./...` is empty
- [x] `go test ./... -race -short` passes
- [x] CI must fail on regressions (verified locally via the new strict config)