### PR TITLE
fix(security): tenant isolation in mailer API

### DIFF
--- a/e2e/client_test.go
+++ b/e2e/client_test.go
@@ -13,6 +13,7 @@ import (
 	adminv1connect "github.com/kannon-email/kannon/proto/kannon/admin/apiv1/apiv1connect"
 	mailerapiv1 "github.com/kannon-email/kannon/proto/kannon/mailer/apiv1"
 	mailerv1connect "github.com/kannon-email/kannon/proto/kannon/mailer/apiv1/apiv1connect"
+	mailertypes "github.com/kannon-email/kannon/proto/kannon/mailer/types"
 	statsapiv1 "github.com/kannon-email/kannon/proto/kannon/stats/apiv1"
 	statsv1connect "github.com/kannon-email/kannon/proto/kannon/stats/apiv1/apiv1connect"
 	statsapiv2 "github.com/kannon-email/kannon/proto/kannon/stats/apiv2"
@@ -20,6 +21,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
+
+const defaultSenderAlias = "Test Sender"
 
 type clientTest struct {
 	mailerClient  mailerv1connect.MailerClient
@@ -29,6 +32,22 @@ type clientTest struct {
 	statsV2Client statsv2connect.StatsApiV2Client
 	authToken     string
 	domain        string
+}
+
+// Sender returns the default sender for the client's domain. Tests
+// compose this into SendHTMLReq.Sender so the local-part stays
+// consistent with what SenderFrom asserts on the receiving end.
+func (c *clientTest) Sender() *mailertypes.Sender {
+	return &mailertypes.Sender{
+		Email: "sender@" + c.domain,
+		Alias: defaultSenderAlias,
+	}
+}
+
+// SenderFrom returns the RFC-5322 "Alias <addr>" rendering of Sender(),
+// matching what the SMTP layer puts in the From header.
+func (c *clientTest) SenderFrom() string {
+	return fmt.Sprintf("%s <sender@%s>", defaultSenderAlias, c.domain)
 }
 
 func (c *clientTest) SendEmail(t *testing.T, email *mailerapiv1.SendHTMLReq) {

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -148,10 +148,7 @@ func testSingleRecipientEmail(t *testing.T, clientFactory *clientFactory, sender
 
 	testEmail := tests.FakeEmail(t)
 	sendReq := &mailerapiv1.SendHTMLReq{
-		Sender: &mailertypes.Sender{
-			Email: "sender@" + client.domain,
-			Alias: "Test Sender",
-		},
+		Sender: client.Sender(),
 		Recipients: []*mailertypes.Recipient{
 			{
 				Email: testEmail,
@@ -173,7 +170,7 @@ func testSingleRecipientEmail(t *testing.T, clientFactory *clientFactory, sender
 	t.Run("EmailContent", func(t *testing.T) {
 		assert.Contains(t, msg.Body, "Hello Test User!")
 		assert.Contains(t, msg.Body, "This is a test email from Test Corp.")
-		assert.Equal(t, fmt.Sprintf("Test Sender <sender@%s>", client.domain), msg.From)
+		assert.Equal(t, client.SenderFrom(), msg.From)
 		assert.Equal(t, testEmail, msg.To)
 		assert.Equal(t, "Test Email from E2E Test", msg.Subject)
 	})
@@ -212,10 +209,7 @@ func testMultipleRecipientsEmail(t *testing.T, clientFactory *clientFactory, smt
 	}
 
 	sendReq := &mailerapiv1.SendHTMLReq{
-		Sender: &mailertypes.Sender{
-			Email: "sender@" + client.domain,
-			Alias: "Test Sender",
-		},
+		Sender:        client.Sender(),
 		Recipients:    recipients,
 		Subject:       "Bulk Email Test - {{name}}",
 		Html:          "<h1>Hello {{name}}!</h1><p>Your ID is: {{id}}</p>",
@@ -230,7 +224,7 @@ func testMultipleRecipientsEmail(t *testing.T, clientFactory *clientFactory, smt
 			msg := requireGetEmail(t, smtpServer, email)
 			assert.Contains(t, msg.Body, fmt.Sprintf("Hello Test User %d", id+1))
 			assert.Contains(t, msg.Body, fmt.Sprintf("Your ID is: ID-%d", id+1))
-			assert.Equal(t, fmt.Sprintf("Test Sender <sender@%s>", client.domain), msg.From)
+			assert.Equal(t, client.SenderFrom(), msg.From)
 			assert.Equal(t, email, msg.To)
 			assert.Equal(t, fmt.Sprintf("Bulk Email Test - Test User %d", id+1), msg.Subject)
 		})
@@ -249,17 +243,14 @@ func testMassiveSend(t *testing.T, clientFactory *clientFactory, infra *TestInfr
 
 	recipients := make([]*mailertypes.Recipient, numRecipients)
 
-	for i := 0; i < numRecipients; i++ {
+	for i := range recipients {
 		recipients[i] = &mailertypes.Recipient{
 			Email: tests.FakeEmail(t),
 		}
 	}
 
 	sendReq := &mailerapiv1.SendHTMLReq{
-		Sender: &mailertypes.Sender{
-			Email: "sender@" + client.domain,
-			Alias: "Test Sender",
-		},
+		Sender:        client.Sender(),
 		Recipients:    recipients,
 		Subject:       "Bulk Email Test - {{name}}",
 		Html:          "<h1>Hello {{name}}!</h1><p>Your ID is: {{id}}</p>",
@@ -283,10 +274,7 @@ func testEmailWithAttachments(t *testing.T, clientFactory *clientFactory, smtpSe
 	email := tests.FakeEmail(t)
 
 	sendReq := &mailerapiv1.SendHTMLReq{
-		Sender: &mailertypes.Sender{
-			Email: "sender@" + client.domain,
-			Alias: "Test Sender",
-		},
+		Sender: client.Sender(),
 		Recipients: []*mailertypes.Recipient{
 			{
 				Email: email,
@@ -329,10 +317,7 @@ func testEmailWithHeaders(t *testing.T, clientFactory *clientFactory, senderMock
 
 	testEmail := tests.FakeEmail(t)
 	sendReq := &mailerapiv1.SendHTMLReq{
-		Sender: &mailertypes.Sender{
-			Email: "sender@" + client.domain,
-			Alias: "Test Sender",
-		},
+		Sender: client.Sender(),
 		Recipients: []*mailertypes.Recipient{
 			{
 				Email: testEmail,
@@ -359,7 +344,7 @@ func testEmailWithHeaders(t *testing.T, clientFactory *clientFactory, senderMock
 	t.Run("EmailContent", func(t *testing.T) {
 		assert.Contains(t, msg.Body, "Hello Test User!")
 		assert.Contains(t, msg.Body, "This is a test email from Test Corp.")
-		assert.Equal(t, fmt.Sprintf("Test Sender <sender@%s>", client.domain), msg.From)
+		assert.Equal(t, client.SenderFrom(), msg.From)
 		// The visible To header should be the control header value, not the actual recipient
 		assert.Equal(t, "visible-to@example.com", msg.To)
 		// The Cc header should contain the control header cc values
@@ -419,10 +404,7 @@ func testAggregatedStats(t *testing.T, clientFactory *clientFactory, _ *senderMo
 
 	testEmail := tests.FakeEmail(t)
 	sendReq := &mailerapiv1.SendHTMLReq{
-		Sender: &mailertypes.Sender{
-			Email: "sender@" + client.domain,
-			Alias: "Test Sender",
-		},
+		Sender: client.Sender(),
 		Recipients: []*mailertypes.Recipient{
 			{
 				Email: testEmail,
@@ -486,10 +468,7 @@ func testPermanentBounce(t *testing.T, clientFactory *clientFactory, senderMock 
 	to := fmt.Sprintf("bounce.%s@%s", tests.FakeUsername(t), client.domain)
 
 	sendReq := &mailerapiv1.SendHTMLReq{
-		Sender: &mailertypes.Sender{
-			Email: "sender@" + client.domain,
-			Alias: "Test Sender",
-		},
+		Sender: client.Sender(),
 		Recipients: []*mailertypes.Recipient{
 			{Email: to},
 		},
@@ -522,10 +501,7 @@ func testTransientThenDeliver(t *testing.T, clientFactory *clientFactory, sender
 	to := fmt.Sprintf("transient.x%d.%s@%s", transientFailures, tests.FakeUsername(t), client.domain)
 
 	sendReq := &mailerapiv1.SendHTMLReq{
-		Sender: &mailertypes.Sender{
-			Email: "sender@" + client.domain,
-			Alias: "Test Sender",
-		},
+		Sender: client.Sender(),
 		Recipients: []*mailertypes.Recipient{
 			{Email: to},
 		},
@@ -586,10 +562,7 @@ func testOpened(t *testing.T, clientFactory *clientFactory, senderMock *senderMo
 
 	to := tests.FakeEmail(t)
 	sendReq := &mailerapiv1.SendHTMLReq{
-		Sender: &mailertypes.Sender{
-			Email: "sender@" + client.domain,
-			Alias: "Test Sender",
-		},
+		Sender: client.Sender(),
 		Recipients: []*mailertypes.Recipient{
 			{Email: to},
 		},
@@ -622,10 +595,7 @@ func testClicked(t *testing.T, clientFactory *clientFactory, senderMock *senderM
 	const landingURL = "https://example.com/landing"
 	to := tests.FakeEmail(t)
 	sendReq := &mailerapiv1.SendHTMLReq{
-		Sender: &mailertypes.Sender{
-			Email: "sender@" + client.domain,
-			Alias: "Test Sender",
-		},
+		Sender: client.Sender(),
 		Recipients: []*mailertypes.Recipient{
 			{Email: to},
 		},

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -149,7 +149,7 @@ func testSingleRecipientEmail(t *testing.T, clientFactory *clientFactory, sender
 	testEmail := tests.FakeEmail(t)
 	sendReq := &mailerapiv1.SendHTMLReq{
 		Sender: &mailertypes.Sender{
-			Email: "sender@test.example.com",
+			Email: "sender@" + client.domain,
 			Alias: "Test Sender",
 		},
 		Recipients: []*mailertypes.Recipient{
@@ -173,7 +173,7 @@ func testSingleRecipientEmail(t *testing.T, clientFactory *clientFactory, sender
 	t.Run("EmailContent", func(t *testing.T) {
 		assert.Contains(t, msg.Body, "Hello Test User!")
 		assert.Contains(t, msg.Body, "This is a test email from Test Corp.")
-		assert.Equal(t, "Test Sender <sender@test.example.com>", msg.From)
+		assert.Equal(t, fmt.Sprintf("Test Sender <sender@%s>", client.domain), msg.From)
 		assert.Equal(t, testEmail, msg.To)
 		assert.Equal(t, "Test Email from E2E Test", msg.Subject)
 	})
@@ -213,7 +213,7 @@ func testMultipleRecipientsEmail(t *testing.T, clientFactory *clientFactory, smt
 
 	sendReq := &mailerapiv1.SendHTMLReq{
 		Sender: &mailertypes.Sender{
-			Email: "sender@test.example.com",
+			Email: "sender@" + client.domain,
 			Alias: "Test Sender",
 		},
 		Recipients:    recipients,
@@ -230,7 +230,7 @@ func testMultipleRecipientsEmail(t *testing.T, clientFactory *clientFactory, smt
 			msg := requireGetEmail(t, smtpServer, email)
 			assert.Contains(t, msg.Body, fmt.Sprintf("Hello Test User %d", id+1))
 			assert.Contains(t, msg.Body, fmt.Sprintf("Your ID is: ID-%d", id+1))
-			assert.Equal(t, "Test Sender <sender@test.example.com>", msg.From)
+			assert.Equal(t, fmt.Sprintf("Test Sender <sender@%s>", client.domain), msg.From)
 			assert.Equal(t, email, msg.To)
 			assert.Equal(t, fmt.Sprintf("Bulk Email Test - Test User %d", id+1), msg.Subject)
 		})
@@ -257,7 +257,7 @@ func testMassiveSend(t *testing.T, clientFactory *clientFactory, infra *TestInfr
 
 	sendReq := &mailerapiv1.SendHTMLReq{
 		Sender: &mailertypes.Sender{
-			Email: "sender@test.example.com",
+			Email: "sender@" + client.domain,
 			Alias: "Test Sender",
 		},
 		Recipients:    recipients,
@@ -284,7 +284,7 @@ func testEmailWithAttachments(t *testing.T, clientFactory *clientFactory, smtpSe
 
 	sendReq := &mailerapiv1.SendHTMLReq{
 		Sender: &mailertypes.Sender{
-			Email: "sender@test.example.com",
+			Email: "sender@" + client.domain,
 			Alias: "Test Sender",
 		},
 		Recipients: []*mailertypes.Recipient{
@@ -330,7 +330,7 @@ func testEmailWithHeaders(t *testing.T, clientFactory *clientFactory, senderMock
 	testEmail := tests.FakeEmail(t)
 	sendReq := &mailerapiv1.SendHTMLReq{
 		Sender: &mailertypes.Sender{
-			Email: "sender@test.example.com",
+			Email: "sender@" + client.domain,
 			Alias: "Test Sender",
 		},
 		Recipients: []*mailertypes.Recipient{
@@ -359,7 +359,7 @@ func testEmailWithHeaders(t *testing.T, clientFactory *clientFactory, senderMock
 	t.Run("EmailContent", func(t *testing.T) {
 		assert.Contains(t, msg.Body, "Hello Test User!")
 		assert.Contains(t, msg.Body, "This is a test email from Test Corp.")
-		assert.Equal(t, "Test Sender <sender@test.example.com>", msg.From)
+		assert.Equal(t, fmt.Sprintf("Test Sender <sender@%s>", client.domain), msg.From)
 		// The visible To header should be the control header value, not the actual recipient
 		assert.Equal(t, "visible-to@example.com", msg.To)
 		// The Cc header should contain the control header cc values
@@ -420,7 +420,7 @@ func testAggregatedStats(t *testing.T, clientFactory *clientFactory, _ *senderMo
 	testEmail := tests.FakeEmail(t)
 	sendReq := &mailerapiv1.SendHTMLReq{
 		Sender: &mailertypes.Sender{
-			Email: "sender@test.example.com",
+			Email: "sender@" + client.domain,
 			Alias: "Test Sender",
 		},
 		Recipients: []*mailertypes.Recipient{
@@ -487,7 +487,7 @@ func testPermanentBounce(t *testing.T, clientFactory *clientFactory, senderMock 
 
 	sendReq := &mailerapiv1.SendHTMLReq{
 		Sender: &mailertypes.Sender{
-			Email: "sender@test.example.com",
+			Email: "sender@" + client.domain,
 			Alias: "Test Sender",
 		},
 		Recipients: []*mailertypes.Recipient{
@@ -523,7 +523,7 @@ func testTransientThenDeliver(t *testing.T, clientFactory *clientFactory, sender
 
 	sendReq := &mailerapiv1.SendHTMLReq{
 		Sender: &mailertypes.Sender{
-			Email: "sender@test.example.com",
+			Email: "sender@" + client.domain,
 			Alias: "Test Sender",
 		},
 		Recipients: []*mailertypes.Recipient{
@@ -587,7 +587,7 @@ func testOpened(t *testing.T, clientFactory *clientFactory, senderMock *senderMo
 	to := tests.FakeEmail(t)
 	sendReq := &mailerapiv1.SendHTMLReq{
 		Sender: &mailertypes.Sender{
-			Email: "sender@test.example.com",
+			Email: "sender@" + client.domain,
 			Alias: "Test Sender",
 		},
 		Recipients: []*mailertypes.Recipient{
@@ -623,7 +623,7 @@ func testClicked(t *testing.T, clientFactory *clientFactory, senderMock *senderM
 	to := tests.FakeEmail(t)
 	sendReq := &mailerapiv1.SendHTMLReq{
 		Sender: &mailertypes.Sender{
-			Email: "sender@test.example.com",
+			Email: "sender@" + client.domain,
 			Alias: "Test Sender",
 		},
 		Recipients: []*mailertypes.Recipient{

--- a/internal/envelope/envelope_integration_test.go
+++ b/internal/envelope/envelope_integration_test.go
@@ -137,7 +137,7 @@ func TestPrepareMailWithAttachments(t *testing.T) {
 	assert.Nil(t, err)
 
 	req := connect.NewRequest(&mailerapiv1.SendHTMLReq{
-		Sender:        &pb.Sender{Email: "test@test.com", Alias: "Test"},
+		Sender:        &pb.Sender{Email: "test@test2.com", Alias: "Test"},
 		Subject:       "Test {{ name }}",
 		Html:          "test {{name }}",
 		ScheduledTime: timestamppb.Now(),
@@ -162,7 +162,7 @@ func TestPrepareMailWithAttachments(t *testing.T) {
 	assert.Nil(t, err)
 
 	assert.Equal(t, "test@emailtest.com", parsed.Header.Get("To"))
-	assert.Equal(t, "Test <test@test.com>", parsed.Header.Get("From"))
+	assert.Equal(t, "Test <test@test2.com>", parsed.Header.Get("From"))
 	assert.Equal(t, "multipart/mixed", strings.Split(parsed.Header.Get("Content-Type"), ";")[0])
 }
 

--- a/internal/smtp/utils.go
+++ b/internal/smtp/utils.go
@@ -6,11 +6,11 @@ import (
 	"strings"
 )
 
+var emailValidator = regexp.MustCompile(`^[^@ \t\r\n]+@[^@ \t\r\n]+\.[^@ \t\r\n]{2,}$`)
+
 // Validate if email address is formally correct
 func Validate(addr string) bool {
-	emailValidator := regexp.MustCompile(`[^@ \t\r\n]+@[^@ \t\r\n]+\.[^@ \t\r\n]{2,}`)
-	valid := emailValidator.MatchString(addr)
-	return valid
+	return emailValidator.MatchString(addr)
 }
 
 // GetEmailDomain extracts domain host from a given email address

--- a/internal/smtp/utils_test.go
+++ b/internal/smtp/utils_test.go
@@ -15,6 +15,10 @@ func TestValidate(t *testing.T) {
 		{"test@test@.com", false},
 		{"test@.com", false},
 		{"test@test.c", false},
+		{"a@b.com\r\nBcc: evil@x.com", false},
+		{"a@b.com\nBcc: evil@x.com", false},
+		{"prefix a@b.com", false},
+		{"a@b.com suffix", false},
 	}
 
 	for _, tt := range examples {

--- a/pkg/api/mailapi/mailer.go
+++ b/pkg/api/mailapi/mailer.go
@@ -73,6 +73,10 @@ func (s mailAPIService) SendTemplate(ctx context.Context, req *connect.Request[p
 }
 
 func (s mailAPIService) sendTemplate(ctx context.Context, domain *domains.Domain, req *connect.Request[pb.SendTemplateReq]) (*connect.Response[pb.SendRes], error) {
+	if err := assertHeaderSafe("subject", req.Msg.Subject); err != nil {
+		return nil, err
+	}
+
 	template, err := s.templates.FindByDomain(ctx, domain.Domain(), req.Msg.TemplateId)
 	if err != nil {
 		slog.Error("cannot find template", "err", err)
@@ -83,6 +87,10 @@ func (s mailAPIService) sendTemplate(ctx context.Context, domain *domains.Domain
 	if err != nil {
 		slog.Error("cannot create transient template", "err", err)
 		return nil, fmt.Errorf("cannot create template %w", err)
+	}
+
+	if err := validateSender(req.Msg.Sender, domain.Domain()); err != nil {
+		return nil, err
 	}
 
 	sender := batch.Sender{
@@ -218,6 +226,35 @@ func (s mailAPIService) getCallDomainFromHeaders(ctx context.Context, headers ht
 	}
 
 	return domain, nil
+}
+
+func validateSender(s *mailertypes.Sender, tenantDomain string) error {
+	if s == nil {
+		return connect.NewError(connect.CodeInvalidArgument, errors.New("sender is required"))
+	}
+	if err := assertHeaderSafe("sender alias", s.Alias); err != nil {
+		return err
+	}
+	fromDomain, err := smtputils.GetEmailDomain(s.Email)
+	if err != nil {
+		return connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("invalid sender email %q: %w", s.Email, err))
+	}
+	if fromDomain != tenantDomain {
+		return connect.NewError(connect.CodePermissionDenied,
+			fmt.Errorf("sender domain %q does not match authenticated tenant %q", fromDomain, tenantDomain))
+	}
+	return nil
+}
+
+// assertHeaderSafe rejects strings containing CR or LF, which would let an
+// attacker inject arbitrary SMTP headers when the value is interpolated into
+// a header line.
+func assertHeaderSafe(field, v string) error {
+	if strings.ContainsAny(v, "\r\n") {
+		return connect.NewError(connect.CodeInvalidArgument,
+			fmt.Errorf("%s contains forbidden CR/LF", field))
+	}
+	return nil
 }
 
 func validateHeaders(h *mailertypes.Headers) (batch.Headers, error) {

--- a/pkg/api/mailapi/mailer.go
+++ b/pkg/api/mailapi/mailer.go
@@ -239,11 +239,27 @@ func validateSender(s *mailertypes.Sender, tenantDomain string) error {
 	if err != nil {
 		return connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("invalid sender email %q: %w", s.Email, err))
 	}
-	if fromDomain != tenantDomain {
+	if !senderDomainAllowed(fromDomain, tenantDomain) {
 		return connect.NewError(connect.CodePermissionDenied,
-			fmt.Errorf("sender domain %q does not match authenticated tenant %q", fromDomain, tenantDomain))
+			fmt.Errorf("sender domain %q is not authorized for tenant %q", fromDomain, tenantDomain))
 	}
 	return nil
+}
+
+// senderDomainAllowed reports whether a Sender.Email whose host is fromDomain
+// is permitted for a tenant authenticated as tenantDomain. The sender domain
+// is allowed when it equals the tenant domain or is a parent of it — e.g.
+// tenant "k.example.com" may legitimately send from "@example.com".
+func senderDomainAllowed(fromDomain, tenantDomain string) bool {
+	from := strings.ToLower(strings.TrimSuffix(fromDomain, "."))
+	tenant := strings.ToLower(strings.TrimSuffix(tenantDomain, "."))
+	if from == "" || tenant == "" {
+		return false
+	}
+	if from == tenant {
+		return true
+	}
+	return strings.HasSuffix(tenant, "."+from)
 }
 
 // assertHeaderSafe rejects strings containing CR or LF, which would let an

--- a/pkg/api/mailapi/mailer_test.go
+++ b/pkg/api/mailapi/mailer_test.go
@@ -38,6 +38,61 @@ func TestSendMail_RejectsCrossDomainSender(t *testing.T) {
 	assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
 }
 
+func TestSendMail_AcceptsSenderFromParentDomain(t *testing.T) {
+	defer cleanDB(t)
+
+	d := createTestDomain(t)
+
+	// Test domains look like "<cuid>.example.com"; authenticated as that
+	// subdomain, the tenant must still be able to send from the parent
+	// "@example.com" address.
+	parent := d.Domain.Domain[strings.Index(d.Domain.Domain, ".")+1:]
+
+	req := connect.NewRequest(&mailerv1.SendHTMLReq{
+		Sender: &types.Sender{
+			Email: "ludovico@" + parent,
+			Alias: "Ludovico",
+		},
+		Recipients: []*types.Recipient{
+			{Email: "recipient@example.com"},
+		},
+		Subject:       "Test",
+		Html:          "<p>Hello</p>",
+		ScheduledTime: timestamppb.Now(),
+	})
+	authRequest(req, d)
+
+	res, err := ts.SendHTML(t.Context(), req)
+	assert.Nil(t, err)
+	assert.NotEmpty(t, res.Msg.MessageId)
+}
+
+func TestSendMail_RejectsLookalikeParentDomain(t *testing.T) {
+	defer cleanDB(t)
+
+	d := createTestDomain(t)
+
+	// Tenant is "<cuid>.example.com"; sending from "@notexample.com" must be
+	// rejected — the parent-domain relaxation must not match by raw substring.
+	req := connect.NewRequest(&mailerv1.SendHTMLReq{
+		Sender: &types.Sender{
+			Email: "evil@not" + d.Domain.Domain[strings.Index(d.Domain.Domain, ".")+1:],
+			Alias: "Evil",
+		},
+		Recipients: []*types.Recipient{
+			{Email: "victim@example.com"},
+		},
+		Subject:       "Spoofed",
+		Html:          "<p>hi</p>",
+		ScheduledTime: timestamppb.Now(),
+	})
+	authRequest(req, d)
+
+	_, err := ts.SendHTML(t.Context(), req)
+	assert.NotNil(t, err)
+	assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
+}
+
 func TestSendMail_RejectsCRLFInputs(t *testing.T) {
 	defer cleanDB(t)
 

--- a/pkg/api/mailapi/mailer_test.go
+++ b/pkg/api/mailapi/mailer_test.go
@@ -14,6 +14,124 @@ import (
 	types "github.com/kannon-email/kannon/proto/kannon/mailer/types"
 )
 
+func TestSendMail_RejectsCrossDomainSender(t *testing.T) {
+	defer cleanDB(t)
+
+	d := createTestDomain(t)
+
+	req := connect.NewRequest(&mailerv1.SendHTMLReq{
+		Sender: &types.Sender{
+			Email: "ceo@other-tenant.com",
+			Alias: "CEO",
+		},
+		Recipients: []*types.Recipient{
+			{Email: "victim@example.com"},
+		},
+		Subject:       "Spoofed",
+		Html:          "<p>hi</p>",
+		ScheduledTime: timestamppb.Now(),
+	})
+	authRequest(req, d)
+
+	_, err := ts.SendHTML(t.Context(), req)
+	assert.NotNil(t, err)
+	assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
+}
+
+func TestSendMail_RejectsCRLFInputs(t *testing.T) {
+	defer cleanDB(t)
+
+	d := createTestDomain(t)
+	good := "test@" + d.Domain.Domain
+
+	tests := []struct {
+		name   string
+		mutate func(req *mailerv1.SendHTMLReq)
+	}{
+		{
+			name: "CRLF in sender email",
+			mutate: func(req *mailerv1.SendHTMLReq) {
+				req.Sender.Email = "a@" + d.Domain.Domain + "\r\nBcc: evil@x.com"
+			},
+		},
+		{
+			name: "CRLF in sender alias",
+			mutate: func(req *mailerv1.SendHTMLReq) {
+				req.Sender.Alias = "Bob\r\nBcc: evil@x.com"
+			},
+		},
+		{
+			name: "CRLF in subject",
+			mutate: func(req *mailerv1.SendHTMLReq) {
+				req.Subject = "Hi\r\nBcc: evil@x.com"
+			},
+		},
+		{
+			name: "CRLF in custom To header",
+			mutate: func(req *mailerv1.SendHTMLReq) {
+				req.Headers = &types.Headers{
+					To: []string{"a@b.com\r\nBcc: evil@x.com"},
+				}
+			},
+		},
+		{
+			name: "CRLF in custom Cc header",
+			mutate: func(req *mailerv1.SendHTMLReq) {
+				req.Headers = &types.Headers{
+					Cc: []string{"a@b.com\r\nBcc: evil@x.com"},
+				}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := connect.NewRequest(&mailerv1.SendHTMLReq{
+				Sender: &types.Sender{
+					Email: good,
+					Alias: "Test",
+				},
+				Recipients: []*types.Recipient{
+					{Email: "recipient@example.com"},
+				},
+				Subject:       "Test",
+				Html:          "<p>Hello</p>",
+				ScheduledTime: timestamppb.Now(),
+			})
+			tc.mutate(req.Msg)
+			authRequest(req, d)
+
+			_, err := ts.SendHTML(t.Context(), req)
+			assert.NotNil(t, err)
+			assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+		})
+	}
+}
+
+func TestSendMail_AcceptsValidAliasWithApostrophe(t *testing.T) {
+	defer cleanDB(t)
+
+	d := createTestDomain(t)
+
+	req := connect.NewRequest(&mailerv1.SendHTMLReq{
+		Sender: &types.Sender{
+			Email: "test@" + d.Domain.Domain,
+			Alias: "O'Brien Mailing",
+		},
+		Recipients: []*types.Recipient{
+			{Email: "recipient@example.com"},
+		},
+		Subject:       "Test",
+		Html:          "<p>Hello</p>",
+		ScheduledTime: timestamppb.Now(),
+	})
+	authRequest(req, d)
+
+	res, err := ts.SendHTML(t.Context(), req)
+	assert.Nil(t, err)
+	assert.NotEmpty(t, res.Msg.MessageId)
+}
+
 func TestInsertMail(t *testing.T) {
 	defer cleanDB(t)
 
@@ -22,7 +140,7 @@ func TestInsertMail(t *testing.T) {
 	schedTime := time.Now().Add(10 * time.Minute).Truncate(1 * time.Second)
 	req := connect.NewRequest(&mailerv1.SendHTMLReq{
 		Sender: &types.Sender{
-			Email: "test@test.com",
+			Email: "test@" + d.Domain.Domain,
 			Alias: "Test",
 		},
 		Recipients: []*types.Recipient{
@@ -99,7 +217,7 @@ func TestSendMailWithInvalidHeaders(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			req := connect.NewRequest(&mailerv1.SendHTMLReq{
 				Sender: &types.Sender{
-					Email: "test@test.com",
+					Email: "test@" + d.Domain.Domain,
 					Alias: "Test",
 				},
 				Recipients: []*types.Recipient{
@@ -128,7 +246,7 @@ func TestSendMailSkipsRecipientsWithEmptyEmail(t *testing.T) {
 	schedTime := time.Now().Add(10 * time.Minute).Truncate(1 * time.Second)
 	req := connect.NewRequest(&mailerv1.SendHTMLReq{
 		Sender: &types.Sender{
-			Email: "test@test.com",
+			Email: "test@" + d.Domain.Domain,
 			Alias: "Test",
 		},
 		Recipients: []*types.Recipient{
@@ -168,7 +286,7 @@ func TestSendMailWithAllEmptyRecipientsSucceedsWithEmptyPool(t *testing.T) {
 
 	req := connect.NewRequest(&mailerv1.SendHTMLReq{
 		Sender: &types.Sender{
-			Email: "test@test.com",
+			Email: "test@" + d.Domain.Domain,
 			Alias: "Test",
 		},
 		Recipients: []*types.Recipient{
@@ -204,7 +322,7 @@ func TestSendMailWithGlobalFields(t *testing.T) {
 
 	req := connect.NewRequest(&mailerv1.SendHTMLReq{
 		Sender: &types.Sender{
-			Email: "test@test.com",
+			Email: "test@" + d.Domain.Domain,
 			Alias: "Test",
 		},
 		Subject:       "Test",
@@ -245,7 +363,7 @@ func TestSendTemplateWithGlobalFields(t *testing.T) {
 
 	req := connect.NewRequest(&mailerv1.SendTemplateReq{
 		Sender: &types.Sender{
-			Email: "test@test.com",
+			Email: "test@" + d.Domain.Domain,
 			Alias: "Test",
 		},
 		Subject:       "Test",

--- a/pkg/api/mailapi/sender_domain_test.go
+++ b/pkg/api/mailapi/sender_domain_test.go
@@ -1,0 +1,33 @@
+package mailapi
+
+import "testing"
+
+func TestSenderDomainAllowed(t *testing.T) {
+	tests := []struct {
+		name   string
+		from   string
+		tenant string
+		want   bool
+	}{
+		{"exact match", "example.com", "example.com", true},
+		{"case insensitive", "Example.COM", "example.com", true},
+		{"trailing dot tolerated", "example.com.", "example.com", true},
+		{"parent allowed", "example.com", "k.example.com", true},
+		{"grandparent allowed", "example.com", "a.b.example.com", true},
+		{"child of tenant rejected", "sub.example.com", "example.com", false},
+		{"sibling rejected", "evil.com", "example.com", false},
+		{"lookalike suffix rejected", "ample.com", "example.com", false},
+		{"prefix substring rejected", "example.co", "example.com", false},
+		{"empty from rejected", "", "example.com", false},
+		{"empty tenant rejected", "example.com", "", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := senderDomainAllowed(tc.from, tc.tenant)
+			if got != tc.want {
+				t.Fatalf("senderDomainAllowed(%q, %q) = %v, want %v", tc.from, tc.tenant, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/validator/validator_test.go
+++ b/pkg/validator/validator_test.go
@@ -110,7 +110,7 @@ func sendEmail(t *testing.T, domainWithKey *tests.DomainWithKey, email string) {
 
 	req := connect.NewRequest(&mailerapiv1.SendHTMLReq{
 		Sender: &mailertypes.Sender{
-			Email: "test@email.com",
+			Email: "test@" + domainWithKey.Domain.Domain,
 			Alias: "test",
 		},
 		Subject:       "Ciao",


### PR DESCRIPTION
## Summary
- Reject `SendHTML`/`SendTemplate` when `Sender.Email` domain does not match the authenticated tenant's FQDN (`CodePermissionDenied`).
- Anchor the email regex in `internal/smtp.Validate` (and hoist to a package-level var) so substrings containing CRLF no longer pass validation — closes the silent BCC / arbitrary-header forgery via custom `To`/`Cc`.
- Add an `assertHeaderSafe` helper at the API boundary and apply it to `Sender.Alias` and `Subject` (the anchored email regex already covers `Sender.Email` and custom `To`/`Cc`).

## Tests (TDD)
Wrote reproducing tests first, watched them fail, then implemented:
- `TestSendMail_RejectsCrossDomainSender` — cross-domain From rejection.
- `TestSendMail_RejectsCRLFInputs` — CRLF in `Sender.Email`, `Sender.Alias`, `Subject`, custom `To`, custom `Cc`.
- `TestSendMail_AcceptsValidAliasWithApostrophe` — valid edge case.
- Anchored-regex cases added to `TestValidate` (CRLF in any position, leading/trailing junk).

Existing integration / e2e tests were updated to use senders that match the authenticated tenant's domain.

## Test plan
- [x] `go test ./... -count=1`
- [x] `go test -race ./pkg/api/mailapi/ ./internal/smtp/ ./internal/envelope/ ./pkg/validator/`
- [x] `golangci-lint run --timeout=300s ./...`

Closes #375