### PR TITLE
refactor: drop redundant loop variable copy in Registry.Run

### DIFF
--- a/x/container/runnable.go
+++ b/x/container/runnable.go
@@ -39,7 +39,6 @@ func (r *Registry) Names() []string {
 func (r *Registry) Run(ctx context.Context) error {
 	g, gctx := errgroup.WithContext(ctx)
 	for _, run := range r.runnables {
-		run := run
 		g.Go(func() error {
 			return run.Run(gctx)
 		})


### PR DESCRIPTION
## Summary
- Remove `run := run` shadow inside `Registry.Run`'s `for _, run := range r.runnables` loop.
- Since Go 1.22 loop variables are scoped per iteration, so capturing the loop variable in the goroutine closure no longer needs the manual copy. The module is on `go 1.26.2`.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./x/container/...`