### PR TITLE
fix(stats): make stat insertion idempotent under JetStream redelivery

### DIFF
--- a/internal/db/statistics.sql
+++ b/internal/db/statistics.sql
@@ -1,5 +1,12 @@
 -- name: InsertStat :exec
-INSERT INTO stats (email, message_id, type, timestamp, domain, data) VALUES  (@email, @message_id, @type, @timestamp, @domain, @data);
+-- The unique index on (email, message_id, domain, type, timestamp) is what makes
+-- this insert idempotent, and the timestamp is set by the publisher: a JetStream
+-- redelivery of the same event carries the same one, so it collides with the row
+-- the first delivery already wrote. DO NOTHING turns that second write into the
+-- no-op it should be. Without it the insert raises a unique violation, the handler
+-- Naks, and the event is redelivered until MaxDeliver gives up on it.
+INSERT INTO stats (email, message_id, type, timestamp, domain, data) VALUES  (@email, @message_id, @type, @timestamp, @domain, @data)
+ON CONFLICT (email, message_id, domain, type, timestamp) DO NOTHING;
 
 -- name: QueryStats :many
 SELECT * FROM stats

--- a/internal/db/statistics.sql.go
+++ b/internal/db/statistics.sql.go
@@ -45,6 +45,7 @@ func (q *Queries) DeleteStatsOlderThan(ctx context.Context, before pgtype.Timest
 
 const insertStat = `-- name: InsertStat :exec
 INSERT INTO stats (email, message_id, type, timestamp, domain, data) VALUES  ($1, $2, $3, $4, $5, $6)
+ON CONFLICT (email, message_id, domain, type, timestamp) DO NOTHING
 `
 
 type InsertStatParams struct {
@@ -56,6 +57,12 @@ type InsertStatParams struct {
 	Data      *pbtypes.StatsData
 }
 
+// The unique index on (email, message_id, domain, type, timestamp) is what makes
+// this insert idempotent, and the timestamp is set by the publisher: a JetStream
+// redelivery of the same event carries the same one, so it collides with the row
+// the first delivery already wrote. DO NOTHING turns that second write into the
+// no-op it should be. Without it the insert raises a unique violation, the handler
+// Naks, and the event is redelivered until MaxDeliver gives up on it.
 func (q *Queries) InsertStat(ctx context.Context, arg InsertStatParams) error {
 	_, err := q.db.Exec(ctx, insertStat,
 		arg.Email,

--- a/internal/stats/inmem_repo.go
+++ b/internal/stats/inmem_repo.go
@@ -26,6 +26,14 @@ func (r *InMemRepository) Insert(_ context.Context, stat *Stat) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
+	// Mirrors the unique index the real table carries: re-inserting an event
+	// already stored is a no-op, not a second row.
+	for _, s := range r.stats {
+		if sameEvent(s, stat) {
+			return nil
+		}
+	}
+
 	stat.ID = r.nextID
 	r.nextID++
 
@@ -37,6 +45,17 @@ func (r *InMemRepository) Insert(_ context.Context, stat *Stat) error {
 	}
 	r.stats = append(r.stats, &cp)
 	return nil
+}
+
+// sameEvent reports whether two stats describe the same event, using the columns
+// the table's unique index is built on. The payload is deliberately not part of
+// the comparison: it is not part of the index either.
+func sameEvent(a, b *Stat) bool {
+	return a.Email == b.Email &&
+		a.MessageID == b.MessageID &&
+		a.Domain == b.Domain &&
+		a.Type == b.Type &&
+		a.Timestamp.Equal(b.Timestamp)
 }
 
 func (r *InMemRepository) Query(_ context.Context, domain string, tr TimeRange, page Pagination) ([]*Stat, error) {

--- a/internal/stats/repospec.go
+++ b/internal/stats/repospec.go
@@ -21,6 +21,9 @@ func RunRepoSpec(t *testing.T, repo Repository) {
 	t.Run("Insert+Query", func(t *testing.T) {
 		testInsertAndQuery(t, repo)
 	})
+	t.Run("Insert/IsIdempotent", func(t *testing.T) {
+		testInsertIsIdempotent(t, repo)
+	})
 	t.Run("Query/Pagination", func(t *testing.T) {
 		testQueryPagination(t, repo)
 	})
@@ -69,6 +72,51 @@ func testInsertAndQuery(t *testing.T, repo Repository) {
 	assert.Equal(t, "user@example.com", results[0].Email)
 	assert.Equal(t, "msg-001", results[0].MessageID)
 	assert.Equal(t, domain, results[0].Domain)
+}
+
+// A stat event carries the timestamp its publisher stamped on it, so a message
+// redelivered by JetStream — because the ack deadline elapsed while this very
+// insert was in flight — arrives identical to the one already stored. Storing it
+// again would inflate the recipient's history with an event that never happened
+// twice, so the second insert must succeed and change nothing.
+func testInsertIsIdempotent(t *testing.T, repo Repository) {
+	ctx := t.Context()
+	domain := fmt.Sprintf("insert-idempotent-%d.test", time.Now().UnixNano())
+	now := time.Date(2026, 1, 15, 10, 30, 0, 0, time.UTC)
+
+	stat := func() *Stat {
+		return &Stat{
+			Type:      TypeDelivered,
+			Email:     "user@example.com",
+			MessageID: "msg-001",
+			Domain:    domain,
+			Timestamp: now,
+			Data:      deliveredData,
+		}
+	}
+
+	require.NoError(t, repo.Insert(ctx, stat()))
+	require.NoError(t, repo.Insert(ctx, stat()))
+
+	tr := TimeRange{Start: now.Add(-time.Hour), Stop: now.Add(time.Hour)}
+	results, err := repo.Query(ctx, domain, tr, Pagination{Limit: 10, Offset: 0})
+	require.NoError(t, err)
+	assert.Len(t, results, 1)
+
+	count, err := repo.Count(ctx, domain, tr)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), count)
+
+	// A genuine second event of the same type is a different moment in time, and
+	// must still be stored: the guard is against redelivery, not against a
+	// recipient opening the same email twice.
+	second := stat()
+	second.Timestamp = now.Add(time.Minute)
+	require.NoError(t, repo.Insert(ctx, second))
+
+	count, err = repo.Count(ctx, domain, tr)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), count)
 }
 
 func testQueryPagination(t *testing.T, repo Repository) {

--- a/internal/stats/service_test.go
+++ b/internal/stats/service_test.go
@@ -1,6 +1,7 @@
 package stats_test
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -94,8 +95,10 @@ func TestQueryStats_FiltersByDomain(t *testing.T) {
 	now := time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC)
 	tr := stats.TimeRange{Start: now.Add(-time.Hour), Stop: now.Add(time.Hour)}
 
-	for _, domain := range []string{"a.com", "b.com", "a.com"} {
-		s := stats.NewStat("u@"+domain, "msg", domain, now, &types.StatsData{
+	// Distinct message ids: two events of the same type, for the same recipient,
+	// at the same instant are the same event as far as the store is concerned.
+	for i, domain := range []string{"a.com", "b.com", "a.com"} {
+		s := stats.NewStat("u@"+domain, fmt.Sprintf("msg-%d", i), domain, now, &types.StatsData{
 			Data: &types.StatsData_Accepted{},
 		})
 		if err := svc.InsertStat(ctx, s); err != nil {
@@ -195,8 +198,8 @@ func TestCleanup(t *testing.T) {
 	old := now.Add(-48 * time.Hour)
 	recent := now.Add(-time.Hour)
 
-	for _, ts := range []time.Time{old, old, recent} {
-		s := stats.NewStat("u@d.com", "msg", "d.com", ts, &types.StatsData{
+	for i, ts := range []time.Time{old, old, recent} {
+		s := stats.NewStat("u@d.com", fmt.Sprintf("msg-%d", i), "d.com", ts, &types.StatsData{
 			Data: &types.StatsData_Delivered{},
 		})
 		if err := svc.InsertStat(ctx, s); err != nil {


### PR DESCRIPTION
Follow-up to the hole flagged at the end of #427: the stats consumers still run on the default 1s first-attempt ack deadline, so a DB write slower than that gets the event redelivered.

## What was wrong

`stats` has carried a unique index on `(email, message_id, domain, type, timestamp)` since the table was introduced in `20240421080953_add-stats-to-database.sql`, and that index is exactly the right guard: a stat event carries the timestamp its *publisher* stamped on it, so a redelivered message is byte-identical to the row the first delivery already wrote. That is also what distinguishes this from #425 — the duplicate deliveries measured there had *different* timestamps, because the emails were genuinely re-sent.

What was missing is the other half: `InsertStat` never said what to do on conflict. The redelivery therefore raised a unique violation, `handleStatsMsg` logged an error and `Nak`'d, and the event came back until `MaxDeliver` gave up on it — a hundred futile round trips and a stream of errors for a write that had already succeeded.

`ON CONFLICT DO NOTHING` turns the second write into the no-op it should be, and the handler acks.

## Also in here

The in-memory repository happily stored duplicates, i.e. it modelled a table looser than the real one. It now mirrors the index, which is what makes the new spec case meaningful for both implementations. Two service tests were relying on that looseness — their fixtures built rows Postgres would have rejected outright — and now use distinct message ids.

## Testing

New case in the shared repo spec (`Insert/IsIdempotent`), so it runs against both the in-memory repository and the sqlc one on a real Postgres: inserting the same event twice leaves one row, while the same event at a later instant is still stored — the guard is against redelivery, not against a recipient opening the same email twice.

`go test ./... -race -short` passes, `internal/db` (testcontainers) passes, `make lint` reports 0 issues.

## Not covered by this

An index cannot protect `aggregated_stats`: that path increments a counter rather than writing a row per event, so a redelivery on the `kannon-aggregated-stats` consumer would silently inflate it, and no constraint can tell that apart from a legitimate second event. Closing that needs an idempotency key — the stream sequence, as the sender guard added in #427 already does, or a dedup table. Worth noting it has never actually happened: there is not a single exact-duplicate row in the production stats table, which is the observable signature of a stats redelivery. Weighed a NATS KV guard here too, mirroring #427's, but for a counter that only feeds a dashboard chart the extra dependency and the doubled KV write volume on every stats event isn't proportionate to a risk that has yet to be observed — a cheaper option worth considering first is simply widening this consumer's ack policy the way #427 did for the sender.