### PR TITLE
fix(pool): race-safe claims with FOR UPDATE SKIP LOCKED

### DIFF
--- a/internal/db/pool.sql
+++ b/internal/db/pool.sql
@@ -4,6 +4,7 @@ UPDATE sending_pool_emails AS sp
     FROM (
             SELECT id FROM sending_pool_emails
             WHERE scheduled_time <= NOW() AND status = 'scheduled'
+            FOR UPDATE SKIP LOCKED
             LIMIT $1
         ) AS t
     WHERE sp.id = t.id
@@ -15,6 +16,7 @@ UPDATE sending_pool_emails AS sp
     FROM (
             SELECT id FROM sending_pool_emails
             WHERE status = 'to_validate'
+            FOR UPDATE SKIP LOCKED
             LIMIT $1
         ) AS t
     WHERE sp.id = t.id

--- a/internal/db/pool.sql.go
+++ b/internal/db/pool.sql.go
@@ -222,6 +222,7 @@ UPDATE sending_pool_emails AS sp
     FROM (
             SELECT id FROM sending_pool_emails
             WHERE scheduled_time <= NOW() AND status = 'scheduled'
+            FOR UPDATE SKIP LOCKED
             LIMIT $1
         ) AS t
     WHERE sp.id = t.id
@@ -265,6 +266,7 @@ UPDATE sending_pool_emails AS sp
     FROM (
             SELECT id FROM sending_pool_emails
             WHERE status = 'to_validate'
+            FOR UPDATE SKIP LOCKED
             LIMIT $1
         ) AS t
     WHERE sp.id = t.id

--- a/internal/db/pool_claimer_test.go
+++ b/internal/db/pool_claimer_test.go
@@ -17,9 +17,9 @@ func (h claimerTestHelper) CreateBatch(t *testing.T) (batch.ID, string) {
 	return seedBatchFixture(t)
 }
 
-func (h claimerTestHelper) Schedule(t *testing.T, d *delivery.Delivery) {
+func (h claimerTestHelper) Schedule(t *testing.T, ds ...*delivery.Delivery) {
 	t.Helper()
-	require.NoError(t, h.deliveries.Schedule(t.Context(), d))
+	require.NoError(t, h.deliveries.Schedule(t.Context(), ds...))
 }
 
 func TestPoolClaimer(t *testing.T) {

--- a/internal/pool/repospec.go
+++ b/internal/pool/repospec.go
@@ -1,6 +1,8 @@
 package pool
 
 import (
+	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -19,9 +21,10 @@ type ClaimerTestHelper interface {
 	// and returns the BatchID and Domain.
 	CreateBatch(t *testing.T) (batch.ID, string)
 
-	// Schedule seeds a fresh Delivery in the pool. The Claimer does not
-	// own initial scheduling — the harness must persist it directly.
-	Schedule(t *testing.T, d *delivery.Delivery)
+	// Schedule seeds one or more fresh Deliveries in the pool. The
+	// Claimer does not own initial scheduling — the harness must persist
+	// them directly.
+	Schedule(t *testing.T, ds ...*delivery.Delivery)
 }
 
 // RunClaimerSpec exercises any Claimer implementation against the
@@ -89,6 +92,59 @@ func RunClaimerSpec(t *testing.T, c Claimer, helper ClaimerTestHelper) {
 		batchID, domain := helper.CreateBatch(t)
 		_, err := c.Lookup(ctx, batchID, "missing@"+domain)
 		assert.ErrorIs(t, err, delivery.ErrDeliveryNotFound)
+	})
+
+	t.Run("ClaimForDispatch_NoDuplicatesUnderConcurrency", func(t *testing.T) {
+		ctx := t.Context()
+
+		const (
+			rounds  = 5
+			total   = 200
+			workers = 4
+		)
+		for round := 0; round < rounds; round++ {
+			batchID, domain := helper.CreateBatch(t)
+
+			ds := make([]*delivery.Delivery, total)
+			for i := range ds {
+				ds[i] = mustNewDelivery(t, batchID, domain, fmt.Sprintf("c%d@%s", i, domain))
+			}
+			helper.Schedule(t, ds...)
+			for _, d := range ds {
+				require.NoError(t, c.MarkValidated(ctx, d))
+			}
+
+			var (
+				wg      sync.WaitGroup
+				start   = make(chan struct{})
+				results = make([][]*delivery.Delivery, workers)
+				errs    = make([]error, workers)
+			)
+			for w := 0; w < workers; w++ {
+				wg.Add(1)
+				go func(idx int) {
+					defer wg.Done()
+					<-start
+					got, err := c.ClaimForDispatch(ctx, total)
+					results[idx] = got
+					errs[idx] = err
+				}(w)
+			}
+			close(start)
+			wg.Wait()
+
+			seen := make(map[string]int, total)
+			for w, got := range results {
+				require.NoError(t, errs[w])
+				for _, d := range got {
+					seen[d.BatchID().String()+"|"+d.Email()]++
+				}
+			}
+			for k, n := range seen {
+				assert.Equal(t, 1, n,
+					"round %d: delivery %s claimed %d times across concurrent dispatchers (must be 1)", round, k, n)
+			}
+		}
 	})
 }
 


### PR DESCRIPTION
## Summary

- `PrepareForSend` / `PrepareForValidate` claimed rows via an `UPDATE ... FROM (SELECT ... LIMIT N)` without `FOR UPDATE SKIP LOCKED`. Under READ COMMITTED two concurrent dispatchers could both see the same ids in `RETURNING` → same recipient emailed twice.
- Add `FOR UPDATE SKIP LOCKED` to the inner SELECT of both queries (and regenerate sqlc). Each candidate row is now exclusively grabbed by exactly one claimer.
- Extend the Claimer spec with a concurrent-claim test (4 dispatchers × 200 deliveries × 5 rounds) that reliably reproduced the duplicate before the fix and is green with it.

Closes #374

## Test plan

- [x] `go test ./internal/db/... ./internal/pool/... ./internal/delivery/...`
- [x] New test `TestPoolClaimer/ClaimForDispatch_NoDuplicatesUnderConcurrency` fails on `main` (`-count=5`) and passes with the fix
- [x] `go build ./...` / `go vet ./...`