### PR TITLE
fix(dispatcher): stop Nak-redelivery hot loop on permanent stat errors

### DIFF
--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -9,6 +9,28 @@ import (
 	"github.com/nats-io/nats.go/jetstream"
 )
 
+// consumerMaxDeliver caps the number of redelivery attempts for any single
+// JetStream message routed through MustGetPullSubscriber. Without this cap
+// (server default is -1 = unbounded) a poison message paired with a Nak()
+// loop saturates a CPU core.
+const consumerMaxDeliver = 100
+
+// consumerAckWait is the base ack timeout. It is also the redelivery delay
+// applied after consumerBackOff is exhausted.
+const consumerAckWait = 30 * time.Second
+
+// consumerBackOff is the per-attempt redelivery delay curve used by the
+// JetStream server when a message is Nak'd or its AckWait elapses. The
+// curve grows quickly so any consumer stuck on a single message backs off
+// to once-per-five-minutes within a handful of attempts.
+var consumerBackOff = []time.Duration{
+	1 * time.Second,
+	5 * time.Second,
+	30 * time.Second,
+	1 * time.Minute,
+	5 * time.Minute,
+}
+
 func MustGetPullSubscriber(ctx context.Context, js jetstream.JetStream, stream string, subj string, durable string) jetstream.Consumer {
 	var lastErr error
 
@@ -17,6 +39,9 @@ func MustGetPullSubscriber(ctx context.Context, js jetstream.JetStream, stream s
 			Name:          durable,
 			Durable:       durable,
 			FilterSubject: subj,
+			MaxDeliver:    consumerMaxDeliver,
+			AckWait:       consumerAckWait,
+			BackOff:       consumerBackOff,
 		})
 		if err == nil {
 			return conn

--- a/pkg/dispatcher/disp.go
+++ b/pkg/dispatcher/disp.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/kannon-email/kannon/internal/batch"
+	"github.com/kannon-email/kannon/internal/delivery"
 	"github.com/kannon-email/kannon/internal/envelope"
 	"github.com/kannon-email/kannon/internal/pool"
 	"github.com/kannon-email/kannon/internal/publisher"
@@ -143,15 +144,31 @@ func (d *disp) handleMsg(ctx context.Context, sbj, subName string, parse parseFu
 	return ctx.Err()
 }
 
+// nakDelay is the redelivery delay applied to transient stat-processing
+// failures. Bare msg.Nak() triggers *instant* redelivery on the JetStream
+// server, which turns any permanent error (e.g. lookup of an already-cleaned
+// delivery) into a tight hot loop that pins a CPU. A delay caps the
+// re-attempt rate even if MaxDeliver is misconfigured upstream.
+const nakDelay = 5 * time.Second
+
 func (d *disp) handleWithAck(ctx context.Context, msg jetstream.Msg, f func(ctx context.Context, msg jetstream.Msg) error) {
 	err := f(ctx, msg)
-	if err != nil {
-		if err := msg.Nak(); err != nil {
-			d.log().Error("Cannot nak msg to nats", "err", err)
-		}
-	} else {
+	switch {
+	case err == nil:
 		if err := msg.Ack(); err != nil {
-			d.log().Error("Cannot hack msg to nats", "err", err)
+			d.log().Error("Cannot ack msg to nats", "err", err)
+		}
+	case errors.Is(err, delivery.ErrDeliveryNotFound):
+		// Permanent: the delivery row is gone from the pool, so no amount of
+		// redelivery will make Lookup succeed. Term the stat to keep the
+		// consumer from spinning.
+		d.log().Debug("dropping stat for unknown delivery", "err", err)
+		if err := msg.Term(); err != nil {
+			d.log().Error("Cannot term msg to nats", "err", err)
+		}
+	default:
+		if err := msg.NakWithDelay(nakDelay); err != nil {
+			d.log().Error("Cannot nak msg to nats", "err", err)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

The dispatcher pod was sitting at ~950m CPU in idle (no emails to send).
Static analysis of the dispatcher's polling loop (`runner.Run` with
`WaitLoop(1s)`) didn't explain it — the real culprit was in the NATS
stat-consumers.

`msg.Nak()` on the nats.go JetStream client **triggers instant
redelivery** (it explicitly bypasses both `AckWait` and `BackOff`). The
three dispatcher consumers (`kannon.stats.error|delivered|bounced`)
Nak'd every error, including `delivery.ErrDeliveryNotFound`, which is
permanent — the row has already been cleaned from the sending pool.
With consumer `MaxDeliver` defaulting to `-1` (unbounded) one such
poison message becomes a `Lookup → Nak → redeliver` tight loop that
pins a CPU core.

## Fix

- `pkg/dispatcher/disp.go`: in `handleWithAck`
  - on `errors.Is(err, delivery.ErrDeliveryNotFound)` → `msg.Term()`
    (the stat is dropped — there is nothing in the pool to update)
  - on any other error → `msg.NakWithDelay(5s)` so transient failures
    can never busy-loop either
- `internal/utils/utils.go`: `MustGetPullSubscriber` now sets
  `MaxDeliver=100`, `AckWait=30s` and a `1s → 5m` `BackOff` curve. This
  is a safety net for every consumer (dispatcher, stats, smtpsender) —
  even a future caller that forgets to distinguish permanent vs
  transient errors backs off quickly and is eventually terminated by
  the server.

## Post-deploy

Once the new image is rolled out, drain any already-poisoned messages
sitting on the existing durables:

```
nats consumer info kannon-stats dispatcher-delivered
nats consumer info kannon-stats dispatcher-error
nats consumer info kannon-stats dispatcher-bounced
```

If `Num Redelivered` is high, purge the relevant subjects:

```
nats stream purge kannon-stats --subject=kannon.stats.delivered
```
(repeat for `.error` and `.bounced` as needed).

Note: `CreateOrUpdateConsumer` reconciles the new `MaxDeliver`/`AckWait`/`BackOff` against the existing durables, so no manual recreate is required.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./... -short` — all green
- [x] `golangci-lint run ./pkg/dispatcher/... ./internal/utils/...` — 0 issues
- [ ] After deploy: verify dispatcher pod CPU drops back to near-zero in idle
- [ ] After deploy: verify `Num Redelivered` on `dispatcher-*` consumers stops climbing