### PR TITLE
build(ci): enable intrange, copyloopvar, usestdlibvars linters

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -3,6 +3,7 @@ linters:
   default: none
   enable:
     - bodyclose
+    - copyloopvar
     - dogsled
     - dupl
     - errcheck
@@ -12,6 +13,7 @@ linters:
     - goprintffuncname
     - govet
     - ineffassign
+    - intrange
     - misspell
     - nolintlint
     - perfsprint
@@ -20,6 +22,7 @@ linters:
     - unconvert
     - unparam
     - unused
+    - usestdlibvars
     - whitespace
   settings:
     dupl:

--- a/internal/apikeys/service_test.go
+++ b/internal/apikeys/service_test.go
@@ -107,7 +107,7 @@ func TestService_ListKeys(t *testing.T) {
 		domain := testDomain
 
 		// Create 3 keys
-		for i := 0; i < 3; i++ {
+		for range 3 {
 			_, err := service.CreateKey(ctx, domain, "test-key", nil)
 			require.NoError(t, err)
 		}
@@ -126,7 +126,7 @@ func TestService_ListKeys(t *testing.T) {
 		domain := testDomain
 
 		// Create 2 active keys
-		for i := 0; i < 2; i++ {
+		for range 2 {
 			_, err := service.CreateKey(ctx, domain, "active-key", nil)
 			require.NoError(t, err)
 		}
@@ -163,7 +163,7 @@ func TestService_ListKeys(t *testing.T) {
 		domain := testDomain
 
 		// Create 5 keys
-		for i := 0; i < 5; i++ {
+		for range 5 {
 			_, err := service.CreateKey(ctx, domain, "test-key", nil)
 			require.NoError(t, err)
 		}

--- a/internal/pool/repospec.go
+++ b/internal/pool/repospec.go
@@ -102,7 +102,7 @@ func RunClaimerSpec(t *testing.T, c Claimer, helper ClaimerTestHelper) {
 			total   = 200
 			workers = 4
 		)
-		for round := 0; round < rounds; round++ {
+		for round := range rounds {
 			batchID, domain := helper.CreateBatch(t)
 
 			ds := make([]*delivery.Delivery, total)
@@ -120,7 +120,7 @@ func RunClaimerSpec(t *testing.T, c Claimer, helper ClaimerTestHelper) {
 				results = make([][]*delivery.Delivery, workers)
 				errs    = make([]error, workers)
 			)
-			for w := 0; w < workers; w++ {
+			for w := range workers {
 				wg.Add(1)
 				go func(idx int) {
 					defer wg.Done()

--- a/internal/stats/service_test.go
+++ b/internal/stats/service_test.go
@@ -58,7 +58,7 @@ func TestQueryStats_Pagination(t *testing.T) {
 	base := time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC)
 	tr := stats.TimeRange{Start: base.Add(-time.Hour), Stop: base.Add(time.Hour)}
 
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		s := stats.NewStat("user@example.com", "msg-1", "example.com", base.Add(time.Duration(i)*time.Minute), &types.StatsData{
 			Data: &types.StatsData_Delivered{},
 		})
@@ -255,7 +255,7 @@ func TestIncrementAggregatedStat(t *testing.T) {
 	ts := time.Date(2026, 1, 15, 14, 30, 0, 0, time.UTC)
 
 	// Increment the same domain/day/type 3 times.
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		if err := svc.IncrementAggregatedStat(ctx, "example.com", ts, stats.TypeDelivered); err != nil {
 			t.Fatalf("IncrementAggregatedStat: %v", err)
 		}

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -12,7 +12,7 @@ import (
 func MustGetPullSubscriber(ctx context.Context, js jetstream.JetStream, stream string, subj string, durable string) jetstream.Consumer {
 	var lastErr error
 
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		conn, err := js.CreateOrUpdateConsumer(ctx, stream, jetstream.ConsumerConfig{
 			Name:          durable,
 			Durable:       durable,

--- a/x/container/closer.go
+++ b/x/container/closer.go
@@ -35,7 +35,7 @@ func (c *Container) CloseWithTimeout(timeout time.Duration) error {
 	}
 
 	var errs []error
-	for i := 0; i < len(closers); i++ {
+	for range closers {
 		select {
 		case err := <-errCh:
 			if err != nil {

--- a/x/container/singleton_test.go
+++ b/x/container/singleton_test.go
@@ -83,7 +83,7 @@ func TestSingleton_ConcurrentAccess(t *testing.T) {
 	results := make(chan string, numGoroutines)
 
 	// Start multiple goroutines trying to initialize concurrently
-	for i := 0; i < numGoroutines; i++ {
+	for range numGoroutines {
 		go func() {
 			result := s.MustGet(ctx, initFunc)
 			results <- result
@@ -91,7 +91,7 @@ func TestSingleton_ConcurrentAccess(t *testing.T) {
 	}
 
 	// Collect all results
-	for i := 0; i < numGoroutines; i++ {
+	for range numGoroutines {
 		result := <-results
 		if result != initialized {
 			t.Errorf("Expected %q, got %s", initialized, result)


### PR DESCRIPTION
## Summary
- Enable `intrange`, `copyloopvar`, and `usestdlibvars` in `.golangci.yaml` so the modernize-style warnings gopls already flags interactively also gate CI.
- Apply the resulting rewrites across the touched call sites (six files, all trivial `for i := 0; i < N; i++` → `for range N` / `for i := range N` conversions; one `for range len(x)` → `for range x`).

## Test plan
- [x] `golangci-lint run ./...` → 0 issues
- [x] `go build ./...`
- [x] `go test -count=1 -short ./...` on the touched packages