### PR TITLE
fix(dispatcher): reschedule claimed deliveries on dispatch failure

### DIFF
--- a/e2e/client_test.go
+++ b/e2e/client_test.go
@@ -50,7 +50,9 @@ func (c *clientTest) SenderFrom() string {
 	return fmt.Sprintf("%s <sender@%s>", defaultSenderAlias, c.domain)
 }
 
-func (c *clientTest) SendEmail(t *testing.T, email *mailerapiv1.SendHTMLReq) {
+// SendEmail submits the request and returns the Batch id (message_id) so
+// callers can correlate pool/stats state for their own Batch.
+func (c *clientTest) SendEmail(t *testing.T, email *mailerapiv1.SendHTMLReq) string {
 	sendReq := connect.NewRequest(email)
 	sendReq.Header().Set("Authorization", "Basic "+c.authToken)
 
@@ -59,6 +61,7 @@ func (c *clientTest) SendEmail(t *testing.T, email *mailerapiv1.SendHTMLReq) {
 	require.NotNil(t, sendResp.Msg)
 
 	t.Logf("✅ Email queued with message ID: %s", sendResp.Msg.MessageId)
+	return sendResp.Msg.MessageId
 }
 
 func (f *clientTest) GetAggregatedStats(t *testing.T) *statsapiv2.GetAggregatedStatsRes {

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -93,6 +94,11 @@ func TestE2EEmailSending(t *testing.T) {
 	t.Run("TransientThenDeliver", func(t *testing.T) {
 		t.Parallel()
 		testTransientThenDeliver(t, factory, senderMock, infra)
+	})
+
+	t.Run("DispatchFailureRecovery", func(t *testing.T) {
+		t.Parallel()
+		testDispatchFailureRecovery(t, factory, senderMock, infra)
 	})
 
 	t.Run("Opened", func(t *testing.T) {
@@ -541,6 +547,78 @@ func testTransientThenDeliver(t *testing.T, clientFactory *clientFactory, sender
 
 	assert.Len(t, senderMock.History(to), transientFailures+1,
 		"senderMock should have observed %d transient attempts plus one success", transientFailures)
+}
+
+// testDispatchFailureRecovery reproduces the failure mode of #400 through
+// the whole stack: a Delivery whose Envelope build fails after the claim
+// must be handed back to the pool (NOT stranded in Pool status 'sending')
+// and must be delivered once the failure clears.
+//
+// The build failure is injected with reversible SQL surgery: renaming the
+// Batch's template makes GetSendingData's messages×templates join come up
+// empty, so the real Dispatcher's Build genuinely errors; renaming it back
+// heals the path. Before the fix this test stalls at the anti-stranding
+// assertion: the Delivery sits in 'sending' with zero attempts forever.
+func testDispatchFailureRecovery(t *testing.T, clientFactory *clientFactory, senderMock *senderMock, infra *TestInfrastructure) {
+	client := clientFactory.NewClient(t, infra)
+
+	db, err := pgxpool.New(t.Context(), infra.dbURL)
+	require.NoError(t, err)
+	t.Cleanup(db.Close)
+
+	to := fmt.Sprintf("recovery.%s@%s", tests.FakeUsername(t), client.domain)
+
+	// Schedule slightly in the future: the gap is the window for breaking
+	// the template BEFORE the Dispatcher can claim the Delivery. The
+	// Validator ignores scheduled_time, so validation still happens now.
+	sendReq := &mailerapiv1.SendHTMLReq{
+		Sender:        client.Sender(),
+		Recipients:    []*mailertypes.Recipient{{Email: to}},
+		Subject:       "Dispatch Failure Recovery Test",
+		Html:          "<h1>Hello!</h1>",
+		ScheduledTime: timestamppb.New(time.Now().Add(3 * time.Second)),
+	}
+	msgID := client.SendEmail(t, sendReq)
+
+	var templateID string
+	require.NoError(t, db.QueryRow(t.Context(),
+		`SELECT template_id FROM messages WHERE message_id = $1`, msgID).Scan(&templateID))
+	_, err = db.Exec(t.Context(),
+		`UPDATE templates SET template_id = $1 WHERE template_id = $2`, templateID+".broken", templateID)
+	require.NoError(t, err)
+
+	// The #400 anti-stranding assertion: the claimed-then-failed Delivery
+	// must come back to 'scheduled' with a bumped attempt counter instead
+	// of dying silently in 'sending'.
+	require.EventuallyWithT(t, func(tt *assert.CollectT) {
+		var status string
+		var attempts int
+		require.NoError(tt, db.QueryRow(t.Context(),
+			`SELECT status, send_attempts_cnt FROM sending_pool_emails WHERE message_id = $1 AND email = $2`,
+			msgID, to).Scan(&status, &attempts))
+		require.GreaterOrEqual(tt, attempts, 1, "the failed dispatch must bump the attempt counter")
+		require.Equal(tt, "scheduled", status, "the failed Delivery must be handed back to the pool")
+	}, 30*time.Second, 100*time.Millisecond,
+		"Delivery must be rescheduled after a dispatch failure, not stranded in 'sending'")
+
+	// Heal the template; the next dispatch cycles must pick the Delivery
+	// up again and the email must actually go out.
+	_, err = db.Exec(t.Context(),
+		`UPDATE templates SET template_id = $1 WHERE template_id = $2`, templateID, templateID+".broken")
+	require.NoError(t, err)
+
+	msg := requireGetEmail(t, senderMock, to)
+	assert.Equal(t, "Dispatch Failure Recovery Test", msg.Subject)
+
+	requireStat(t, client, to, "delivered", 1)
+
+	// Terminal outcome: the Delivery leaves the Pool entirely.
+	require.EventuallyWithT(t, func(tt *assert.CollectT) {
+		var n int
+		require.NoError(tt, db.QueryRow(t.Context(),
+			`SELECT count(*) FROM sending_pool_emails WHERE message_id = $1`, msgID).Scan(&n))
+		require.Zero(tt, n, "delivered Deliveries must be cleaned from the pool")
+	}, 30*time.Second, 500*time.Millisecond, "pool must drain for the batch")
 }
 
 // openTokenRe extracts the JWT-style token from a `/o/<token>` tracking

--- a/internal/pool/repospec.go
+++ b/internal/pool/repospec.go
@@ -94,6 +94,45 @@ func RunClaimerSpec(t *testing.T, c Claimer, helper ClaimerTestHelper) {
 		assert.ErrorIs(t, err, delivery.ErrDeliveryNotFound)
 	})
 
+	t.Run("ClaimForDispatch_RespectsMax", func(t *testing.T) {
+		ctx := t.Context()
+		batchID, domain := helper.CreateBatch(t)
+
+		const (
+			eligible = 50
+			max      = 20
+		)
+		ds := make([]*delivery.Delivery, eligible)
+		for i := range ds {
+			ds[i] = mustNewDelivery(t, batchID, domain, fmt.Sprintf("m%d@%s", i, domain))
+		}
+		helper.Schedule(t, ds...)
+		for _, d := range ds {
+			require.NoError(t, c.MarkValidated(ctx, d))
+		}
+
+		got, err := c.ClaimForDispatch(ctx, max)
+		require.NoError(t, err)
+
+		// The core invariant: a single claim must never hand back more than
+		// max deliveries, no matter how many are eligible. (Hypothesis under
+		// test: a runaway claim returning the whole due backlog at once.)
+		assert.LessOrEqual(t, len(got), max,
+			"ClaimForDispatch returned %d deliveries with %d eligible — must be capped at max=%d",
+			len(got), eligible, max)
+		assert.Len(t, got, max,
+			"with %d eligible deliveries a claim of max=%d should fill exactly one page", eligible, max)
+
+		// And no delivery appears twice within the same claim.
+		seen := make(map[string]int, len(got))
+		for _, d := range got {
+			seen[d.BatchID().String()+"|"+d.Email()]++
+		}
+		for k, n := range seen {
+			assert.Equal(t, 1, n, "delivery %s returned %d times within a single claim (must be 1)", k, n)
+		}
+	})
+
 	t.Run("ClaimForDispatch_NoDuplicatesUnderConcurrency", func(t *testing.T) {
 		ctx := t.Context()
 

--- a/pkg/dispatcher/disp.go
+++ b/pkg/dispatcher/disp.go
@@ -31,10 +31,17 @@ func (d *disp) log() *slog.Logger {
 	return slog.With("component", "dispatcher")
 }
 
+// Dispatch timeouts. The claim gets its own budget; each Delivery then
+// gets an individual budget for Build. A single per-cycle budget shared
+// across the whole claimed page guillotines the page tail when one
+// Delivery is slow — see #400.
+const (
+	claimTimeout       = 10 * time.Second
+	perDeliveryTimeout = 5 * time.Second
+)
+
 func (d *disp) DispatchCycle(ctx context.Context) error {
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	defer cancel()
-	emails, err := d.claimer.ClaimForDispatch(ctx, 20)
+	emails, err := d.claimForDispatch(ctx)
 	if err != nil {
 		return fmt.Errorf("cannot prepare emails for send: %w", err)
 	}
@@ -42,26 +49,62 @@ func (d *disp) DispatchCycle(ctx context.Context) error {
 	d.log().Debug(fmt.Sprintf("seding %d emails", len(emails)))
 
 	for _, dlv := range emails {
-		log := d.log()
-		env, err := d.eb.Build(ctx, dlv)
-
-		if err != nil {
-			log.With("err", err).Error("Cannot send email")
-			continue
-		}
-
-		log = log.With("email", utils.ObfuscateEmail(env.To()), "email_id", env.EmailID())
-
-		if err := publisher.SendEmail(d.pub, env); err != nil {
-			log.With("err", err).Error("Cannot send email")
-			continue
-		}
-
-		log.Info("[✅ accepted]")
+		d.dispatchOne(ctx, dlv)
 	}
 
 	d.log().Debug("done sending emails")
 	return nil
+}
+
+func (d *disp) claimForDispatch(ctx context.Context) ([]*delivery.Delivery, error) {
+	ctx, cancel := context.WithTimeout(ctx, claimTimeout)
+	defer cancel()
+	return d.claimer.ClaimForDispatch(ctx, 20)
+}
+
+// dispatchOne builds and publishes the Envelope for one claimed Delivery.
+// On any failure the Delivery is handed back to the pool (Reschedule):
+// the claim already flipped it to 'sending', and the only other exits from
+// that status are stats-feedback driven — which can never arrive for an
+// Envelope that was never published. Dropping the row on the floor here
+// loses it silently and permanently (#400).
+func (d *disp) dispatchOne(ctx context.Context, dlv *delivery.Delivery) {
+	log := d.log().With(
+		"email", utils.ObfuscateEmail(dlv.Email()),
+		"batch_id", dlv.BatchID().String(),
+	)
+
+	buildCtx, cancel := context.WithTimeout(ctx, perDeliveryTimeout)
+	defer cancel()
+
+	env, err := d.eb.Build(buildCtx, dlv)
+	if err != nil {
+		log.With("err", err).Error("Cannot send email")
+		d.reschedule(ctx, dlv, log)
+		return
+	}
+
+	log = log.With("email_id", env.EmailID())
+
+	if err := publisher.SendEmail(d.pub, env); err != nil {
+		log.With("err", err).Error("Cannot send email")
+		d.reschedule(ctx, dlv, log)
+		return
+	}
+
+	log.Info("[✅ accepted]")
+}
+
+// reschedule returns a claimed-but-failed Delivery to the pool with the
+// usual retry backoff. It runs on a context detached from cancellation:
+// the failure being handled is often the cycle context dying, and the
+// recovery write must not share that fate.
+func (d *disp) reschedule(ctx context.Context, dlv *delivery.Delivery, log *slog.Logger) {
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), claimTimeout)
+	defer cancel()
+	if err := d.claimer.Reschedule(ctx, dlv); err != nil {
+		log.With("err", err).Error("Cannot reschedule delivery after dispatch failure")
+	}
 }
 
 func (d *disp) handleErrors(ctx context.Context) error {

--- a/pkg/dispatcher/dispatch_cycle_incident_test.go
+++ b/pkg/dispatcher/dispatch_cycle_incident_test.go
@@ -1,0 +1,269 @@
+package dispatcher
+
+// Incident regression — dispatcher budget death mid-page (#400).
+//
+// In production a single multi-recipient Batch saw a large tail of its
+// Deliveries fail inside eb.Build with err="context deadline exceeded",
+// all within a few milliseconds, and remain stranded in status='sending'
+// forever (no reaper, no retry): the per-cycle context budget was SHARED
+// across the whole claimed page, and a claimed-but-failed Delivery had no
+// recovery path at all.
+//
+// This test drives the REAL DispatchCycle + REAL pool.Claimer + REAL
+// Postgres (dockertest) through the same mechanism and asserts the fixed
+// behaviour:
+//
+//  1. a Delivery that exhausts its per-Delivery budget fails ALONE — it
+//     cannot guillotine the rest of the claimed page;
+//  2. every claimed-but-failed Delivery is handed back to the pool
+//     (status='scheduled', attempt counter bumped) and is eventually
+//     published by later healthy cycles — zero silent loss.
+//
+// The DB latency spike is injected at the seam the builder already exposes
+// (envelope.NewBuilderWith): gateSource serves the first `free` calls
+// instantly, then blocks until its context dies.
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"math"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	schema "github.com/kannon-email/kannon/db"
+	"github.com/kannon-email/kannon/internal/batch"
+	sqlc "github.com/kannon-email/kannon/internal/db"
+	"github.com/kannon-email/kannon/internal/delivery"
+	"github.com/kannon-email/kannon/internal/dkim"
+	"github.com/kannon-email/kannon/internal/envelope"
+	"github.com/kannon-email/kannon/internal/pool"
+	"github.com/kannon-email/kannon/internal/tests"
+	mailertypes "github.com/kannon-email/kannon/proto/kannon/mailer/types"
+)
+
+var testDB *pgxpool.Pool
+
+func TestMain(m *testing.M) {
+	var purge tests.PurgeFunc
+	var err error
+
+	testDB, purge, err = tests.TestPostgresInit(schema.Schema)
+	if err != nil {
+		slog.Error("could not start test postgres", "err", err)
+		os.Exit(1)
+	}
+
+	code := m.Run()
+
+	if err := purge(); err != nil {
+		slog.Error("could not purge test postgres", "err", err)
+		os.Exit(1)
+	}
+
+	os.Exit(code)
+}
+
+// gateSource simulates the production DB latency spike inside Build.
+// The first `free` GetSendingData calls return instantly; the next call
+// blocks until its context dies; every call after that sees a dead parent
+// and fails in microseconds — the original incident burst.
+type gateSource struct {
+	data  envelope.SendingData
+	free  int
+	calls int
+}
+
+func (s *gateSource) GetSendingData(ctx context.Context, _ batch.ID) (envelope.SendingData, error) {
+	s.calls++
+	if s.calls <= s.free {
+		return s.data, nil
+	}
+	<-ctx.Done()
+	return envelope.SendingData{}, ctx.Err()
+}
+
+type noopTokens struct{}
+
+func (noopTokens) CreateLinkToken(_ context.Context, _, _, _ string) (string, error) {
+	return "tok", nil
+}
+
+func (noopTokens) CreateOpenToken(_ context.Context, _, _ string) (string, error) {
+	return "tok", nil
+}
+
+// recordingPublisher captures the recipient of every published Envelope.
+type recordingPublisher struct {
+	published []string
+}
+
+func (p *recordingPublisher) Publish(_ string, data []byte) error {
+	var m mailertypes.EmailToSend
+	if err := proto.Unmarshal(data, &m); err != nil {
+		return err
+	}
+	p.published = append(p.published, m.To)
+	return nil
+}
+
+func TestDispatchCycle_BudgetDeathMidPage_NoDeliveryLost(t *testing.T) {
+	ctx := t.Context()
+	q := sqlc.New(testDB)
+
+	// --- seed: Domain + transient Template + Batch (same shape as a
+	// SendTemplate call) --------------------------------------------------
+	keys, err := dkim.GenerateDKIMKeysPair()
+	require.NoError(t, err)
+
+	const domain = "k.incident.test"
+	_, err = q.CreateDomain(ctx, sqlc.CreateDomainParams{
+		Domain:         domain,
+		DkimPrivateKey: keys.PrivateKey,
+		DkimPublicKey:  keys.PublicKey,
+	})
+	require.NoError(t, err)
+
+	tpl, err := q.CreateTemplate(ctx, sqlc.CreateTemplateParams{
+		TemplateID: "template_incident@" + domain,
+		Html:       `<html><body><p style="font-size:18px">test</p></body></html>`,
+		Domain:     domain,
+		Type:       sqlc.TemplateTypeTransient,
+	})
+	require.NoError(t, err)
+
+	b, err := batch.New(domain, "incident repro",
+		batch.Sender{Email: "noreply@" + domain, Alias: "Incident"},
+		tpl.TemplateID, batch.Attachments{}, batch.Headers{})
+	require.NoError(t, err)
+	require.NoError(t, sqlc.NewBatchRepository(testDB).Create(ctx, b))
+
+	// --- seed: 50 due Deliveries, validated ('scheduled') ----------------
+	const (
+		total    = 50
+		page     = 20 // the hardcoded claim cap in DispatchCycle
+		accepted = 3  // builds that succeed before the budget dies
+	)
+	// Production backoff floors retries at 5m; collapse it so rescheduled
+	// Deliveries become due again within test time (the e2e suite does the
+	// same via container.WithBackoff).
+	backoff := delivery.ExponentialBackoff{Base: 10 * time.Millisecond, Min: 10 * time.Millisecond}
+	repo := sqlc.NewDeliveryRepository(testDB, backoff)
+	claimer := pool.NewClaimer(repo)
+
+	ds := make([]*delivery.Delivery, total)
+	for i := range ds {
+		d, err := delivery.New(delivery.NewParams{
+			BatchID:       b.ID(),
+			Email:         fmt.Sprintf("victim%02d@%s", i, domain),
+			Fields:        map[string]string{"name": "X"},
+			Domain:        domain,
+			ScheduledTime: time.Now().UTC().Add(-time.Minute),
+			Backoff:       backoff,
+		})
+		require.NoError(t, err)
+		ds[i] = d
+	}
+	require.NoError(t, repo.Schedule(ctx, ds...))
+	for _, d := range ds {
+		require.NoError(t, claimer.MarkValidated(ctx, d))
+	}
+
+	// --- the real dispatcher, with latency injected in Build -------------
+	src := &gateSource{
+		free: accepted,
+		data: envelope.SendingData{
+			Subject:        "incident repro",
+			HTML:           tpl.Html,
+			Domain:         domain,
+			MessageID:      b.ID().String(),
+			SenderEmail:    "noreply@" + domain,
+			SenderAlias:    "Incident",
+			DkimPrivateKey: keys.PrivateKey,
+		},
+	}
+	pub := &recordingPublisher{}
+	d := &disp{
+		claimer: claimer,
+		eb:      envelope.NewBuilderWith(src, noopTokens{}),
+		pub:     pub,
+	}
+
+	// Cycle 1 — the incident cycle. The parent context carries a 1s
+	// deadline, shrinking the per-Delivery budget into test time; gateSource
+	// blocks build #accepted+1 until that deadline fires, and every later
+	// build in the page sees a dead parent.
+	cycleCtx, cancel := context.WithTimeout(ctx, 1*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	require.NoError(t, d.DispatchCycle(cycleCtx),
+		"per-email failures are handled in-loop: the cycle itself reports success")
+	elapsed := time.Since(start)
+
+	// The claim cap held: one page of 20, despite 50 due.
+	assert.Len(t, pub.published, accepted,
+		"only the builds that ran before the budget death are published")
+
+	// FIX assertion 1 — no Delivery is stranded in 'sending': the failed
+	// tail of the page (page-accepted rows) is back in 'scheduled' with the
+	// attempt counter bumped, ready to be claimed again. Only the published
+	// ones legitimately remain 'sending' (waiting for SMTPSender feedback,
+	// absent in this harness).
+	assert.Equal(t, accepted, countByStatus(t, "sending"),
+		"only published deliveries may sit in 'sending'")
+	assert.Equal(t, total-accepted, countByStatus(t, "scheduled"),
+		"claimed-but-failed deliveries must be handed back to the pool")
+	assert.Equal(t, page-accepted, countRescheduled(t),
+		"every failed delivery of the claimed page carries one bumped attempt")
+
+	// The failure burst still ends quickly (failed builds don't run
+	// serially into their own 5s budgets once the parent is dead)...
+	assert.Less(t, elapsed, 3*time.Second,
+		"after the deadline fires, remaining builds must fail fast")
+
+	// --- cycles 2..n: latency gone, drain the pool -----------------------
+	src.free = math.MaxInt // heal the "DB": every later build succeeds
+
+	// FIX assertion 2 — zero silent loss: every Delivery, including the
+	// rescheduled victims, is eventually published by healthy cycles.
+	require.EventuallyWithT(t, func(tt *assert.CollectT) {
+		require.NoError(tt, d.DispatchCycle(ctx))
+		assert.Len(tt, pub.published, total)
+	}, 10*time.Second, 20*time.Millisecond,
+		"healthy cycles must drain the backlog, rescheduled victims included")
+
+	assert.Equal(t, 0, countByStatus(t, "scheduled"), "no delivery left behind")
+	assert.Equal(t, total, countByStatus(t, "sending"),
+		"all deliveries were published and await stats feedback")
+
+	published := make(map[string]bool, len(pub.published))
+	for _, to := range pub.published {
+		published[to] = true
+	}
+	for _, dlv := range ds {
+		assert.True(t, published[dlv.Email()], "delivery %s was never published", dlv.Email())
+	}
+}
+
+func countByStatus(t *testing.T, status string) int {
+	t.Helper()
+	var n int
+	require.NoError(t, testDB.QueryRow(t.Context(),
+		`SELECT count(*) FROM sending_pool_emails WHERE status = $1`, status).Scan(&n))
+	return n
+}
+
+func countRescheduled(t *testing.T) int {
+	t.Helper()
+	var n int
+	require.NoError(t, testDB.QueryRow(t.Context(),
+		`SELECT count(*) FROM sending_pool_emails WHERE send_attempts_cnt > 0`).Scan(&n))
+	return n
+}


### PR DESCRIPTION
Fixes #400

## Problem

`DispatchCycle` ran the claim **and** every sequential `Build` under one shared 10s budget. When the budget died mid-page (e.g. under a transient DB latency spike), the entire remaining tail of the claimed page failed instantly and together. Worse: a Delivery that failed between claim and publish stayed in Pool status `'sending'` forever — the only exits from that status are stats-feedback driven, and no stat can ever arrive for an Envelope that was never published. **Silent permanent loss.**

## Fix

- **Scoped timeouts** — the claim gets its own 10s budget; each Delivery gets an individual 5s budget for `Build`. One slow Delivery can no longer guillotine the rest of the page.
- **Recovery on failure** — any `Build`/publish error hands the Delivery back to the pool via `Reschedule` (attempt bump + backoff), on a context detached from cancellation: the failure being handled is often the cycle context dying, and the recovery write must not share that fate. `Reschedule` (rather than a plain flip back to `'scheduled'`) damps a deterministically-failing Build into backoff instead of a ~1Hz re-claim hot loop.
- **Attributable logs** — the dispatch logger is enriched with `email`/`batch_id` *before* `Build`, so in-Build failures are no longer anonymous (the incident burst was unattributable precisely because enrichment only happened after `Build`).

## Tests

- `TestDispatchCycle_BudgetDeathMidPage_NoDeliveryLost` (`pkg/dispatcher`) — drives the real `DispatchCycle` + real `pool.Claimer` + real Postgres, injecting the latency spike at the `envelope.NewBuilderWith` seam. Started life as a characterization test of the incident; its assertions are now flipped to pin the fix: a budget death mid-page strands nothing, and every claimed Delivery is eventually published.
- `DispatchFailureRecovery` (e2e) — reproduces the failure mode through the whole stack (real API, Validator, Dispatcher, NATS): the Batch's template is broken via reversible SQL surgery so `Build` genuinely fails after the claim, then healed. Asserts the Delivery comes back to `'scheduled'` with a bumped attempt counter and is delivered after healing. **Verified red against `main`** (stalls exactly at the anti-stranding assertion) and green with the fix.
- `ClaimForDispatch_RespectsMax` (pool spec) — pins the claim page-size cap invariant ruled out during the investigation.

`go test ./... -race`, `make test-e2e`, and `golangci-lint run` all pass.

## Out of scope (follow-ups filed)

- #401 — cache `SendingData` per Batch within a dispatch page
- #402 — reaper for stale `'sending'` rows (claim-then-**crash** recovery; needs a `claimed_at` migration)

## Operational note

Rows already stranded by the bug can be recovered manually:

```sql
UPDATE sending_pool_emails SET status = 'scheduled'
WHERE status = 'sending' AND <appropriate scoping>;
```