### PR TITLE
test: use t.Context() / b.Context() in tests

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -403,7 +403,7 @@ func waitForAPIServer(t *testing.T, infra *TestInfrastructure) {
 	)
 
 	require.EventuallyWithT(t, func(tt *assert.CollectT) {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 		defer cancel()
 
 		_, err := hzClient.HZ(ctx, connect.NewRequest(&adminapiv1.HZRequest{}))

--- a/internal/apikeys/service_test.go
+++ b/internal/apikeys/service_test.go
@@ -1,7 +1,6 @@
 package apikeys_test
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -15,7 +14,7 @@ const testDomain = "test.example.com"
 
 func TestService_CreateKey(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := t.Context()
 		repo := apikeyshelpers.NewInMemoryRepository()
 		service := apikeys.NewService(repo)
 
@@ -34,7 +33,7 @@ func TestService_CreateKey(t *testing.T) {
 	})
 
 	t.Run("WithExpiration", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := t.Context()
 		repo := apikeyshelpers.NewInMemoryRepository()
 		service := apikeys.NewService(repo)
 
@@ -48,7 +47,7 @@ func TestService_CreateKey(t *testing.T) {
 	})
 
 	t.Run("InvalidDomain", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := t.Context()
 		repo := apikeyshelpers.NewInMemoryRepository()
 		service := apikeys.NewService(repo)
 
@@ -57,7 +56,7 @@ func TestService_CreateKey(t *testing.T) {
 	})
 
 	t.Run("InvalidName", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := t.Context()
 		repo := apikeyshelpers.NewInMemoryRepository()
 		service := apikeys.NewService(repo)
 
@@ -68,7 +67,7 @@ func TestService_CreateKey(t *testing.T) {
 
 func TestService_GetKey(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := t.Context()
 		repo := apikeyshelpers.NewInMemoryRepository()
 		service := apikeys.NewService(repo)
 
@@ -85,7 +84,7 @@ func TestService_GetKey(t *testing.T) {
 	})
 
 	t.Run("NotFound", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := t.Context()
 		repo := apikeyshelpers.NewInMemoryRepository()
 		service := apikeys.NewService(repo)
 
@@ -101,7 +100,7 @@ func TestService_GetKey(t *testing.T) {
 
 func TestService_ListKeys(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := t.Context()
 		repo := apikeyshelpers.NewInMemoryRepository()
 		service := apikeys.NewService(repo)
 
@@ -120,7 +119,7 @@ func TestService_ListKeys(t *testing.T) {
 	})
 
 	t.Run("WithActiveFilter", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := t.Context()
 		repo := apikeyshelpers.NewInMemoryRepository()
 		service := apikeys.NewService(repo)
 
@@ -157,7 +156,7 @@ func TestService_ListKeys(t *testing.T) {
 	})
 
 	t.Run("WithPagination", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := t.Context()
 		repo := apikeyshelpers.NewInMemoryRepository()
 		service := apikeys.NewService(repo)
 
@@ -189,7 +188,7 @@ func TestService_ListKeys(t *testing.T) {
 	})
 
 	t.Run("InvalidDomain", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := t.Context()
 		repo := apikeyshelpers.NewInMemoryRepository()
 		service := apikeys.NewService(repo)
 
@@ -200,7 +199,7 @@ func TestService_ListKeys(t *testing.T) {
 
 func TestService_DeactivateKey(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := t.Context()
 		repo := apikeyshelpers.NewInMemoryRepository()
 		service := apikeys.NewService(repo)
 
@@ -223,7 +222,7 @@ func TestService_DeactivateKey(t *testing.T) {
 	})
 
 	t.Run("NotFound", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := t.Context()
 		repo := apikeyshelpers.NewInMemoryRepository()
 		service := apikeys.NewService(repo)
 
@@ -239,7 +238,7 @@ func TestService_DeactivateKey(t *testing.T) {
 
 func TestService_ValidateForAuth(t *testing.T) {
 	t.Run("ValidKey", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := t.Context()
 		repo := apikeyshelpers.NewInMemoryRepository()
 		service := apikeys.NewService(repo)
 
@@ -254,7 +253,7 @@ func TestService_ValidateForAuth(t *testing.T) {
 	})
 
 	t.Run("InactiveKey", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := t.Context()
 		repo := apikeyshelpers.NewInMemoryRepository()
 		service := apikeys.NewService(repo)
 
@@ -272,7 +271,7 @@ func TestService_ValidateForAuth(t *testing.T) {
 	})
 
 	t.Run("ExpiredKey", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := t.Context()
 		repo := apikeyshelpers.NewInMemoryRepository()
 		service := apikeys.NewService(repo)
 
@@ -313,7 +312,7 @@ func TestService_ValidateForAuth(t *testing.T) {
 	})
 
 	t.Run("NonExistentKey", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := t.Context()
 		repo := apikeyshelpers.NewInMemoryRepository()
 		service := apikeys.NewService(repo)
 
@@ -325,7 +324,7 @@ func TestService_ValidateForAuth(t *testing.T) {
 	})
 
 	t.Run("InvalidKeyFormat", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := t.Context()
 		repo := apikeyshelpers.NewInMemoryRepository()
 		service := apikeys.NewService(repo)
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1,7 +1,6 @@
 package sqlc
 
 import (
-	"context"
 	"fmt"
 	"log/slog"
 	"os"
@@ -43,7 +42,7 @@ func TestMain(m *testing.M) {
 
 func TestDomains(t *testing.T) {
 	// when user create a domain
-	domain, err := q.CreateDomain(context.Background(), CreateDomainParams{
+	domain, err := q.CreateDomain(t.Context(), CreateDomainParams{
 		Domain:         "test@test.com",
 		DkimPrivateKey: "test",
 		DkimPublicKey:  "test",
@@ -52,17 +51,17 @@ func TestDomains(t *testing.T) {
 	assert.Equal(t, domain.Domain, "test@test.com")
 
 	// can list all domains present
-	domains, err := q.GetDomains(context.Background())
+	domains, err := q.GetDomains(t.Context())
 	assert.Nil(t, err)
 	assert.Equal(t, len(domains), 1)
 
 	// can search a domain for domain
-	d, err := q.FindDomain(context.Background(), "test@test.com")
+	d, err := q.FindDomain(t.Context(), "test@test.com")
 	assert.Nil(t, err)
 	assert.Equal(t, d.ID, domain.ID)
 
 	// cleanup
-	_, err = db.Exec(context.Background(), "DELETE FROM domains")
+	_, err = db.Exec(t.Context(), "DELETE FROM domains")
 	assert.Nil(t, err)
 }
 
@@ -78,7 +77,7 @@ func TestHashKeyMatchesPostgres(t *testing.T) {
 			goHash := apikeys.HashKey(input)
 
 			var pgHash string
-			err := db.QueryRow(context.Background(),
+			err := db.QueryRow(t.Context(),
 				"SELECT encode(digest($1, 'sha256'), 'hex')", input,
 			).Scan(&pgHash)
 			require.NoError(t, err)
@@ -89,7 +88,7 @@ func TestHashKeyMatchesPostgres(t *testing.T) {
 }
 
 func TestTemplates(t *testing.T) {
-	domain, err := q.CreateDomain(context.Background(), CreateDomainParams{
+	domain, err := q.CreateDomain(t.Context(), CreateDomainParams{
 		Domain:         "test@test.com",
 		DkimPrivateKey: "test",
 		DkimPublicKey:  "test",
@@ -97,7 +96,7 @@ func TestTemplates(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, domain.Domain, "test@test.com")
 
-	template, err := q.CreateTemplate(context.Background(), CreateTemplateParams{
+	template, err := q.CreateTemplate(t.Context(), CreateTemplateParams{
 		TemplateID: "template id",
 		Html:       "template",
 		Domain:     domain.Domain,
@@ -106,7 +105,7 @@ func TestTemplates(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, template.Html, "template")
 
-	tmp, err := q.FindTemplate(context.Background(), FindTemplateParams{
+	tmp, err := q.FindTemplate(t.Context(), FindTemplateParams{
 		TemplateID: "template id",
 		Domain:     domain.Domain,
 	})
@@ -114,8 +113,8 @@ func TestTemplates(t *testing.T) {
 	assert.Equal(t, template, tmp)
 
 	// cleanup
-	_, err = db.Exec(context.Background(), "DELETE FROM templates")
+	_, err = db.Exec(t.Context(), "DELETE FROM templates")
 	assert.Nil(t, err)
-	_, err = db.Exec(context.Background(), "DELETE FROM domains")
+	_, err = db.Exec(t.Context(), "DELETE FROM domains")
 	assert.Nil(t, err)
 }

--- a/internal/db/delivery_repo_bench_test.go
+++ b/internal/db/delivery_repo_bench_test.go
@@ -1,7 +1,6 @@
 package sqlc
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -32,7 +31,7 @@ func buildDeliveries(b *testing.B, batchID batch.ID, domain string, n, iter int)
 
 func BenchmarkScheduleMany(b *testing.B) {
 	repo := NewDeliveryRepository(db, delivery.DefaultBackoff)
-	ctx := context.Background()
+	ctx := b.Context()
 
 	for _, n := range []int{10, 100, 1000, 10_000} {
 		b.Run(fmt.Sprintf("N=%d", n), func(b *testing.B) {

--- a/internal/db/domains_repo_test.go
+++ b/internal/db/domains_repo_test.go
@@ -13,7 +13,7 @@ func TestDomainsRepository(t *testing.T) {
 		//nolint:errcheck // best-effort test cleanup
 		db.Exec(context.Background(), "DELETE FROM domains CASCADE")
 	})
-	_, err := db.Exec(context.Background(), "DELETE FROM domains CASCADE")
+	_, err := db.Exec(t.Context(), "DELETE FROM domains CASCADE")
 	require.NoError(t, err)
 
 	repo := NewDomainsRepository(db)

--- a/internal/db/pool_helper_test.go
+++ b/internal/db/pool_helper_test.go
@@ -1,7 +1,6 @@
 package sqlc
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -16,7 +15,7 @@ import (
 // and benchmarks for the delivery / pool packages.
 func seedBatchFixture(tb testing.TB) (batch.ID, string) {
 	tb.Helper()
-	ctx := context.Background()
+	ctx := tb.Context()
 	domainName := fmt.Sprintf("test-pool-%d.com", time.Now().UnixNano())
 	_, err := q.CreateDomain(ctx, CreateDomainParams{
 		Domain:         domainName,
@@ -48,7 +47,7 @@ func seedBatchFixture(tb testing.TB) (batch.ID, string) {
 	require.NoError(tb, err)
 
 	tb.Cleanup(func() {
-		cleanupCtx := context.Background()
+		cleanupCtx := tb.Context()
 		//nolint:errcheck // best-effort test cleanup
 		db.Exec(cleanupCtx, "DELETE FROM sending_pool_emails WHERE domain = $1", domainName)
 		//nolint:errcheck // best-effort test cleanup

--- a/internal/db/statistics_test.go
+++ b/internal/db/statistics_test.go
@@ -1,7 +1,6 @@
 package sqlc
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -11,7 +10,7 @@ import (
 )
 
 func TestReadAndWriteStats(t *testing.T) {
-	err := q.InsertStat(context.Background(), InsertStatParams{
+	err := q.InsertStat(t.Context(), InsertStatParams{
 		Email:     "test@test.com",
 		MessageID: "123",
 		Type:      StatsTypeAccepted,
@@ -26,7 +25,7 @@ func TestReadAndWriteStats(t *testing.T) {
 
 	require.Nil(t, err)
 
-	stats, err := q.QueryStats(context.Background(), QueryStatsParams{
+	stats, err := q.QueryStats(t.Context(), QueryStatsParams{
 		Domain: "test.com",
 		Start:  pgtype.Timestamp{Time: time.Now().Add(-1 * time.Hour), Valid: true},
 		Stop:   pgtype.Timestamp{Time: time.Now().Add(1 * time.Hour), Valid: true},

--- a/internal/envelope/builder_test.go
+++ b/internal/envelope/builder_test.go
@@ -72,7 +72,7 @@ func TestBuilderRendersSubjectFromAndTo(t *testing.T) {
 	b := envelope.NewBuilderWith(src, stubTokens{link: "ltok", open: "otok"})
 
 	d := mustDelivery(t, batch.ID("msg-1@test.com"), "rcpt@example.com", map[string]string{"name": "World"})
-	env, err := b.Build(context.Background(), d)
+	env, err := b.Build(t.Context(), d)
 	assert.Nil(t, err)
 
 	assert.Equal(t, "rcpt@example.com", env.To())
@@ -100,7 +100,7 @@ func TestBuilderInsertsTrackingPixelAndRewritesLinks(t *testing.T) {
 	b := envelope.NewBuilderWith(src, stubTokens{link: "LTOK", open: "OTOK"})
 
 	d := mustDelivery(t, batch.ID("msg-1@test.com"), "rcpt@example.com", nil)
-	env, err := b.Build(context.Background(), d)
+	env, err := b.Build(t.Context(), d)
 	assert.Nil(t, err)
 
 	parsed, err := mail.ReadMessage(bytes.NewReader(env.Body()))
@@ -141,7 +141,7 @@ func TestBuilderShouldRetryFalseAfterMaxAttempts(t *testing.T) {
 		SendAttempts: 10,
 		Backoff:      delivery.DefaultBackoff,
 	})
-	env, err := b.Build(context.Background(), d)
+	env, err := b.Build(t.Context(), d)
 	assert.Nil(t, err)
 	assert.False(t, env.ShouldRetry())
 }

--- a/internal/envelope/envelope_integration_test.go
+++ b/internal/envelope/envelope_integration_test.go
@@ -2,7 +2,6 @@ package envelope_test
 
 import (
 	"bytes"
-	"context"
 	"encoding/base64"
 	"io"
 	"log/slog"
@@ -68,12 +67,12 @@ func TestMain(m *testing.M) {
 }
 
 func TestPrepareMail(t *testing.T) {
-	d, err := adminAPI.CreateDomain(context.Background(), connect.NewRequest(&adminapiv1.CreateDomainRequest{
+	d, err := adminAPI.CreateDomain(t.Context(), connect.NewRequest(&adminapiv1.CreateDomainRequest{
 		Domain: "test.com",
 	}))
 	assert.Nil(t, err)
 
-	keyRes, err := adminAPI.CreateAPIKey(context.Background(), connect.NewRequest(&adminapiv1.CreateAPIKeyRequest{
+	keyRes, err := adminAPI.CreateAPIKey(t.Context(), connect.NewRequest(&adminapiv1.CreateAPIKeyRequest{
 		Domain: d.Msg.Domain,
 		Name:   "test-key",
 	}))
@@ -90,13 +89,13 @@ func TestPrepareMail(t *testing.T) {
 	})
 	authRequest(req, d.Msg, keyRes.Msg.Key)
 
-	res, err := ma.SendHTML(context.Background(), req)
+	res, err := ma.SendHTML(t.Context(), req)
 	assert.Nil(t, err)
 
 	emails := markValidatedAndClaim(t, batch.ID(res.Msg.MessageId), "test@emailtest.com")
 	assert.Equal(t, 1, len(emails))
 
-	env, err := eb.Build(context.Background(), emails[0])
+	env, err := eb.Build(t.Context(), emails[0])
 	assert.Nil(t, err)
 	parsed, err := mail.ReadMessage(bytes.NewReader(env.Body()))
 	assert.Nil(t, err)
@@ -121,17 +120,17 @@ func TestPrepareMailNoAccess(t *testing.T) {
 		},
 	})
 
-	_, err := ma.SendHTML(context.Background(), req)
+	_, err := ma.SendHTML(t.Context(), req)
 	assert.NotNil(t, err)
 }
 
 func TestPrepareMailWithAttachments(t *testing.T) {
-	d, err := adminAPI.CreateDomain(context.Background(), connect.NewRequest(&adminapiv1.CreateDomainRequest{
+	d, err := adminAPI.CreateDomain(t.Context(), connect.NewRequest(&adminapiv1.CreateDomainRequest{
 		Domain: "test2.com",
 	}))
 	assert.Nil(t, err)
 
-	keyRes, err := adminAPI.CreateAPIKey(context.Background(), connect.NewRequest(&adminapiv1.CreateAPIKeyRequest{
+	keyRes, err := adminAPI.CreateAPIKey(t.Context(), connect.NewRequest(&adminapiv1.CreateAPIKeyRequest{
 		Domain: d.Msg.Domain,
 		Name:   "test-key",
 	}))
@@ -151,13 +150,13 @@ func TestPrepareMailWithAttachments(t *testing.T) {
 	})
 	authRequest(req, d.Msg, keyRes.Msg.Key)
 
-	res, err := ma.SendHTML(context.Background(), req)
+	res, err := ma.SendHTML(t.Context(), req)
 	assert.Nil(t, err)
 
 	emails := markValidatedAndClaim(t, batch.ID(res.Msg.MessageId), "test@emailtest.com")
 	assert.Equal(t, 1, len(emails))
 
-	env, err := eb.Build(context.Background(), emails[0])
+	env, err := eb.Build(t.Context(), emails[0])
 	assert.Nil(t, err)
 	parsed, err := mail.ReadMessage(bytes.NewReader(env.Body()))
 	assert.Nil(t, err)
@@ -168,12 +167,12 @@ func TestPrepareMailWithAttachments(t *testing.T) {
 }
 
 func TestPrepareMailWithHeaders(t *testing.T) {
-	d, err := adminAPI.CreateDomain(context.Background(), connect.NewRequest(&adminapiv1.CreateDomainRequest{
+	d, err := adminAPI.CreateDomain(t.Context(), connect.NewRequest(&adminapiv1.CreateDomainRequest{
 		Domain: "test-ch.com",
 	}))
 	assert.Nil(t, err)
 
-	keyRes, err := adminAPI.CreateAPIKey(context.Background(), connect.NewRequest(&adminapiv1.CreateAPIKeyRequest{
+	keyRes, err := adminAPI.CreateAPIKey(t.Context(), connect.NewRequest(&adminapiv1.CreateAPIKeyRequest{
 		Domain: d.Msg.Domain,
 		Name:   "test-key-ch",
 	}))
@@ -194,13 +193,13 @@ func TestPrepareMailWithHeaders(t *testing.T) {
 	})
 	authRequest(req, d.Msg, keyRes.Msg.Key)
 
-	res, err := ma.SendHTML(context.Background(), req)
+	res, err := ma.SendHTML(t.Context(), req)
 	assert.Nil(t, err)
 
 	emails := markValidatedAndClaim(t, batch.ID(res.Msg.MessageId), "actual-recipient@emailtest.com")
 	assert.Equal(t, 1, len(emails))
 
-	env, err := eb.Build(context.Background(), emails[0])
+	env, err := eb.Build(t.Context(), emails[0])
 	assert.Nil(t, err)
 
 	assert.Equal(t, "actual-recipient@emailtest.com", env.To())
@@ -214,7 +213,7 @@ func TestPrepareMailWithHeaders(t *testing.T) {
 
 func markValidatedAndClaim(t *testing.T, batchID batch.ID, email string) []*delivery.Delivery {
 	t.Helper()
-	ctx := context.Background()
+	ctx := t.Context()
 	dlv, err := claimer.Lookup(ctx, batchID, email)
 	assert.Nil(t, err)
 	err = claimer.MarkValidated(ctx, dlv)

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -19,7 +19,7 @@ func (t *testLooper) Loop(ctx context.Context) error {
 }
 
 func TestMaxLoops(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	l := &testLooper{}
 	err := runner.Run(ctx, l.Loop, runner.MaxLoop(1))
 	assert.Nil(t, err)
@@ -27,7 +27,7 @@ func TestMaxLoops(t *testing.T) {
 }
 
 func TestMaxLoops10(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	l := &testLooper{}
 	err := runner.Run(ctx, l.Loop, runner.MaxLoop(10))
 	assert.Nil(t, err)
@@ -35,7 +35,7 @@ func TestMaxLoops10(t *testing.T) {
 }
 
 func TestRunWithoutMaxLoopShouldEndWithErrContextExpired(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
+	ctx, cancel := context.WithTimeout(t.Context(), 1*time.Millisecond)
 	defer cancel()
 
 	l := &testLooper{}
@@ -45,7 +45,7 @@ func TestRunWithoutMaxLoopShouldEndWithErrContextExpired(t *testing.T) {
 }
 
 func TestWithLoopWaitBig(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
+	ctx, cancel := context.WithTimeout(t.Context(), 1*time.Millisecond)
 	defer cancel()
 
 	l := &testLooper{}
@@ -55,7 +55,7 @@ func TestWithLoopWaitBig(t *testing.T) {
 }
 
 func TestWithLoopWaitSmall(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Microsecond)
+	ctx, cancel := context.WithTimeout(t.Context(), 1*time.Microsecond)
 	defer cancel()
 
 	l := &testLooper{}

--- a/internal/stats/service_test.go
+++ b/internal/stats/service_test.go
@@ -1,7 +1,6 @@
 package stats_test
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -20,7 +19,7 @@ func newTestServiceWithAggregated() *stats.Service {
 
 func TestInsertAndQueryStats(t *testing.T) {
 	svc := newTestService()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	now := time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC)
 	tr := stats.TimeRange{Start: now.Add(-time.Hour), Stop: now.Add(time.Hour)}
@@ -54,7 +53,7 @@ func TestInsertAndQueryStats(t *testing.T) {
 
 func TestQueryStats_Pagination(t *testing.T) {
 	svc := newTestService()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	base := time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC)
 	tr := stats.TimeRange{Start: base.Add(-time.Hour), Stop: base.Add(time.Hour)}
@@ -90,7 +89,7 @@ func TestQueryStats_Pagination(t *testing.T) {
 
 func TestQueryStats_FiltersByDomain(t *testing.T) {
 	svc := newTestService()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	now := time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC)
 	tr := stats.TimeRange{Start: now.Add(-time.Hour), Stop: now.Add(time.Hour)}
@@ -118,7 +117,7 @@ func TestQueryStats_FiltersByDomain(t *testing.T) {
 
 func TestQueryStats_FiltersByTimeRange(t *testing.T) {
 	svc := newTestService()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	base := time.Date(2026, 1, 15, 12, 0, 0, 0, time.UTC)
 	tr := stats.TimeRange{Start: base, Stop: base.Add(2 * time.Hour)}
@@ -150,7 +149,7 @@ func TestQueryStats_FiltersByTimeRange(t *testing.T) {
 
 func TestQueryTimeline(t *testing.T) {
 	svc := newTestService()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	base := time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC)
 	tr := stats.TimeRange{Start: base, Stop: base.Add(3 * time.Hour)}
@@ -190,7 +189,7 @@ func TestQueryTimeline(t *testing.T) {
 
 func TestCleanup(t *testing.T) {
 	svc := newTestService()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	now := time.Now().UTC()
 	old := now.Add(-48 * time.Hour)
@@ -251,7 +250,7 @@ func TestDetermineType(t *testing.T) {
 
 func TestIncrementAggregatedStat(t *testing.T) {
 	svc := newTestServiceWithAggregated()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	ts := time.Date(2026, 1, 15, 14, 30, 0, 0, time.UTC)
 
@@ -284,7 +283,7 @@ func TestIncrementAggregatedStat(t *testing.T) {
 
 func TestIncrementAggregatedStat_SeparateEntries(t *testing.T) {
 	svc := newTestServiceWithAggregated()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	day1 := time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC)
 	day2 := time.Date(2026, 1, 16, 14, 0, 0, 0, time.UTC)
@@ -316,7 +315,7 @@ func TestIncrementAggregatedStat_SeparateEntries(t *testing.T) {
 
 func TestQueryAggregatedStats_FiltersByDomainAndTimeRange(t *testing.T) {
 	svc := newTestServiceWithAggregated()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	ts := time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC)
 

--- a/internal/statssec/statssec_test.go
+++ b/internal/statssec/statssec_test.go
@@ -1,7 +1,6 @@
 package statssec_test
 
 import (
-	"context"
 	"log/slog"
 	"os"
 	"testing"
@@ -44,12 +43,12 @@ func TestMain(m *testing.M) {
 
 func TestCreateOpenToken(t *testing.T) {
 	// when user create a domain
-	token, err := s.CreateOpenToken(context.Background(), "<xxxx/test@test.com>", "test@test.com")
+	token, err := s.CreateOpenToken(t.Context(), "<xxxx/test@test.com>", "test@test.com")
 	assert.Nil(t, err)
 
 	assert.NotEmpty(t, token)
 
-	c, err := s.VerifyOpenToken(context.Background(), token)
+	c, err := s.VerifyOpenToken(t.Context(), token)
 	assert.Nil(t, err)
 
 	assert.Equal(t, "<xxxx/test@test.com>", c.MessageID)
@@ -58,12 +57,12 @@ func TestCreateOpenToken(t *testing.T) {
 
 func TestCreateLinkToken(t *testing.T) {
 	// when user create a domain
-	token, err := s.CreateLinkToken(context.Background(), "<xxxx/test@test.com>", "test@test.com", "https://test.com")
+	token, err := s.CreateLinkToken(t.Context(), "<xxxx/test@test.com>", "test@test.com", "https://test.com")
 	assert.Nil(t, err)
 
 	assert.NotEmpty(t, token)
 
-	c, err := s.VerifyLinkToken(context.Background(), token)
+	c, err := s.VerifyLinkToken(t.Context(), token)
 	assert.Nil(t, err)
 
 	assert.Equal(t, "<xxxx/test@test.com>", c.MessageID)

--- a/pkg/api/adminapi/adminapi_test.go
+++ b/pkg/api/adminapi/adminapi_test.go
@@ -1,7 +1,6 @@
 package adminapi_test
 
 import (
-	"context"
 	"log/slog"
 	"os"
 	"testing"
@@ -43,7 +42,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestEmptyDatabase(t *testing.T) {
-	res, err := testservice.GetDomains(context.Background(), connect.NewRequest(&pb.GetDomainsReq{}))
+	res, err := testservice.GetDomains(t.Context(), connect.NewRequest(&pb.GetDomainsReq{}))
 	assert.Nil(t, err)
 	assert.Empty(t, len(res.Msg.Domains))
 }
@@ -56,7 +55,7 @@ func TestCreateANewDomain(t *testing.T) {
 	// When I create a domain
 	t.Run("When I create a domain", func(t *testing.T) {
 		var err error
-		res, err := testservice.CreateDomain(context.Background(), connect.NewRequest(&pb.CreateDomainRequest{
+		res, err := testservice.CreateDomain(t.Context(), connect.NewRequest(&pb.CreateDomainRequest{
 			Domain: newDomain,
 		}))
 		domain = res.Msg
@@ -66,13 +65,13 @@ func TestCreateANewDomain(t *testing.T) {
 	})
 
 	t.Run("I Should find 1 domain in the datastore", func(t *testing.T) {
-		resGetDomains, err := testservice.GetDomains(context.Background(), connect.NewRequest(&pb.GetDomainsReq{}))
+		resGetDomains, err := testservice.GetDomains(t.Context(), connect.NewRequest(&pb.GetDomainsReq{}))
 		assert.Nil(t, err)
 		assert.Equal(t, 1, len(resGetDomains.Msg.Domains))
 	})
 
 	t.Run("I Should query the created domain", func(t *testing.T) {
-		resGetDomain, err := testservice.GetDomain(context.Background(), connect.NewRequest(&pb.GetDomainReq{
+		resGetDomain, err := testservice.GetDomain(t.Context(), connect.NewRequest(&pb.GetDomainReq{
 			Domain: newDomain,
 		}))
 		assert.Nil(t, err)
@@ -84,7 +83,7 @@ func TestCreateANewDomain(t *testing.T) {
 
 func createTestDomain(t *testing.T) *pb.Domain {
 	domain := tests.FakeDomain(t)
-	res, err := testservice.CreateDomain(context.Background(), connect.NewRequest(&pb.CreateDomainRequest{
+	res, err := testservice.CreateDomain(t.Context(), connect.NewRequest(&pb.CreateDomainRequest{
 		Domain: domain,
 	}))
 	assert.Nil(t, err)
@@ -92,12 +91,12 @@ func createTestDomain(t *testing.T) *pb.Domain {
 }
 
 func cleanDB(t *testing.T) {
-	_, err := db.Exec(context.Background(), "DELETE FROM domains")
+	_, err := db.Exec(t.Context(), "DELETE FROM domains")
 	assert.Nil(t, err)
 
-	_, err = db.Exec(context.Background(), "DELETE FROM sending_pool_emails")
+	_, err = db.Exec(t.Context(), "DELETE FROM sending_pool_emails")
 	assert.Nil(t, err)
 
-	_, err = db.Exec(context.Background(), "DELETE FROM templates")
+	_, err = db.Exec(t.Context(), "DELETE FROM templates")
 	assert.Nil(t, err)
 }

--- a/pkg/api/adminapi/templates_test.go
+++ b/pkg/api/adminapi/templates_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestCreateTemplate(t *testing.T) {
 	d := createTestDomain(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	res, err := testservice.CreateTemplate(ctx, connect.NewRequest(&pb.CreateTemplateReq{
 		Html:   "Hello {{ name }}",
@@ -27,7 +27,7 @@ func TestCreateTemplate(t *testing.T) {
 
 func TestGetTemplate(t *testing.T) {
 	d := createTestDomain(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	t1 := createTemplate(t, ctx, d, "Hello {{ name }}")
 
@@ -41,7 +41,7 @@ func TestGetTemplate(t *testing.T) {
 
 func TestDeleteTemplate(t *testing.T) {
 	d := createTestDomain(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	t1 := createTemplate(t, ctx, d, "Hello {{ name }}")
 
@@ -63,7 +63,7 @@ func TestDeleteTemplate(t *testing.T) {
 
 func TestGetTemplates(t *testing.T) {
 	d := createTestDomain(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	t1 := createTemplate(t, ctx, d, "Hello {{ name }}")
 	t2 := createTemplate(t, ctx, d, "Hello 2 {{ name }}")
@@ -84,7 +84,7 @@ func TestGetTemplates(t *testing.T) {
 
 func TestUpdateTemplates(t *testing.T) {
 	d := createTestDomain(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	t1 := createTemplate(t, ctx, d, "Hello {{ name }}")
 

--- a/pkg/api/mailapi/base_test.go
+++ b/pkg/api/mailapi/base_test.go
@@ -1,7 +1,6 @@
 package mailapi_test
 
 import (
-	"context"
 	"encoding/base64"
 	"log/slog"
 	"os"
@@ -58,13 +57,13 @@ func createTestDomain(t *testing.T) *tests.DomainWithKey {
 
 func cleanDB(t *testing.T) {
 	t.Helper()
-	_, err := db.Exec(context.Background(), "DELETE FROM domains")
+	_, err := db.Exec(t.Context(), "DELETE FROM domains")
 	assert.Nil(t, err)
 
-	_, err = db.Exec(context.Background(), "DELETE FROM sending_pool_emails")
+	_, err = db.Exec(t.Context(), "DELETE FROM sending_pool_emails")
 	assert.Nil(t, err)
 
-	_, err = db.Exec(context.Background(), "DELETE FROM templates")
+	_, err = db.Exec(t.Context(), "DELETE FROM templates")
 	assert.Nil(t, err)
 }
 

--- a/pkg/api/mailapi/mailer_test.go
+++ b/pkg/api/mailapi/mailer_test.go
@@ -1,7 +1,6 @@
 package mailapi_test
 
 import (
-	"context"
 	"strings"
 	"testing"
 	"time"
@@ -41,7 +40,7 @@ func TestInsertMail(t *testing.T) {
 
 	authRequest(req, d)
 
-	res, err := ts.SendHTML(context.Background(), req)
+	res, err := ts.SendHTML(t.Context(), req)
 
 	assert.Nil(t, err)
 	assert.NotEmpty(t, res.Msg.MessageId)
@@ -49,7 +48,7 @@ func TestInsertMail(t *testing.T) {
 	assert.True(t, strings.HasSuffix(res.Msg.MessageId, "@"+d.Domain.Domain))
 	assert.True(t, strings.HasSuffix(res.Msg.TemplateId, "@"+d.Domain.Domain))
 
-	sp, err := q.GetSendingPoolsEmails(context.Background(), sqlc.GetSendingPoolsEmailsParams{
+	sp, err := q.GetSendingPoolsEmails(t.Context(), sqlc.GetSendingPoolsEmailsParams{
 		MessageID: res.Msg.MessageId,
 		Limit:     100,
 		Offset:    0,
@@ -113,7 +112,7 @@ func TestSendMailWithInvalidHeaders(t *testing.T) {
 			})
 			authRequest(req, d)
 
-			_, err := ts.SendHTML(context.Background(), req)
+			_, err := ts.SendHTML(t.Context(), req)
 			assert.NotNil(t, err)
 			assert.Contains(t, err.Error(), tc.errMsg)
 			assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
@@ -145,12 +144,12 @@ func TestSendMailSkipsRecipientsWithEmptyEmail(t *testing.T) {
 	})
 	authRequest(req, d)
 
-	res, err := ts.SendHTML(context.Background(), req)
+	res, err := ts.SendHTML(t.Context(), req)
 
 	assert.Nil(t, err)
 	assert.NotEmpty(t, res.Msg.MessageId)
 
-	sp, err := q.GetSendingPoolsEmails(context.Background(), sqlc.GetSendingPoolsEmailsParams{
+	sp, err := q.GetSendingPoolsEmails(t.Context(), sqlc.GetSendingPoolsEmailsParams{
 		MessageID: res.Msg.MessageId,
 		Limit:     100,
 		Offset:    0,
@@ -182,12 +181,12 @@ func TestSendMailWithAllEmptyRecipientsSucceedsWithEmptyPool(t *testing.T) {
 	})
 	authRequest(req, d)
 
-	res, err := ts.SendHTML(context.Background(), req)
+	res, err := ts.SendHTML(t.Context(), req)
 
 	assert.Nil(t, err)
 	assert.NotEmpty(t, res.Msg.MessageId)
 
-	sp, err := q.GetSendingPoolsEmails(context.Background(), sqlc.GetSendingPoolsEmailsParams{
+	sp, err := q.GetSendingPoolsEmails(t.Context(), sqlc.GetSendingPoolsEmailsParams{
 		MessageID: res.Msg.MessageId,
 		Limit:     100,
 		Offset:    0,
@@ -217,13 +216,13 @@ func TestSendMailWithGlobalFields(t *testing.T) {
 	})
 	authRequest(req, d)
 
-	res, err := ts.SendHTML(context.Background(), req)
+	res, err := ts.SendHTML(t.Context(), req)
 
 	assert.Nil(t, err)
 	assert.NotEmpty(t, res.Msg.MessageId)
 	assert.NotEmpty(t, res.Msg.TemplateId)
 
-	template, err := q.GetTemplate(context.Background(), res.Msg.TemplateId)
+	template, err := q.GetTemplate(t.Context(), res.Msg.TemplateId)
 	assert.NoError(t, err)
 	assert.Equal(t, "Hello Global", template.Html)
 }
@@ -235,7 +234,7 @@ func TestSendTemplateWithGlobalFields(t *testing.T) {
 
 	schedTime := time.Now().Add(10 * time.Minute).Truncate(1 * time.Second)
 
-	tmp, err := q.CreateTemplate(context.Background(), sqlc.CreateTemplateParams{
+	tmp, err := q.CreateTemplate(t.Context(), sqlc.CreateTemplateParams{
 		Html:       "Hello {{ name }}",
 		TemplateID: "test-template",
 		Title:      "Test",
@@ -258,13 +257,13 @@ func TestSendTemplateWithGlobalFields(t *testing.T) {
 	})
 	authRequest(req, d)
 
-	res, err := ts.SendTemplate(context.Background(), req)
+	res, err := ts.SendTemplate(t.Context(), req)
 
 	assert.Nil(t, err)
 	assert.NotEmpty(t, res.Msg.MessageId)
 	assert.NotEmpty(t, res.Msg.TemplateId)
 
-	template, err := q.GetTemplate(context.Background(), res.Msg.TemplateId)
+	template, err := q.GetTemplate(t.Context(), res.Msg.TemplateId)
 	assert.NoError(t, err)
 	assert.NotEqual(t, tmp.ID, template.ID)
 	assert.Equal(t, "Hello Global", template.Html)

--- a/pkg/stats/cleanup_test.go
+++ b/pkg/stats/cleanup_test.go
@@ -1,7 +1,6 @@
 package stats
 
 import (
-	"context"
 	"log/slog"
 	"os"
 	"testing"
@@ -59,7 +58,7 @@ func newTestHandler() statsHandler {
 func TestCleanupCycle_DeletesOldStats(t *testing.T) {
 	cleanDB(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Insert an old stat (2 years ago)
 	oldTime := time.Now().Add(-2 * 365 * 24 * time.Hour)
@@ -103,7 +102,7 @@ func TestCleanupCycle_DeletesOldStats(t *testing.T) {
 func TestCleanupCycle_KeepsRecentStats(t *testing.T) {
 	cleanDB(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Insert two recent stats
 	for _, email := range []string{"a@test.com", "b@test.com"} {
@@ -135,7 +134,7 @@ func TestCleanupCycle_KeepsRecentStats(t *testing.T) {
 func TestCleanupCycle_DeletesExpiredStatsKeys(t *testing.T) {
 	cleanDB(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Insert an expired key
 	_, err := q.CreateStatsKeys(ctx, sq.CreateStatsKeysParams{
@@ -182,7 +181,7 @@ func TestCleanupCycle_DeletesExpiredStatsKeys(t *testing.T) {
 func TestCleanupCycle_NoRowsToDelete(t *testing.T) {
 	cleanDB(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	h := newTestHandler()
 
@@ -193,7 +192,7 @@ func TestCleanupCycle_NoRowsToDelete(t *testing.T) {
 
 func cleanDB(t *testing.T) {
 	t.Helper()
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := db.Exec(ctx, "DELETE FROM stats")
 	require.NoError(t, err)
 	_, err = db.Exec(ctx, "DELETE FROM stats_keys")

--- a/pkg/validator/validator_test.go
+++ b/pkg/validator/validator_test.go
@@ -1,7 +1,6 @@
 package validator_test
 
 import (
-	"context"
 	"encoding/base64"
 	"log/slog"
 	"os"
@@ -64,7 +63,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestLoop(t *testing.T) {
-	err := runner.Run(context.Background(), vt.Cycle, runner.MaxLoop(1))
+	err := runner.Run(t.Context(), vt.Cycle, runner.MaxLoop(1))
 	assert.Nil(t, err)
 }
 
@@ -82,7 +81,6 @@ func TestValidEmail(t *testing.T) {
 
 	t.Cleanup(func() {
 		mp.subjects = nil
-		cleanDB(t)
 	})
 }
 
@@ -98,13 +96,12 @@ func TestInvalidEmail(t *testing.T) {
 
 	t.Cleanup(func() {
 		mp.subjects = nil
-		cleanDB(t)
 	})
 }
 
 func runOneCycle(t *testing.T) {
 	t.Helper()
-	err := runner.Run(context.Background(), vt.Cycle, runner.MaxLoop(1))
+	err := runner.Run(t.Context(), vt.Cycle, runner.MaxLoop(1))
 	assert.Nil(t, err)
 }
 
@@ -128,25 +125,13 @@ func sendEmail(t *testing.T, domainWithKey *tests.DomainWithKey, email string) {
 
 	authRequest(req, domainWithKey)
 
-	_, err := ts.SendHTML(context.Background(), req)
+	_, err := ts.SendHTML(t.Context(), req)
 	assert.Nil(t, err)
 }
 
 func createTestDomain(t *testing.T) *tests.DomainWithKey {
 	t.Helper()
 	return tests.CreateTestDomain(t, adminAPI)
-}
-
-func cleanDB(t *testing.T) {
-	t.Helper()
-	_, err := db.Exec(context.Background(), "DELETE FROM domains")
-	assert.Nil(t, err)
-
-	_, err = db.Exec(context.Background(), "DELETE FROM sending_pool_emails")
-	assert.Nil(t, err)
-
-	_, err = db.Exec(context.Background(), "DELETE FROM templates")
-	assert.Nil(t, err)
 }
 
 func authRequest[T any](req *connect.Request[T], d *tests.DomainWithKey) {

--- a/x/container/runnable_test.go
+++ b/x/container/runnable_test.go
@@ -23,7 +23,7 @@ func TestRegistry_RunInvokesAllAndShareCtx(t *testing.T) {
 	var reg Registry
 	var ranA, ranB atomic.Bool
 	type ctxKey struct{}
-	parent := context.WithValue(context.Background(), ctxKey{}, "shared")
+	parent := context.WithValue(t.Context(), ctxKey{}, "shared")
 	parent, cancel := context.WithCancel(parent)
 
 	reg.Register(Runnable{Name: "a", Run: func(ctx context.Context) error {
@@ -77,7 +77,7 @@ func TestRegistry_ErrorCancelsSibling(t *testing.T) {
 		return ctx.Err()
 	}})
 
-	err := reg.Run(context.Background())
+	err := reg.Run(t.Context())
 	if !errors.Is(err, boom) {
 		t.Errorf("expected boom, got %v", err)
 	}

--- a/x/container/singleton_test.go
+++ b/x/container/singleton_test.go
@@ -14,7 +14,7 @@ const (
 
 func TestSingleton_SuccessfulInitialization(t *testing.T) {
 	s := &singleton[string]{}
-	ctx := context.Background()
+	ctx := t.Context()
 
 	expected := testValue
 	initFunc := func(ctx context.Context) (string, error) {
@@ -34,7 +34,7 @@ func TestSingleton_SuccessfulInitialization(t *testing.T) {
 
 func TestSingleton_OnlyInitializedOnce(t *testing.T) {
 	s := &singleton[int]{}
-	ctx := context.Background()
+	ctx := t.Context()
 
 	callCount := 0
 	initFunc := func(ctx context.Context) (int, error) {
@@ -66,7 +66,7 @@ func TestSingleton_OnlyInitializedOnce(t *testing.T) {
 
 func TestSingleton_ConcurrentAccess(t *testing.T) {
 	s := &singleton[string]{}
-	ctx := context.Background()
+	ctx := t.Context()
 
 	callCount := 0
 	var mu sync.Mutex
@@ -113,7 +113,7 @@ func TestSingleton_StructType(t *testing.T) {
 	}
 
 	s := &singleton[testStruct]{}
-	ctx := context.Background()
+	ctx := t.Context()
 
 	expected := testStruct{Name: "test", ID: 42}
 	initFunc := func(ctx context.Context) (testStruct, error) {
@@ -134,7 +134,7 @@ func TestSingleton_PointerType(t *testing.T) {
 	}
 
 	s := &singleton[*testStruct]{}
-	ctx := context.Background()
+	ctx := t.Context()
 
 	expected := &testStruct{Name: "test", ID: 42}
 	initFunc := func(ctx context.Context) (*testStruct, error) {
@@ -172,7 +172,7 @@ func (ti *testImpl) GetValue() string {
 
 func TestSingleton_InterfaceType(t *testing.T) {
 	s := &singleton[testInterface]{}
-	ctx := context.Background()
+	ctx := t.Context()
 
 	expected := &testImpl{value: "test-interface"}
 	initFunc := func(ctx context.Context) (testInterface, error) {
@@ -196,7 +196,7 @@ const testKey contextKey = "key"
 
 func TestSingleton_ContextPassing(t *testing.T) {
 	s := &singleton[string]{}
-	ctx := context.WithValue(context.Background(), testKey, testValue)
+	ctx := context.WithValue(t.Context(), testKey, testValue)
 
 	var receivedCtx context.Context
 	initFunc := func(ctx context.Context) (string, error) {


### PR DESCRIPTION
## Summary
- Replace `context.Background()` / `context.TODO()` with `t.Context()` (or `b.Context()` for benchmarks) in 20 test files where a `*testing.T` / `*testing.B` is in scope. Tests now get a context that is automatically cancelled when the test ends.
- `t.Cleanup` callbacks intentionally keep `context.Background()` — `t.Context()` is cancelled *before* cleanup runs, so using it there would silently fail DB cleanup queries (which is exactly the bug that surfaced during this refactor and required reverting three cleanup blocks).
- `TestMain(m *testing.M)` left untouched (no `m.Context()`).

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/db/...` (the package whose cross-test ordering bug was caught and fixed)
- [ ] CI runs the full test suite