### PR TITLE
fix(sender): stop physically re-sending emails on JetStream redelivery

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -141,6 +141,7 @@ Kannon is a cloud-native, scalable SMTP mail sender designed for Kubernetes and 
 #### `pkg/smtpsender/`
 
 - Worker that consumes emails to send from NATS, performs SMTP delivery, and publishes delivery/bounce/error stats back to NATS.
+- Acknowledges a message only once the SMTP transaction has returned, so its consumer is given an ack deadline that outlasts one (`sendAckPolicy`), and every send is claimed in the `kannon-sent-envelopes` key/value bucket first, so a redelivery cannot put the same email in a mailbox twice. See [ADR 0004](docs/adr/0004-send-idempotency-guard.md).
 
 #### `pkg/smtp/`
 

--- a/docs/adr/0004-send-idempotency-guard.md
+++ b/docs/adr/0004-send-idempotency-guard.md
@@ -1,0 +1,91 @@
+# ADR 0004: The SMTPSender guards its own sends, in NATS rather than in the Pool
+
+## Status
+
+Accepted (2026-07-27).
+
+## Context
+
+The **SMTPSender** acknowledges a JetStream message only once the SMTP
+transaction has returned — that is what makes a crashed worker's Envelope get
+picked up by another one. The flip side is that any redelivery of a message
+whose send is still in flight, or already finished, produces a *second* SMTP
+transaction: the recipient receives the same email twice.
+
+Issue #425 is that failure in production. A consumer-wide `BackOff` curve gave
+every consumer a one-second first ack deadline (`BackOff` overrides `AckWait`),
+so essentially every send was redelivered, and roughly one delivery in six was
+duplicated. Giving the sending consumer a deadline that outlasts an SMTP
+transaction removes the cause, but not the class: a pod restart mid-send, a
+relay stuck past the whole backoff curve, or any of the `MaxDeliver` retries
+still hands the same stored Envelope to a second worker.
+
+So the send needs to be idempotent. Three designs were on the table.
+
+1. **Check the Pool row before sending.** The Delivery's Pool row is deleted on
+   a terminal outcome, so a redelivery arriving after the Delivered stat has
+   been processed would find nothing and could be skipped.
+2. **Claim the Pool row from the sender**, flipping `sending` → `sent` with a
+   conditional `UPDATE` before the transaction, so two workers holding the same
+   Envelope cannot both send.
+3. **Claim the stored message in NATS**, in a JetStream key/value bucket keyed
+   by the stream sequence of the message being delivered.
+
+## Decision
+
+(3). Before handing an Envelope to SMTP, the sender takes an atomic `Create` on
+a key derived from the message's stream sequence; the delivery that loses the
+race is acknowledged and dropped.
+
+### Why not the Pool
+
+(1) only catches the subset of redeliveries that arrive after the Delivered
+stat has been consumed. The duplicates measured in #425 were 1s and 5s apart —
+the second send starts while the first is still talking to the relay, with the
+row still in `sending` and indistinguishable from a first attempt. A check that
+misses the observed failure is not a fix.
+
+(2) closes that race, but at two prices. It puts the Pool's lifecycle in two
+hands: today the Dispatcher owns every transition and the sender owns none, and
+the Pool's states are explicitly implementation detail (`CONTEXT.md`, *Internal
+mechanics*). And it gives the SMTPSender a database dependency it does not have
+— `--run-sender` runs today with no `database_url` at all, so this would be a
+breaking change for split deployments, in the component that must keep running
+when Postgres is unavailable.
+
+### Why the stream sequence is the right key
+
+The unit to deduplicate is *one stored message*, not one Delivery. Every
+redelivery of a message carries the same stream sequence, so they collapse onto
+one key; a Delivery legitimately dispatched again after a transient failure is
+a new message with a new sequence, and is sent again as it should be. Keying on
+the Delivery instead (the email ID) would need a time window to distinguish the
+two, and no window is correct — `Delivery.NextRetryAt()` is measured from the
+Batch's *original* scheduled time, so a retry can be due immediately.
+
+### Why not `Nats-Msg-Id` publish deduplication
+
+The `Duplicates` window on a stream collapses duplicate *publishes*. Redelivery
+to a consumer is not a publish, so it does not go through that path at all: a
+message id on `kannon.sending` would not have prevented a single one of the
+duplicate emails in #425. It remains worth adding against duplicate dispatch,
+which is a different failure and needs headers on the publisher interface.
+
+## Consequences
+
+- The sender keeps its shape: NATS in, SMTP out, NATS out. No new dependency,
+  no schema change, no migration.
+- The guard holds across the worker pool of one process, across replicas, and
+  across restarts, which is when redelivery actually happens.
+- One more JetStream asset to operate: the `kannon-sent-envelopes` bucket, one
+  small entry per Envelope, expiring after an hour.
+- The guard **fails open**. If the bucket cannot be reached the send proceeds:
+  a duplicate is a smaller failure than a batch that never leaves.
+- A delivery that gets past the claim and then fails — a worker dying
+  mid-transaction, or a successful send whose outcome stat cannot be published
+  — is not retried by its own redelivery any more, because the claim it left
+  behind stops it. The Pool row is stranded in `sending` by those failures with
+  or without the guard, since no stat reaches the Dispatcher either way; what
+  the guard changes is that the email is not sent a second time on the way
+  there. That is the trade the issue asks for: a rare stranded Delivery instead
+  of a systematic duplicate.

--- a/internal/tests/nats.go
+++ b/internal/tests/nats.go
@@ -1,0 +1,57 @@
+package tests
+
+import (
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats-server/v2/server"
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+// NatsJetStream starts an in-process NATS server with JetStream enabled and
+// returns a JetStream context connected to it. Server, connection and store
+// directory are torn down when the test ends.
+//
+// This is the same embedded server the binary itself can run
+// (x/container.EmbeddedNatsServer), so consumer and stream behaviour — ack
+// deadlines, redelivery, key/value buckets — is the real thing rather than a
+// stub, without the Docker round trip the e2e suite pays for.
+func NatsJetStream(t *testing.T) jetstream.JetStream {
+	t.Helper()
+
+	ns, err := server.NewServer(&server.Options{
+		Host:      "127.0.0.1",
+		Port:      -1, // random available port
+		JetStream: true,
+		StoreDir:  t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("cannot create embedded NATS server: %v", err)
+	}
+
+	go ns.Start()
+	if !ns.ReadyForConnections(10 * time.Second) {
+		ns.Shutdown()
+		t.Fatal("embedded NATS server not ready")
+	}
+
+	nc, err := nats.Connect(ns.ClientURL())
+	if err != nil {
+		ns.Shutdown()
+		t.Fatalf("cannot connect to embedded NATS server: %v", err)
+	}
+
+	t.Cleanup(func() {
+		nc.Close()
+		ns.Shutdown()
+		ns.WaitForShutdown()
+	})
+
+	js, err := jetstream.New(nc)
+	if err != nil {
+		t.Fatalf("cannot create JetStream context: %v", err)
+	}
+
+	return js
+}

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -15,15 +15,46 @@ import (
 // loop saturates a CPU core.
 const consumerMaxDeliver = 100
 
-// consumerAckWait is the base ack timeout. It is also the redelivery delay
-// applied after consumerBackOff is exhausted.
-const consumerAckWait = 30 * time.Second
+// AckPolicy is how long a consumer is given to settle a delivery before the
+// JetStream server hands the same message to somebody else, attempt by
+// attempt: entry i is the deadline of attempt i+1, and equally the delay
+// before attempt i+2 goes out. The last entry governs every further attempt,
+// up to consumerMaxDeliver.
+//
+// One curve, and not a base deadline plus a backoff, because JetStream
+// conflates the two: a non-empty BackOff "overrides AckWait" (see the doc
+// comment on jetstream.ConsumerConfig.BackOff) — the server rewrites AckWait
+// to BackOff[0] when it creates the consumer, and reuses the last entry of the
+// curve once the curve runs out. An AckWait set next to a BackOff therefore
+// says nothing at all: that is how the sending consumer came to have one
+// second to acknowledge an SMTP transaction, and to physically re-send every
+// email slower than that (#425).
+type AckPolicy []time.Duration
 
-// consumerBackOff is the per-attempt redelivery delay curve used by the
-// JetStream server when a message is Nak'd or its AckWait elapses. The
-// curve grows quickly so any consumer stuck on a single message backs off
-// to once-per-five-minutes within a handful of attempts.
-var consumerBackOff = []time.Duration{
+// FirstDeadline is the deadline of a first delivery. It is the one that
+// matters: every later attempt is by definition a redelivery, so this is the
+// only deadline that applies while the work is being done for the first time.
+func (p AckPolicy) FirstDeadline() time.Duration {
+	return p[0]
+}
+
+// applyTo writes the policy onto a consumer config, keeping AckWait and
+// BackOff in agreement so the config states the deadline it actually gets.
+func (p AckPolicy) applyTo(cfg *jetstream.ConsumerConfig) {
+	cfg.AckWait = p.FirstDeadline()
+	cfg.BackOff = p
+}
+
+// DefaultAckPolicy suits a consumer whose handler is a local unit of work —
+// a database round trip or two — and which therefore acks within
+// milliseconds. It reacts quickly and grows fast, so a consumer stuck on a
+// single message backs off to once per five minutes within a handful of
+// attempts (#396).
+//
+// A handler that can legitimately hold a message for longer than the first
+// entry must say so with WithAckPolicy, or the server will hand its message to
+// another worker while it is still being worked on.
+var DefaultAckPolicy = AckPolicy{
 	1 * time.Second,
 	5 * time.Second,
 	30 * time.Second,
@@ -31,18 +62,42 @@ var consumerBackOff = []time.Duration{
 	5 * time.Minute,
 }
 
-func MustGetPullSubscriber(ctx context.Context, js jetstream.JetStream, stream string, subj string, durable string) jetstream.Consumer {
+type consumerOptions struct {
+	ack AckPolicy
+}
+
+// ConsumerOption customises the consumer created by MustGetPullSubscriber.
+type ConsumerOption func(*consumerOptions)
+
+// WithAckPolicy gives this consumer its own ack deadline curve in place of
+// DefaultAckPolicy. An empty policy is ignored.
+func WithAckPolicy(p AckPolicy) ConsumerOption {
+	return func(o *consumerOptions) {
+		if len(p) == 0 {
+			return
+		}
+		o.ack = p
+	}
+}
+
+func MustGetPullSubscriber(ctx context.Context, js jetstream.JetStream, stream string, subj string, durable string, opts ...ConsumerOption) jetstream.Consumer {
+	o := consumerOptions{ack: DefaultAckPolicy}
+	for _, opt := range opts {
+		opt(&o)
+	}
+
+	cfg := jetstream.ConsumerConfig{
+		Name:          durable,
+		Durable:       durable,
+		FilterSubject: subj,
+		MaxDeliver:    consumerMaxDeliver,
+	}
+	o.ack.applyTo(&cfg)
+
 	var lastErr error
 
 	for range 10 {
-		conn, err := js.CreateOrUpdateConsumer(ctx, stream, jetstream.ConsumerConfig{
-			Name:          durable,
-			Durable:       durable,
-			FilterSubject: subj,
-			MaxDeliver:    consumerMaxDeliver,
-			AckWait:       consumerAckWait,
-			BackOff:       consumerBackOff,
-		})
+		conn, err := js.CreateOrUpdateConsumer(ctx, stream, cfg)
 		if err == nil {
 			return conn
 		}

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -1,0 +1,61 @@
+package utils_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/kannon-email/kannon/internal/tests"
+	"github.com/kannon-email/kannon/internal/utils"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The deadline a consumer is really given is the one the server ends up
+// holding, and the server rewrites AckWait to BackOff[0]. Asserting against
+// the config read back is therefore the only assertion worth making: it is
+// what caught #425, where the requested AckWait and the effective one were
+// thirty seconds apart.
+func TestAckPolicyIsTheDeadlineTheServerHolds(t *testing.T) {
+	ctx := t.Context()
+	js := tests.NatsJetStream(t)
+	mustStream(ctx, t, js)
+
+	policy := utils.AckPolicy{90 * time.Second, 3 * time.Minute}
+	info := consumerInfo(ctx, t, js, "explicit-policy", utils.WithAckPolicy(policy))
+
+	assert.Equal(t, policy.FirstDeadline(), info.Config.AckWait)
+	assert.Equal(t, []time.Duration(policy), info.Config.BackOff)
+}
+
+// Without an explicit policy a consumer gets the fast curve, which is right
+// for a handler that acks within milliseconds and wrong for anything else —
+// the property that makes WithAckPolicy necessary rather than decorative.
+func TestConsumerDefaultsToTheFastAckPolicy(t *testing.T) {
+	ctx := t.Context()
+	js := tests.NatsJetStream(t)
+	mustStream(ctx, t, js)
+
+	info := consumerInfo(ctx, t, js, "default-policy")
+
+	assert.Equal(t, utils.DefaultAckPolicy.FirstDeadline(), info.Config.AckWait)
+	assert.Equal(t, []time.Duration(utils.DefaultAckPolicy), info.Config.BackOff)
+}
+
+func consumerInfo(ctx context.Context, t *testing.T, js jetstream.JetStream, durable string, opts ...utils.ConsumerOption) *jetstream.ConsumerInfo {
+	t.Helper()
+	con := utils.MustGetPullSubscriber(ctx, js, "test-stream", "test.subject", durable, opts...)
+	info, err := con.Info(ctx)
+	require.NoError(t, err)
+	return info
+}
+
+func mustStream(ctx context.Context, t *testing.T, js jetstream.JetStream) {
+	t.Helper()
+	_, err := js.CreateOrUpdateStream(ctx, jetstream.StreamConfig{
+		Name:     "test-stream",
+		Subjects: []string{"test.subject"},
+	})
+	require.NoError(t, err)
+}

--- a/pkg/smtpsender/guard.go
+++ b/pkg/smtpsender/guard.go
@@ -1,0 +1,101 @@
+package smtpsender
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+// sendGuard admits at most one SMTP transaction per Envelope stored on the
+// sending stream.
+//
+// A correct ack deadline (see sendAckPolicy) keeps the server from redelivering
+// an Envelope that is merely slow to send, but it cannot rule redelivery out:
+// a worker that dies mid-send, a relay that hangs past the deadline, or any of
+// the MaxDeliver retries hands the same stored message to another worker, and
+// the mail goes out twice. The guard is what makes that harmless — a claim
+// taken before the transaction starts, so two workers holding the same message
+// at the same time still produce one email (#425).
+type sendGuard interface {
+	// Claim reserves key for the caller. It reports false when the key was
+	// already claimed, which means another delivery of the same stored message
+	// is being — or has already been — sent.
+	Claim(ctx context.Context, key string) (bool, error)
+}
+
+const (
+	// sendGuardBucket holds one entry per Envelope handed to SMTP.
+	sendGuardBucket = "kannon-sent-envelopes"
+
+	// sendGuardTTL is how long a claim is remembered. It has to outlast the
+	// window in which the server can still redeliver a message — the whole
+	// sendAckPolicy curve, plus the time a dead worker takes to be replaced —
+	// and no longer, since every entry is dead weight after that.
+	sendGuardTTL = 1 * time.Hour
+)
+
+// mustGetSendGuard opens the guard's key/value bucket, exiting on failure the
+// same way a missing stream does: a sender that cannot deduplicate its own
+// redeliveries is a sender that re-sends live email.
+func mustGetSendGuard(ctx context.Context, js jetstream.JetStream) sendGuard {
+	kv, err := js.CreateOrUpdateKeyValue(ctx, jetstream.KeyValueConfig{
+		Bucket:      sendGuardBucket,
+		Description: "Envelopes already handed to SMTP, so a redelivery does not send them again",
+		TTL:         sendGuardTTL,
+		Storage:     jetstream.FileStorage,
+		Replicas:    1,
+	})
+	if err != nil {
+		slog.Error("cannot create send guard bucket", "bucket", sendGuardBucket, "err", err)
+		os.Exit(1)
+	}
+
+	slog.Info("send guard ready", "bucket", sendGuardBucket)
+	return &kvSendGuard{kv: kv}
+}
+
+// kvSendGuard keeps the claims in a JetStream key/value bucket, so the guard
+// holds across the worker pool of one process, across replicas, and across
+// restarts — which is exactly when a redelivery happens.
+type kvSendGuard struct {
+	kv jetstream.KeyValue
+}
+
+func (g *kvSendGuard) Claim(ctx context.Context, key string) (bool, error) {
+	// Create is the atomic primitive: it fails rather than overwriting, so of
+	// two workers racing on the same Envelope exactly one is told to send.
+	if _, err := g.kv.Create(ctx, key, nil); err != nil {
+		if errors.Is(err, jetstream.ErrKeyExists) {
+			return false, nil
+		}
+		return false, fmt.Errorf("cannot claim %s: %w", key, err)
+	}
+	return true, nil
+}
+
+// sendKey names the unit the guard protects: one stored message on the sending
+// stream, which is one intended SMTP transaction.
+//
+// The stream sequence is what makes this precise. Every redelivery of a message
+// carries the same sequence, so they collapse onto one key; a Delivery that is
+// legitimately dispatched again after a transient failure is a *new* message
+// with a new sequence, and is sent again as it should be. The Envelope's email
+// ID is folded in as well, so a sequence reused by a recreated stream cannot
+// suppress an unrelated Delivery.
+func sendKey(msg jetstream.Msg, emailID string) (string, error) {
+	meta, err := msg.Metadata()
+	if err != nil {
+		return "", fmt.Errorf("cannot read message metadata: %w", err)
+	}
+
+	sum := sha256.Sum256([]byte(emailID))
+	return strconv.FormatUint(meta.Sequence.Stream, 10) + "." + base64.RawURLEncoding.EncodeToString(sum[:8]), nil
+}

--- a/pkg/smtpsender/smtpsender.go
+++ b/pkg/smtpsender/smtpsender.go
@@ -33,7 +33,27 @@ type smtpSender struct {
 	sender    smtp.Sender
 	publisher publisher.Publisher
 	js        jetstream.JetStream
+	guard     sendGuard
 	cfg       Config
+}
+
+// sendAckPolicy is the ack deadline curve of the sending consumer, and it is
+// deliberately much longer than utils.DefaultAckPolicy: this worker acks only
+// once the SMTP transaction has returned, so the first deadline has to outlast
+// the slowest transaction worth waiting for — internal/smtp gives a single
+// delivery attempt two minutes, and falls back across MX hosts.
+//
+// A shorter deadline does not merely retry bookkeeping: the server hands the
+// Envelope to a second worker while the first is still talking to the relay,
+// and the recipient receives the email twice. That is #425, where the curve
+// left behind by #396 gave every SMTP transaction one second to complete.
+//
+// The later entries keep an Envelope no worker can settle from cycling: the
+// last one governs every attempt up to MaxDeliver.
+var sendAckPolicy = utils.AckPolicy{
+	2 * time.Minute,
+	5 * time.Minute,
+	15 * time.Minute,
 }
 
 // New constructs the SMTPSender runnable, loading its slice of configuration
@@ -63,9 +83,16 @@ func (s *smtpSender) Run(ctx context.Context) error {
 		Info("Starting SMTPSender Service")
 	mustConfigureStatsJS(ctx, s.js)
 
-	consumer := utils.MustGetPullSubscriber(ctx, s.js, "kannon-sending", "kannon.sending", "kannon-sending-pool")
+	s.guard = mustGetSendGuard(ctx, s.js)
+	consumer := s.mustSendingConsumer(ctx)
 
 	return s.handleSend(ctx, consumer)
+}
+
+// mustSendingConsumer subscribes to the Envelopes waiting to be transmitted.
+func (s *smtpSender) mustSendingConsumer(ctx context.Context) jetstream.Consumer {
+	return utils.MustGetPullSubscriber(ctx, s.js, "kannon-sending", "kannon.sending", "kannon-sending-pool",
+		utils.WithAckPolicy(sendAckPolicy))
 }
 
 func (s *smtpSender) handleSend(ctx context.Context, consumer jetstream.Consumer) error {
@@ -77,7 +104,7 @@ func (s *smtpSender) handleSend(ctx context.Context, consumer jetstream.Consumer
 
 	con, err := consumer.Consume(func(msg jetstream.Msg) {
 		tasks.RunTask(func() {
-			err := s.handleMessage(msg)
+			err := s.handleMessage(ctx, msg)
 			s.handleMsgAck(msg, err)
 		})
 	})
@@ -106,12 +133,17 @@ func (s *smtpSender) handleMsgAck(msg jetstream.Msg, err error) {
 	}
 }
 
-func (s *smtpSender) handleMessage(msg jetstream.Msg) error {
+func (s *smtpSender) handleMessage(ctx context.Context, msg jetstream.Msg) error {
 	data := &msgtypes.EmailToSend{}
 	err := proto.Unmarshal(msg.Data(), data)
 	if err != nil {
 		return err
 	}
+
+	if !s.claimSend(ctx, msg, data) {
+		return nil
+	}
+
 	sendErr := s.sender.Send(data.ReturnPath, data.To, data.Body)
 	if sendErr != nil {
 		slog.Info(fmt.Sprintf("Cannot send email %v - %v: %v", utils.ObfuscateEmail(data.To), data.EmailId, sendErr.Error()))
@@ -119,6 +151,39 @@ func (s *smtpSender) handleMessage(msg jetstream.Msg) error {
 	}
 	slog.Info(fmt.Sprintf("Email delivered: %v - %v", utils.ObfuscateEmail(data.To), data.EmailId))
 	return s.handleSendSuccess(data)
+}
+
+// claimSend reports whether this delivery of the Envelope is the one allowed
+// to talk to SMTP. A delivery that loses the claim is a redelivery of an
+// Envelope already handed to a relay: it is acknowledged and dropped, because
+// re-sending it would put the same email in the recipient's mailbox twice.
+//
+// The guard fails open, including when it was never wired (Run always wires
+// it): it exists to make a rare redelivery harmless, and a bucket that cannot
+// be reached is not a reason to stop sending mail — a duplicate is a far
+// smaller failure than a batch that never leaves.
+func (s *smtpSender) claimSend(ctx context.Context, msg jetstream.Msg, data *msgtypes.EmailToSend) bool {
+	if s.guard == nil {
+		return true
+	}
+
+	key, err := sendKey(msg, data.EmailId)
+	if err != nil {
+		slog.Error("cannot derive send guard key, sending anyway", "email_id", data.EmailId, "err", err)
+		return true
+	}
+
+	claimed, err := s.guard.Claim(ctx, key)
+	if err != nil {
+		slog.Error("send guard unavailable, sending anyway", "email_id", data.EmailId, "err", err)
+		return true
+	}
+
+	if !claimed {
+		slog.Warn("skipping redelivered envelope: already handed to SMTP",
+			"email_id", data.EmailId, "to", utils.ObfuscateEmail(data.To))
+	}
+	return claimed
 }
 
 func (s *smtpSender) handleSendSuccess(data *msgtypes.EmailToSend) error {

--- a/pkg/smtpsender/smtpsender_test.go
+++ b/pkg/smtpsender/smtpsender_test.go
@@ -1,0 +1,245 @@
+package smtpsender
+
+import (
+	"context"
+	"encoding/base64"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/kannon-email/kannon/internal/smtp"
+	"github.com/kannon-email/kannon/internal/tests"
+	"github.com/kannon-email/kannon/internal/utils"
+	msgtypes "github.com/kannon-email/kannon/proto/kannon/mailer/types"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+)
+
+// The sending consumer acks only once the SMTP transaction has returned, so
+// the deadline it is given is the deadline of a real email delivery. #396 set
+// a BackOff curve on every consumer, and BackOff overrides AckWait: the
+// deadline silently became one second and every slower send went out twice
+// (#425). This is that regression, expressed against a real server — the
+// consumer is read back from NATS, so what is asserted is the configuration
+// the server actually holds, not the one requested.
+func TestSendingConsumerAckDeadlineOutlastsAnSMTPTransaction(t *testing.T) {
+	ctx := t.Context()
+	js := tests.NatsJetStream(t)
+	mustSendingStream(ctx, t, js)
+
+	s := &smtpSender{js: js}
+	info, err := s.mustSendingConsumer(ctx).Info(ctx)
+	require.NoError(t, err)
+
+	assert.GreaterOrEqual(t, info.Config.AckWait, 60*time.Second,
+		"an SMTP transaction cannot be acknowledged inside this deadline, so the server redelivers it and the email is sent again")
+	assert.Equal(t, sendAckPolicy.FirstDeadline(), info.Config.AckWait)
+
+	require.NotEmpty(t, info.Config.BackOff)
+	assert.Equal(t, info.Config.AckWait, info.Config.BackOff[0],
+		"BackOff[0] is the deadline of a first delivery: an AckWait that disagrees with it is not the deadline in force")
+}
+
+// Two deliveries of one stored Envelope are one email. This is the layer that
+// holds when the deadline does not: a worker that dies mid-send, a relay stuck
+// past the whole backoff curve, or any redelivery up to MaxDeliver.
+func TestRedeliveredEnvelopeIsSentOnce(t *testing.T) {
+	ctx := t.Context()
+	js := tests.NatsJetStream(t)
+
+	sender := &countingSender{}
+	pub := &recordingPublisher{}
+	s := &smtpSender{sender: sender, publisher: pub, js: js, guard: mustGetSendGuard(ctx, js)}
+
+	msg := envelopeMsg(t, "duplicate@example.com", 42)
+
+	require.NoError(t, s.handleMessage(ctx, msg))
+	require.NoError(t, s.handleMessage(ctx, msg))
+
+	assert.Equal(t, 1, sender.count(), "the same stored Envelope must reach the relay once")
+	assert.Equal(t, []string{"kannon.stats.delivered"}, pub.subjects(),
+		"a suppressed redelivery must not report a second Delivered outcome either")
+}
+
+// A Delivery that failed transiently is dispatched again by the Dispatcher as a
+// new message on the stream, and that one is a genuine send: the guard keys on
+// the stored message, not on the Delivery, so it must not swallow the retry.
+func TestRedispatchedEnvelopeIsSentAgain(t *testing.T) {
+	ctx := t.Context()
+	js := tests.NatsJetStream(t)
+
+	sender := &countingSender{}
+	pub := &recordingPublisher{}
+	s := &smtpSender{sender: sender, publisher: pub, js: js, guard: mustGetSendGuard(ctx, js)}
+
+	const to = "retried@example.com"
+	require.NoError(t, s.handleMessage(ctx, envelopeMsg(t, to, 1)))
+	require.NoError(t, s.handleMessage(ctx, envelopeMsg(t, to, 2)))
+
+	assert.Equal(t, 2, sender.count())
+}
+
+// End to end against a real consumer: a deadline too short for the handler —
+// the shape #425 ran in production — does make the server redeliver, and the
+// guard is what keeps that from reaching the relay twice.
+func TestShortAckDeadlineRedeliversButDoesNotResend(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	js := tests.NatsJetStream(t)
+	mustSendingStream(ctx, t, js)
+
+	sender := &blockingSender{released: make(chan struct{})}
+	pub := &recordingPublisher{}
+	guard := &countingGuard{inner: mustGetSendGuard(ctx, js)}
+	s := &smtpSender{sender: sender, publisher: pub, js: js, guard: guard, cfg: Config{MaxJobs: 4}}
+
+	consumer := utils.MustGetPullSubscriber(ctx, js, "kannon-sending", "kannon.sending", "kannon-sending-pool",
+		utils.WithAckPolicy(utils.AckPolicy{200 * time.Millisecond}))
+
+	data, err := proto.Marshal(envelope("slow@example.com"))
+	require.NoError(t, err)
+	_, err = js.Publish(ctx, "kannon.sending", data)
+	require.NoError(t, err)
+
+	stopped := make(chan error, 1)
+	go func() {
+		stopped <- s.handleSend(ctx, consumer)
+	}()
+
+	// The handler is still inside the SMTP transaction, so the ack deadline
+	// elapses and the server hands the same Envelope to a second worker.
+	require.Eventually(t, func() bool { return guard.count() >= 2 }, 10*time.Second, 10*time.Millisecond,
+		"expected the server to redeliver the Envelope while the first send was in flight")
+
+	close(sender.released)
+	assert.Eventually(t, func() bool { return len(pub.subjects()) == 1 }, 10*time.Second, 10*time.Millisecond)
+
+	cancel()
+	assert.ErrorIs(t, <-stopped, context.Canceled)
+
+	assert.Equal(t, 1, sender.count(), "the redelivery must not reach the relay")
+	assert.Equal(t, []string{"kannon.stats.delivered"}, pub.subjects())
+}
+
+func mustSendingStream(ctx context.Context, t *testing.T, js jetstream.JetStream) {
+	t.Helper()
+	_, err := js.CreateOrUpdateStream(ctx, jetstream.StreamConfig{
+		Name:     "kannon-sending",
+		Subjects: []string{"kannon.sending"},
+	})
+	require.NoError(t, err)
+}
+
+func envelope(to string) *msgtypes.EmailToSend {
+	emailID := "<" + base64.URLEncoding.EncodeToString([]byte(to)) + "/msg_test@example.com>"
+	return &msgtypes.EmailToSend{
+		From:       "sender@example.com",
+		To:         to,
+		Body:       []byte("body"),
+		EmailId:    emailID,
+		ReturnPath: "bump_" + base64.URLEncoding.EncodeToString([]byte(to)) + "+msg_test@example.com",
+	}
+}
+
+// envelopeMsg is one Envelope as it arrives from the stream, stored at the
+// given sequence. Two messages sharing a sequence are two deliveries of the
+// same stored message; different sequences are different messages.
+func envelopeMsg(t *testing.T, to string, seq uint64) jetstream.Msg {
+	t.Helper()
+	data, err := proto.Marshal(envelope(to))
+	require.NoError(t, err)
+	return &fakeMsg{data: data, seq: seq}
+}
+
+// fakeMsg stands in for a JetStream message. jetstream.Msg is embedded to pick
+// up the parts of the interface the handler does not touch; calling one of
+// those panics loudly rather than passing silently.
+type fakeMsg struct {
+	jetstream.Msg
+	data []byte
+	seq  uint64
+}
+
+func (m *fakeMsg) Data() []byte { return m.data }
+
+func (m *fakeMsg) Metadata() (*jetstream.MsgMetadata, error) {
+	return &jetstream.MsgMetadata{
+		Stream:   "kannon-sending",
+		Sequence: jetstream.SequencePair{Stream: m.seq},
+	}, nil
+}
+
+type countingSender struct {
+	mu    sync.Mutex
+	calls int
+}
+
+func (s *countingSender) SenderName() string { return "countingSender" }
+
+func (s *countingSender) Send(_, _ string, _ []byte) smtp.SenderError {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls++
+	return nil
+}
+
+func (s *countingSender) count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.calls
+}
+
+// blockingSender holds the SMTP transaction open until the test releases it,
+// standing in for a relay slower than the consumer's ack deadline.
+type blockingSender struct {
+	countingSender
+	released chan struct{}
+}
+
+func (s *blockingSender) Send(from, to string, body []byte) smtp.SenderError {
+	err := s.countingSender.Send(from, to, body)
+	<-s.released
+	return err
+}
+
+type recordingPublisher struct {
+	mu   sync.Mutex
+	subj []string
+}
+
+func (p *recordingPublisher) Publish(subj string, _ []byte) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.subj = append(p.subj, subj)
+	return nil
+}
+
+func (p *recordingPublisher) subjects() []string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return append([]string(nil), p.subj...)
+}
+
+// countingGuard counts how many deliveries reached the guard, which is how a
+// test observes a redelivery that never reaches the relay.
+type countingGuard struct {
+	inner  sendGuard
+	mu     sync.Mutex
+	claims int
+}
+
+func (g *countingGuard) Claim(ctx context.Context, key string) (bool, error) {
+	g.mu.Lock()
+	g.claims++
+	g.mu.Unlock()
+	return g.inner.Claim(ctx, key)
+}
+
+func (g *countingGuard) count() int {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.claims
+}


### PR DESCRIPTION
Fixes #425

## The cause

`MustGetPullSubscriber` applied one redelivery curve to every consumer:

```go
const consumerAckWait = 30 * time.Second
var consumerBackOff = []time.Duration{1s, 5s, 30s, 1m, 5m}
```

In JetStream `BackOff` **overrides** `AckWait` — the server literally rewrites
`AckWait` to `BackOff[0]` when it creates the consumer
(`server/consumer.go`: `config.AckWait = config.BackOff[0]`), and reuses the
last entry of the curve for every attempt past its end. So the deadline for a
first delivery was **1 second**, not 30, and the `consumerAckWait` comment
describing itself as the base ack timeout — and as the delay applied once the
curve is exhausted — was wrong on both counts.

`kannon-sending-pool` acks only *after* the SMTP transaction returns, so any
send slower than a second was treated as unacknowledged: the server handed the
Envelope to a second worker and **the email was sent again**. Hence the ~1 in 6
duplicate deliveries, with the gaps between duplicates landing exactly on
1s / 5s / 30s.

## What changes

**1. The ack deadline is per-consumer.** `internal/utils` now exposes an
`AckPolicy` — a single per-attempt curve rather than an `AckWait` sitting next
to a `BackOff`, precisely because setting one without the other says nothing.
`applyTo` writes both from the same source, so the config states the deadline it
actually gets. Callers that pass no option get `DefaultAckPolicy`, which is
#396's curve unchanged: the dispatcher and stats consumers keep it.

The sending consumer opts into its own (`sendAckPolicy`, `pkg/smtpsender`):
`{2m, 5m, 15m}` — the first entry outlasts an SMTP transaction, which
`internal/smtp` caps at two minutes per delivery attempt.

**2. The send is idempotent.** A correct deadline removes the cause but not the
class: a pod restart mid-send, a relay stuck past the whole curve, or any of the
`MaxDeliver` retries still hands the same stored Envelope to a second worker.
The sender now claims an Envelope before handing it to SMTP, with an atomic
`Create` in a JetStream key/value bucket (`kannon-sent-envelopes`, entries
expiring after an hour); the delivery that loses the claim is acked and dropped.

The key is the **stream sequence** of the message being delivered, folded
together with the Envelope's email ID. Every redelivery of a message carries the
same sequence, so they collapse onto one key — while a Delivery legitimately
re-dispatched after a transient failure is a *new* message with a new sequence
and is sent again, as it must be. (Keying on the Delivery would need a time
window, and no window is correct: `NextRetryAt()` is measured from the Batch's
original scheduled time, so a retry can be due immediately.)

The guard fails open: if the bucket cannot be reached the send proceeds, because
a duplicate is a smaller failure than a batch that never leaves.

### Why not the Pool, why not `Nats-Msg-Id`

Written up in [ADR 0004](docs/adr/0004-send-idempotency-guard.md), in short:

- *Checking* the Pool row only catches redeliveries arriving after the Delivered
  stat has been consumed. The measured duplicates were 1s and 5s apart — the
  second send starts while the first is still talking to the relay, with the row
  still in `sending` and indistinguishable from a first attempt.
- *Claiming* the Pool row closes that race but splits ownership of the Pool
  lifecycle (today the Dispatcher owns every transition) and gives the
  SMTPSender a database dependency it does not have — `--run-sender` runs with
  no `database_url` at all today, so it would break split deployments.
- `Nats-Msg-Id` deduplicates *publishes*. A redelivery to a consumer is not a
  publish, so a message id on `kannon.sending` would not have prevented a single
  one of these duplicate emails. Worth adding against duplicate *dispatch*, which
  is a different failure and needs headers on the publisher interface.

Known trade-off, documented in the ADR: a delivery that gets past the claim and
then dies (or cannot publish its outcome stat) is not retried by its own
redelivery any more. Its Pool row is stranded in `sending` by such a failure with
or without the guard — what changes is that the email does not go out twice on
the way there.

## Testing

`internal/tests.NatsJetStream(t)` starts the embedded NATS server the binary
itself can run, so consumer and KV behaviour under test is the real thing
without a Docker round trip. New tests:

- `TestSendingConsumerAckDeadlineOutlastsAnSMTPTransaction` reads the consumer
  back from the server and asserts the effective deadline is ≥ 60s and that
  `BackOff[0]` agrees with it. This is the test that would have failed the day
  #396 landed.
- `TestAckPolicyIsTheDeadlineTheServerHolds` / `TestConsumerDefaultsToTheFastAckPolicy`
  pin the mechanism and the unchanged default.
- `TestRedeliveredEnvelopeIsSentOnce` delivers the same stored message twice to
  the handler: one SMTP transaction, one `delivered` stat.
- `TestRedispatchedEnvelopeIsSentAgain` guards the opposite direction — a new
  message for the same Delivery is sent.
- `TestShortAckDeadlineRedeliversButDoesNotResend` runs the real consumer with a
  200ms deadline and a handler that blocks: the server does redeliver (the test
  waits on that event, not on a sleep), and the guard keeps it to one send and
  one stat. Reverting the guard makes it fail with 2 sends and 2 stats; it takes
  ~0.3s and was run repeatedly for stability.

Local results: `go test ./... -race -short` passes, `go test ./e2e -race` passes
(the sender's KV bucket is exercised against the real NATS container there),
`golangci-lint run` reports 0 issues, `go tool deadcode -test ./...` is clean.

## Follow-up spotted, not done here

The default curve's 1s first deadline is also short for the stats consumers,
whose handler is a database write: a write slower than a second is redelivered
and the stat row inserted twice. Out of scope here — #396's hot loop was on those
consumers — but worth its own issue.
