### PR TITLE
feat(mailer): carry a one-click unsubscribe endpoint (RFC 8058)

### DIFF
--- a/.proto/kannon/mailer/apiv1/mailerapiv1.proto
+++ b/.proto/kannon/mailer/apiv1/mailerapiv1.proto
@@ -30,6 +30,10 @@ message SendHTMLReq {
   // imposes no restriction of its own and resolves to the Domain's ceiling
   // (ADR 0003). A Mode above that ceiling fails the call.
   optional pkg.kannon.tracking.types.TrackingPolicy tracking = 10;
+  // The sender's own one-click unsubscribe endpoint, emitted as
+  // List-Unsubscribe + List-Unsubscribe-Post on every Delivery of this Batch.
+  // Omitted when absent: Kannon never adds one of its own.
+  optional pkg.kannon.mailer.types.OneClickUnsubscribe one_click_unsubscribe = 11;
 }
 
 message SendTemplateReq {
@@ -45,6 +49,10 @@ message SendTemplateReq {
   // imposes no restriction of its own and resolves to the Domain's ceiling
   // (ADR 0003). A Mode above that ceiling fails the call.
   optional pkg.kannon.tracking.types.TrackingPolicy tracking = 10;
+  // The sender's own one-click unsubscribe endpoint, emitted as
+  // List-Unsubscribe + List-Unsubscribe-Post on every Delivery of this Batch.
+  // Omitted when absent: Kannon never adds one of its own.
+  optional pkg.kannon.mailer.types.OneClickUnsubscribe one_click_unsubscribe = 11;
 }
 
 message SendRes {
@@ -77,6 +85,10 @@ message RejectedRecipient {
   //   unsupported_tracking_mode  the Recipient stated a Tracking Mode this
   //                              build will not act on — the reserved
   //                              `pseudonymous`, or a value from a newer schema
+  //   unsubscribe_url_unresolved this Recipient's fields leave a placeholder in
+  //                              one_click_unsubscribe.url_template unresolved,
+  //                              so its unsubscribe endpoint would be advertised
+  //                              as authenticated while being unreachable
   //
   // Treat an unrecognised value as a refusal of unknown cause: the set grows as
   // new causes are added.

--- a/.proto/kannon/mailer/types/send.proto
+++ b/.proto/kannon/mailer/types/send.proto
@@ -31,3 +31,36 @@ message Headers {
   repeated string to = 1;
   repeated string cc = 2;
 }
+
+// OneClickUnsubscribe is the sender's own unsubscribe endpoint, carried in the
+// List-Unsubscribe and List-Unsubscribe-Post headers (RFC 8058).
+//
+// Kannon personalises, emits and DKIM-signs it, and does nothing else with it:
+// it never calls the endpoint, keeps no suppression list, and records no
+// engagement when a recipient uses it. The URL travels in a header, so it is
+// never rewritten for click tracking.
+//
+// Stated per Batch. There is no Domain-level default and no Recipient-level
+// override — an unsubscribe on a password reset offers something the sender
+// cannot honour, and personalising the template is already what makes the
+// endpoint per-Recipient.
+message OneClickUnsubscribe {
+  // The https URL of the endpoint, as a template.
+  //
+  // The endpoint MUST accept POST with body `List-Unsubscribe=One-Click` and
+  // unsubscribe the recipient with no further confirmation. Supplying a URL
+  // here asserts that: Kannon cannot verify it, and a message advertising
+  // one-click that does not honour it is worse than one that never advertised
+  // it, since the recipient believes they have unsubscribed.
+  //
+  // `{{ field }}` placeholders are substituted per Delivery from the
+  // Recipient's fields, plus `email`, which Kannon supplies as the Recipient's
+  // address unless the caller passes a field of that name itself. Substituted
+  // values are percent-encoded, so pass raw values rather than pre-encoded
+  // ones.
+  //
+  // A template that is unparseable or not https fails the whole call. A
+  // Recipient whose fields leave a placeholder unresolved is Rejected on its
+  // own, with reason `unsubscribe_url_unresolved`.
+  string url_template = 1;
+}

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -50,6 +50,12 @@ A pair of Tracking Modes — one governing opens, one governing links — expres
 A Policy states what *may* be observed, not what must be: the authored HTML may keep a single link out of click tracking with a `data-no-track` attribute on its `<a>` tag. That is an authoring decision taken inside an already-resolved Policy — it narrows what that Delivery's Policy allows and can never widen it — not a fourth level of the cascade, and it is stripped from the delivered HTML.
 _Avoid_: Tracking Settings, Tracking Config, Consent (a Policy conveys a consent decision taken elsewhere; it is not itself the consent, and Kannon never stores consent)
 
+**One-Click Unsubscribe**:
+The **sender's own** unsubscribe endpoint, stated once per Batch as an `https` URL template and personalised per Delivery, carried in the `List-Unsubscribe` and `List-Unsubscribe-Post` headers (RFC 8058). Kannon signs it, so that a receiver can trust the destination was part of the authenticated message, but does not own it, never calls it, and retains nothing about who used it: leaving is not engagement, and to the Tracker a Delivery that ends in an unsubscribe is indistinguishable from one that does not.
+
+Stated at Batch level only — there is no Domain default and no Recipient override. A Domain default would stamp an unsubscribe on the password resets and receipts that are this sender's core traffic, offering a recipient something the sender cannot honour; and a Recipient override would add nothing, since personalising the template from the Recipient's fields is already what makes the endpoint per-Recipient. This is a deliberate asymmetry with **Tracking Policy**, which does cascade: a Policy expresses a permission that is meaningful to narrow by degrees, while this is an operational instruction that is meaningful only where the intent of a single Batch lives.
+_Avoid_: Unsubscribe Link (suggests something to click, and therefore something trackable), Unsubscribe List / Suppression List (Kannon keeps neither), Opt-out (a consent notion, which under ADR 0002 Kannon does not store)
+
 ### Actors
 
 **Mailer API**:

--- a/README.md
+++ b/README.md
@@ -255,6 +255,36 @@ The optional `headers` field allows overriding the `To` and adding a `Cc` header
 
 This is useful for scenarios where you want the email to appear addressed to a group or alias while delivering to individual recipients.
 
+#### One-click unsubscribe
+
+The optional `one_click_unsubscribe` field carries **your own** unsubscribe
+endpoint in the `List-Unsubscribe` and `List-Unsubscribe-Post` headers
+(RFC 8058), which the large receivers require of bulk senders. Kannon
+personalises the URL, emits it and DKIM-signs it — it never calls it, keeps no
+suppression list, and records nothing when a recipient uses it.
+
+```json
+{
+  "one_click_unsubscribe": {
+    "url_template": "https://yourdomain.com/unsub?email={{ email }}"
+  }
+}
+```
+
+- The URL must be **https**; `mailto:` and plain `http` are refused, and a
+  malformed template fails the whole call.
+- Your endpoint must accept **`POST`** with body `List-Unsubscribe=One-Click`
+  and unsubscribe with no confirmation step. Setting this field asserts that,
+  and Kannon cannot check it for you.
+- `{{ field }}` placeholders are substituted per recipient and
+  **percent-encoded**, so pass raw values. `email` is always available and holds
+  the recipient's address unless you pass a field of that name yourself.
+- A recipient whose fields leave a placeholder unresolved is refused on its own,
+  with reason `unsubscribe_url_unresolved`, while the rest of the send proceeds.
+
+State it per send: it is deliberately not a per-domain default, since an
+unsubscribe header does not belong on a password reset or a receipt.
+
 #### Link tracking
 
 When the Tracking Policy governing a message allows link tracking, every `<a href="...">` in the HTML is rewritten into a `https://stats.<your-domain>/c/<token>` redirect that records the click and forwards the recipient to the original URL.

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -5,6 +5,71 @@ releases that change behaviour of an installation already in production appear
 here; everything else is in [`CHANGELOG.md`](../CHANGELOG.md), which is
 generated from commits.
 
+## Unreleased — One-Click Unsubscribe
+
+### What changes
+
+Kannon can now carry a `List-Unsubscribe` / `List-Unsubscribe-Post` pair
+(RFC 8058), which the large receivers require of bulk senders. The endpoint is
+**yours**: Kannon personalises the URL, emits it and signs it, and does nothing
+else with it — it never calls it, keeps no suppression list, and records no
+engagement when a recipient uses it. Nothing is emitted unless you ask for it,
+so an installation that ignores this section is unaffected.
+
+Two changes reach mail you are already sending, though:
+
+- **Every DKIM signature now covers a fixed header set**:
+  `From, To, Cc, Subject, Message-ID, List-Unsubscribe, List-Unsubscribe-Post`,
+  whether or not each header is on the message. Signing a header that is absent
+  is what lets a receiver detect one inserted in transit (RFC 6376 §5.4). The
+  practical consequence: a relay that *adds* a Cc or an unsubscribe header to
+  your mail now breaks the signature instead of having its addition ride along
+  unsigned. A forwarder that inserts its own `List-*` headers — a mailing list
+  expander, typically — will fail DKIM at the final hop, where before it would
+  have passed. See
+  [ADR 0005](adr/0005-one-click-unsubscribe-and-signed-header-set.md).
+- **`{{ email }}` now resolves in your subject and body**, to the recipient's
+  address. Before this release it rendered as literal braces unless you passed a
+  field of that name yourself. If you pass your own `email` field, your value
+  still wins — nothing you already send changes.
+
+### Using it
+
+State the endpoint per send. It is deliberately not a Domain-wide setting:
+Kannon is a transactional sender, and an unsubscribe header on a password reset
+offers a recipient something you cannot honour.
+
+```json
+{
+  "one_click_unsubscribe": {
+    "url_template": "https://yourdomain.com/unsub?email={{ email }}"
+  }
+}
+```
+
+Four things the API will hold you to:
+
+1. **The URL must be `https`.** A `mailto:` fallback is not supported, and plain
+   `http` would put the recipient's identifier on the wire in the clear. A
+   template that is malformed, relative or non-https fails the whole call.
+2. **Your endpoint must accept `POST`** with body `List-Unsubscribe=One-Click`
+   and unsubscribe with no further confirmation. Supplying a URL here asserts
+   that, and Kannon cannot verify it. Advertising one-click without honouring it
+   is worse than not advertising it: the recipient presses the button, believes
+   they are unsubscribed, and reports your next message as spam.
+3. **Pass raw field values, not pre-encoded ones.** Kannon percent-encodes every
+   value it substitutes into the URL, so `mario+rossi@example.com` arrives
+   intact rather than as `mario rossi@example.com`.
+4. **Every placeholder must resolve for every Recipient.** One whose fields
+   leave a placeholder unresolved is Rejected on its own, with reason
+   `unsubscribe_url_unresolved` in `rejected_recipients`, while the rest of the
+   send proceeds. `{{ email }}` always resolves; a custom `{{ token }}` only
+   does if you pass it for that row.
+
+The link in your message *body* is a separate matter and is still tracked like
+any other. If it points at the same URL, keep it out of click tracking with
+`data-no-track` on the `<a>` tag (see below).
+
 ## Unreleased — Tracking Policy
 
 ### What changes

--- a/docs/adr/0005-one-click-unsubscribe-and-signed-header-set.md
+++ b/docs/adr/0005-one-click-unsubscribe-and-signed-header-set.md
@@ -1,0 +1,198 @@
+# ADR 0005: One-Click Unsubscribe, and the header set Kannon signs
+
+## Status
+
+Accepted (2026-08-02).
+
+## Context
+
+Kannon emits no `List-Unsubscribe` header of any kind. `batch.Headers` carries
+`To` and `Cc` and nothing else, and `buildHeaders` writes a fixed set that has
+no room for one. A sender wanting an unsubscribe has only the message body,
+where the link is subject to click tracking like any other — mitigated since
+#322 by the `data-no-track` attribute, which exists precisely for it.
+
+That is no longer enough. Since February 2024 the large receivers require bulk
+senders to offer one-click unsubscribe (RFC 8058) and to honour it promptly.
+A sender that cannot emit the header is a sender whose mail is filtered.
+
+ADR 0002 fixes the boundary this feature has to respect: Kannon executes
+tracking instructions and does not store consent. Owning an unsubscribe — a
+suppression list, a Kannon-minted token, an endpoint of our own — would put
+Kannon on the other side of that line and turn it into a list manager.
+
+`CONTEXT.md` defines **One-Click Unsubscribe** as the term for what this ADR
+builds.
+
+## Decision
+
+### The endpoint belongs to the sender; Kannon carries it
+
+The caller states the URL of **its own** endpoint. Kannon personalises it,
+emits it, signs it, and does nothing else with it: it is never called, never
+recorded, and never resolved against any state Kannon holds. There is no
+suppression list and no Kannon-issued unsubscribe token.
+
+This follows directly from ADR 0002. It also settles what the Tracker does with
+an unsubscribe, which is nothing: the URL travels in a header, and the click
+rewriter only ever touches `<a>` tags in the body, so the property holds by
+construction rather than by a rule someone has to remember.
+
+### One-click `https` only — no `mailto` branch
+
+RFC 2369 allows a list of URIs and a `mailto:` fallback. Kannon accepts one
+`https` URL and always emits both headers:
+
+```
+List-Unsubscribe: <https://sender.example/unsub?u=...>
+List-Unsubscribe-Post: List-Unsubscribe=One-Click
+```
+
+Emitting `List-Unsubscribe-Post` is an assertion about someone else's server —
+that it answers `POST` with body `List-Unsubscribe=One-Click` and unsubscribes
+with no further confirmation. Kannon cannot verify it, so the assertion has to
+be made by the party that knows, and it has to be unmissable. Rather than a
+`one_click` boolean beside a general-purpose URL, the field itself *is* the
+assertion: it is named `one_click_unsubscribe`, its type is
+`OneClickUnsubscribe`, and its documentation states the contract. There is no
+way to supply a URL here while meaning something weaker.
+
+The failure this avoids is asymmetric. A missing `List-Unsubscribe-Post` fails
+visibly — the client opens the URL in a browser and the recipient completes the
+unsubscribe by hand. A present-but-unhonoured one fails silently: the recipient
+presses the button, believes they are unsubscribed, is not, and reports the
+next message as spam.
+
+### Batch level only
+
+No Domain default, no Recipient override. Kannon is a transactional sender:
+a Domain-wide default would attach an unsubscribe to password resets, receipts
+and OTPs, where it offers a recipient something the sender cannot honour. A
+Recipient-level override would add nothing that personalisation does not
+already give.
+
+This is a deliberate asymmetry with the three-level cascade of **Tracking
+Policy** (ADR 0003), and the two are different in kind: a Policy is a permission
+that is meaningful to narrow by degrees, this is an operational instruction that
+is meaningful only where a Batch's intent lives.
+
+### Personalised per Delivery, percent-encoded
+
+The URL is a template. `{{ field }}` placeholders are substituted from the
+Recipient's fields, as subject and body already are, and the address of the
+Recipient is injected as an `email` field so that the common case needs no
+per-row data at all. The injection is a **default**: a caller that supplies its
+own `email` field keeps its value, because silently overriding a value the
+caller passed would change the meaning of templates already in production. It
+is injected when the message is rendered rather than at intake, so nothing is
+duplicated into every Pool row.
+
+Substituted values are **percent-encoded**, unlike everywhere else. The body is
+left alone because the context of a placeholder there is undecidable — it may be
+prose, an attribute, or a URL — while here the context is known by construction.
+Without encoding, `mario+rossi@example.com` reaches the endpoint as
+`mario rossi@example.com`, and a value containing `&` injects a parameter into
+someone else's URL. The contract is therefore that callers pass raw values.
+
+### An unresolvable URL refuses the Recipient, and never ships broken
+
+`ReplaceCustomFields` leaves an unmatched placeholder in the string verbatim.
+For a body that is cosmetic; for a DKIM-signed one-click header it is the worst
+outcome the feature can produce — a receiver told the destination is
+authenticated, a recipient pressing a button, and a `POST` to a URL with braces
+in it.
+
+Two checks, at the two levels where the fault actually sits:
+
+- **The call fails** (`INVALID_ARGUMENT`) if the stated template is unparseable
+  or not `https`. That is a fault in the request, not in one row of it.
+- **The Recipient is Rejected**, with reason `unsubscribe_url_unresolved`,
+  if its own fields leave a placeholder unresolved. One bad row does not fail a
+  send of thousands, and the caller learns which rows in the send response.
+
+The Builder keeps a backstop: a URL that still fails to resolve there causes the
+two headers to be **omitted** for that Delivery. A message without an unsubscribe
+is a deliverability cost; a signed and broken one is a complaint.
+
+### A fixed signed header set, oversigned, doubled only where it earns it
+
+`signMessage` built `h=` conditionally, appending `Cc` only when present. It now
+signs a fixed list, whether or not each header exists on the message:
+
+```
+From:From:To:To:Cc:Cc:Subject:Subject:Message-ID:Message-ID:
+List-Unsubscribe:List-Unsubscribe:List-Unsubscribe-Post:List-Unsubscribe-Post
+```
+
+RFC 6376 §5.4 makes both halves of this explicit. A signer "MAY contain names of
+header fields that do not exist when signed; nonexistent header fields do not
+contribute to the signature computation", and the purpose is stated outright:
+"By 'signing' header fields that do not actually exist, a Signer can allow a
+Verifier to detect insertion of those header fields after signing." §5.4.2 adds
+that multiple instances are signed bottom-up, which is why naming a header once
+does not protect a message that already has it — a second copy prepended in
+transit stays outside the signature while remaining the one a client reads
+first. §8.15 covers the threat under "Attacks Involving Extra Header Fields".
+
+Naming every header twice would be the thorough reading, and it was rejected.
+Oversigning is **not** common practice: real-world signatures from ordinary
+corporate senders list each name once, including `From`, and the public advice
+recommending it reads as advocacy for something not yet widely enabled. For
+`From`/`To`/`Cc`/`Subject`/`Message-ID` the fixed list already buys protection
+against insertion where the header is absent, and the second listing would buy
+a divergence from what everyone else emits.
+
+The two `List-*` headers are doubled because there the threat is specific and
+the payoff concrete: a second injected copy redirects an unauthenticated `POST`
+to an attacker's endpoint, which is the exact attack RFC 8058's signing
+requirement exists to prevent.
+
+## Consequences
+
+- **Every outgoing message's DKIM signature changes**, including mail with no
+  unsubscribe: `h=` is now fixed rather than derived from what is present. The
+  signature stays valid; what changes is that adding any of these headers in
+  transit now breaks it.
+- **Forwarders that add `List-*` headers will break the signature.** A message
+  relayed through a list expander that inserts its own `List-Unsubscribe` will
+  fail DKIM at the final hop. Such a path usually breaks DKIM anyway — footers,
+  subject tags — and re-signs or ARC-seals, so the marginal cost is small, but
+  it is a real narrowing and it is accepted knowingly.
+- The `email` field becomes resolvable in **subject and body too**, where today
+  `{{ email }}` renders as literal braces. This is a visible behaviour change
+  for anyone who wrote that placeholder and never passed the field.
+- No migration. The declaration is persisted as a key in the existing `headers`
+  JSONB column on `messages`; rows written before this change simply lack it.
+- `rejected_recipients` gains a value. Callers were already told to treat an
+  unrecognised reason as a refusal of unknown cause, so this is additive.
+- **Kannon still cannot tell whether an unsubscribe was honoured.** It does not
+  call the endpoint and keeps no list, so a sender that ignores its own
+  one-click POSTs looks identical to one that acts on them. That is the sender's
+  obligation, not something this ADR can enforce.
+- A single definition of "the fields available to this Delivery" has to be
+  shared by the intake check and the renderer. If they drift, intake accepts a
+  Recipient the Builder cannot resolve, or refuses one it could.
+
+## Rejected alternatives
+
+- **A generic custom-header map.** Cheap, and wrong for this: Kannon applies
+  semantics to these headers — personalisation, encoding, validation, signing —
+  and semantics hung off an untyped map key is invisible to the caller and
+  impossible to validate.
+- **A `one_click` boolean beside a neutral `unsubscribe_url`.** Makes the
+  strongest claim in the message the easiest field to leave at its default.
+- **Supporting the `mailto:` fallback.** Requires the sender to run and parse an
+  inbound mailbox, and the receivers that matter want one-click. Reintroducible
+  later without a wire break, which is why the field is a message and not a
+  string.
+- **Auto-excluding body links that match the header URL from click tracking.**
+  Considered, then dropped: a one-click `POST` endpoint and a footer's
+  confirmation page are different URLs by construction, so the match would find
+  nothing in the common case. Where a sender genuinely serves both from one URL,
+  `data-no-track` already covers it.
+- **A Domain-level default unsubscribe URL.** Silently stamps an unsubscribe on
+  transactional mail.
+- **Emitting the header with placeholders unresolved.** Produces exactly the
+  authenticated-but-broken one-click this feature exists to avoid.
+- **Percent-encoding substitutions everywhere.** Would render `{{ name }}` in
+  prose as `Mario%20Rossi`.

--- a/internal/batch/batch.go
+++ b/internal/batch/batch.go
@@ -6,6 +6,9 @@ package batch
 
 import (
 	"errors"
+	"fmt"
+	"net/url"
+	"strings"
 
 	"github.com/kannon-email/kannon/internal/tracking"
 )
@@ -29,6 +32,50 @@ type Headers struct {
 	Cc []string
 }
 
+// OneClickUnsubscribe is the sender's own unsubscribe endpoint as stated for a
+// Batch (CONTEXT.md, ADR 0005): an https URL template, personalised per
+// Delivery, carried in the List-Unsubscribe and List-Unsubscribe-Post headers.
+// Kannon emits and signs it and does nothing else with it.
+//
+// It is deliberately not a field of Headers. The To/Cc there are literal values
+// written out as given, while this one is templated, percent-encoded and
+// validated before it reaches a header line — sitting it beside them would
+// suggest it is passed through as written.
+type OneClickUnsubscribe struct {
+	URLTemplate string
+}
+
+// IsZero reports whether the Batch states no unsubscribe endpoint, in which
+// case neither header is emitted. Kannon never supplies one of its own.
+func (u OneClickUnsubscribe) IsZero() bool { return u.URLTemplate == "" }
+
+// validate checks what can be known before any Recipient is seen: that the
+// template is a well-formed absolute https URL. Whether a given Recipient can
+// actually resolve its placeholders is a per-Recipient question, answered at
+// intake against that Recipient's fields.
+//
+// Only https qualifies. A one-click unsubscribe is a POST to an authenticated
+// destination, so plain http would carry the recipient's identifier in the
+// clear, and mailto is not one-click at all.
+func (u OneClickUnsubscribe) validate() error {
+	if u.IsZero() {
+		return nil
+	}
+	// url.Parse rejects ASCII control characters, so this also covers the CR/LF
+	// that would otherwise let a caller inject header lines of its own.
+	parsed, err := url.Parse(u.URLTemplate)
+	if err != nil {
+		return fmt.Errorf("one-click unsubscribe URL is not a valid URL: %w", err)
+	}
+	if !strings.EqualFold(parsed.Scheme, "https") {
+		return fmt.Errorf("one-click unsubscribe URL must be https, got %q", parsed.Scheme)
+	}
+	if parsed.Host == "" {
+		return errors.New("one-click unsubscribe URL must be absolute")
+	}
+	return nil
+}
+
 // Attachments maps a filename to its raw bytes.
 type Attachments map[string][]byte
 
@@ -36,71 +83,93 @@ type Attachments map[string][]byte
 // metadata shared by all recipients of that call; per-recipient delivery
 // state is tracked in the Delivery domain (see internal/delivery).
 type Batch struct {
-	id          ID
-	subject     string
-	sender      Sender
-	templateID  string
-	domain      string
-	attachments Attachments
-	headers     Headers
-	tracking    tracking.Policy
+	id                  ID
+	subject             string
+	sender              Sender
+	templateID          string
+	domain              string
+	attachments         Attachments
+	headers             Headers
+	oneClickUnsubscribe OneClickUnsubscribe
+	tracking            tracking.Policy
+}
+
+// NewParams contains all fields needed to create a fresh Batch.
+type NewParams struct {
+	Domain      string
+	Subject     string
+	Sender      Sender
+	TemplateID  string
+	Attachments Attachments
+	Headers     Headers
+	// OneClickUnsubscribe is the sender's own unsubscribe endpoint. Zero when
+	// the caller states none, in which case no unsubscribe header is emitted.
+	OneClickUnsubscribe OneClickUnsubscribe
+	// Tracking is the Tracking Policy as the caller stated it for this Batch —
+	// persisted as provenance only (ADR 0003).
+	Tracking tracking.Policy
 }
 
 // New creates a new Batch with a freshly generated ID for the given domain.
-// trackingPolicy is the Tracking Policy as the caller stated it for this
-// Batch — persisted as provenance only (ADR 0003). It is not normalised: an
-// unstated Mode is kept exactly as stated, since the Batch column is the one
-// place an unstated Mode may be stored. The value that actually governs each
-// Delivery is resolved separately, against the Domain's ceiling, and frozen
-// there instead.
-func New(domain, subject string, sender Sender, templateID string, attachments Attachments, headers Headers, trackingPolicy tracking.Policy) (*Batch, error) {
-	if domain == "" {
+//
+// The Tracking Policy is not normalised: an unstated Mode is kept exactly as
+// stated, since the Batch column is the one place an unstated Mode may be
+// stored. The value that actually governs each Delivery is resolved separately,
+// against the Domain's ceiling, and frozen there instead.
+func New(p NewParams) (*Batch, error) {
+	if p.Domain == "" {
 		return nil, errors.New("domain is required")
 	}
-	if subject == "" {
+	if p.Subject == "" {
 		return nil, errors.New("subject is required")
 	}
-	if templateID == "" {
+	if p.TemplateID == "" {
 		return nil, errors.New("template ID is required")
 	}
-	if sender.Email == "" {
+	if p.Sender.Email == "" {
 		return nil, errors.New("sender email is required")
 	}
+	if err := p.OneClickUnsubscribe.validate(); err != nil {
+		return nil, err
+	}
 	return &Batch{
-		id:          NewID(domain),
-		subject:     subject,
-		sender:      sender,
-		templateID:  templateID,
-		domain:      domain,
-		attachments: attachments,
-		headers:     headers,
-		tracking:    trackingPolicy,
+		id:                  NewID(p.Domain),
+		subject:             p.Subject,
+		sender:              p.Sender,
+		templateID:          p.TemplateID,
+		domain:              p.Domain,
+		attachments:         p.Attachments,
+		headers:             p.Headers,
+		oneClickUnsubscribe: p.OneClickUnsubscribe,
+		tracking:            p.Tracking,
 	}, nil
 }
 
 // LoadParams contains all fields needed to rehydrate a Batch from storage.
 type LoadParams struct {
-	ID          ID
-	Subject     string
-	Sender      Sender
-	TemplateID  string
-	Domain      string
-	Attachments Attachments
-	Headers     Headers
-	Tracking    tracking.Policy
+	ID                  ID
+	Subject             string
+	Sender              Sender
+	TemplateID          string
+	Domain              string
+	Attachments         Attachments
+	Headers             Headers
+	OneClickUnsubscribe OneClickUnsubscribe
+	Tracking            tracking.Policy
 }
 
 // Load rehydrates a Batch from stored data (used by repository implementations).
 func Load(p LoadParams) *Batch {
 	return &Batch{
-		id:          p.ID,
-		subject:     p.Subject,
-		sender:      p.Sender,
-		templateID:  p.TemplateID,
-		domain:      p.Domain,
-		attachments: p.Attachments,
-		headers:     p.Headers,
-		tracking:    p.Tracking,
+		id:                  p.ID,
+		subject:             p.Subject,
+		sender:              p.Sender,
+		templateID:          p.TemplateID,
+		domain:              p.Domain,
+		attachments:         p.Attachments,
+		headers:             p.Headers,
+		oneClickUnsubscribe: p.OneClickUnsubscribe,
+		tracking:            p.Tracking,
 	}
 }
 
@@ -113,6 +182,10 @@ func (b *Batch) TemplateID() string       { return b.templateID }
 func (b *Batch) Domain() string           { return b.domain }
 func (b *Batch) Attachments() Attachments { return b.attachments }
 func (b *Batch) Headers() Headers         { return b.headers }
+
+// OneClickUnsubscribe is the sender's unsubscribe endpoint for this Batch, zero
+// when none was stated.
+func (b *Batch) OneClickUnsubscribe() OneClickUnsubscribe { return b.oneClickUnsubscribe }
 
 // TrackingPolicy is the Tracking Policy as stated by the caller for this
 // Batch — not the resolved value that governs any Delivery. It participates

--- a/internal/batch/batch_test.go
+++ b/internal/batch/batch_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestNewBatch(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
-		b, err := New("example.com", "subject", Sender{Email: "from@example.com", Alias: "From"}, "tpl_abc", nil, Headers{}, tracking.Policy{})
+		b, err := New(NewParams{Domain: "example.com", Subject: "subject", Sender: Sender{Email: "from@example.com", Alias: "From"}, TemplateID: "tpl_abc"})
 		require.NoError(t, err)
 		assert.False(t, b.ID().IsZero())
 		assert.True(t, strings.HasPrefix(b.ID().String(), IDPrefix))
@@ -24,28 +24,28 @@ func TestNewBatch(t *testing.T) {
 
 	t.Run("TracksStatedPolicy", func(t *testing.T) {
 		stated := tracking.Policy{Opens: tracking.ModeFull}
-		b, err := New("example.com", "subject", Sender{Email: "from@example.com", Alias: "From"}, "tpl_abc", nil, Headers{}, stated)
+		b, err := New(NewParams{Domain: "example.com", Subject: "subject", Sender: Sender{Email: "from@example.com", Alias: "From"}, TemplateID: "tpl_abc", Tracking: stated})
 		require.NoError(t, err)
 		assert.Equal(t, stated, b.TrackingPolicy(), "New must keep the stated Policy as-is, not normalise it")
 	})
 
 	t.Run("MissingDomain", func(t *testing.T) {
-		_, err := New("", "subject", Sender{Email: "a@b.c"}, "tpl", nil, Headers{}, tracking.Policy{})
+		_, err := New(NewParams{Subject: "subject", Sender: Sender{Email: "a@b.c"}, TemplateID: "tpl"})
 		assert.Error(t, err)
 	})
 
 	t.Run("MissingSubject", func(t *testing.T) {
-		_, err := New("d", "", Sender{Email: "a@b.c"}, "tpl", nil, Headers{}, tracking.Policy{})
+		_, err := New(NewParams{Domain: "d", Sender: Sender{Email: "a@b.c"}, TemplateID: "tpl"})
 		assert.Error(t, err)
 	})
 
 	t.Run("MissingTemplateID", func(t *testing.T) {
-		_, err := New("d", "s", Sender{Email: "a@b.c"}, "", nil, Headers{}, tracking.Policy{})
+		_, err := New(NewParams{Domain: "d", Subject: "s", Sender: Sender{Email: "a@b.c"}})
 		assert.Error(t, err)
 	})
 
 	t.Run("MissingSenderEmail", func(t *testing.T) {
-		_, err := New("d", "s", Sender{}, "tpl", nil, Headers{}, tracking.Policy{})
+		_, err := New(NewParams{Domain: "d", Subject: "s", TemplateID: "tpl"})
 		assert.Error(t, err)
 	})
 }
@@ -92,4 +92,57 @@ func TestLoad(t *testing.T) {
 	assert.Equal(t, []byte("hi"), b.Attachments()["file.txt"])
 	assert.Equal(t, []string{"to@d"}, b.Headers().To)
 	assert.Equal(t, tracking.Policy{Opens: tracking.ModeFull}, b.TrackingPolicy())
+}
+
+func TestNewBatchValidatesTheUnsubscribeEndpoint(t *testing.T) {
+	newWith := func(tpl string) error {
+		_, err := New(NewParams{
+			Domain:              "example.com",
+			Subject:             "subject",
+			Sender:              Sender{Email: "from@example.com", Alias: "From"},
+			TemplateID:          "tpl_abc",
+			OneClickUnsubscribe: OneClickUnsubscribe{URLTemplate: tpl},
+		})
+		return err
+	}
+
+	t.Run("HTTPSTemplateAccepted", func(t *testing.T) {
+		assert.NoError(t, newWith("https://test.com/unsub?email={{ email }}"))
+	})
+
+	t.Run("NoneStatedAccepted", func(t *testing.T) {
+		assert.NoError(t, newWith(""))
+	})
+
+	t.Run("PlainHTTPRejected", func(t *testing.T) {
+		// A one-click POST carries the recipient's identifier; http would put it
+		// on the wire in the clear.
+		assert.Error(t, newWith("http://test.com/unsub"))
+	})
+
+	t.Run("MailtoRejected", func(t *testing.T) {
+		assert.Error(t, newWith("mailto:unsub@test.com"))
+	})
+
+	t.Run("RelativeRejected", func(t *testing.T) {
+		assert.Error(t, newWith("/unsub"))
+	})
+
+	t.Run("HeaderInjectionRejected", func(t *testing.T) {
+		assert.Error(t, newWith("https://test.com/unsub\r\nBcc: victim@test.com"))
+	})
+}
+
+func TestBatchExposesTheUnsubscribeEndpoint(t *testing.T) {
+	b, err := New(NewParams{
+		Domain:              "example.com",
+		Subject:             "subject",
+		Sender:              Sender{Email: "from@example.com", Alias: "From"},
+		TemplateID:          "tpl_abc",
+		OneClickUnsubscribe: OneClickUnsubscribe{URLTemplate: "https://test.com/unsub"},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "https://test.com/unsub", b.OneClickUnsubscribe().URLTemplate)
+	assert.False(t, b.OneClickUnsubscribe().IsZero())
 }

--- a/internal/batch/repospec.go
+++ b/internal/batch/repospec.go
@@ -10,6 +10,8 @@ import (
 
 // testSenderAlias is the Sender alias shared by the repo spec's fixture
 // Batches; factored out so goconst does not flag its repeated use.
+const testSubject = "hello"
+
 const testSenderAlias = "From"
 
 // RepoTestHelper provides test utilities for repository spec tests.
@@ -45,7 +47,7 @@ func testCreate(t *testing.T, repo Repository, helper RepoTestHelper) {
 		domain := helper.CreateDomain(t)
 		tpl := helper.CreateTemplate(t, domain)
 
-		b, err := New(domain, "hello", Sender{Email: "from@" + domain, Alias: testSenderAlias}, tpl, nil, Headers{}, tracking.Policy{})
+		b, err := New(NewParams{Domain: domain, Subject: testSubject, Sender: Sender{Email: "from@" + domain, Alias: testSenderAlias}, TemplateID: tpl})
 		require.NoError(t, err)
 
 		err = repo.Create(ctx, b)
@@ -59,7 +61,7 @@ func testCreate(t *testing.T, repo Repository, helper RepoTestHelper) {
 
 		atts := Attachments{"a.txt": []byte("hi")}
 		hdrs := Headers{To: []string{"to@" + domain}, Cc: []string{"cc@" + domain}}
-		b, err := New(domain, "hello", Sender{Email: "from@" + domain, Alias: testSenderAlias}, tpl, atts, hdrs, tracking.Policy{})
+		b, err := New(NewParams{Domain: domain, Subject: testSubject, Sender: Sender{Email: "from@" + domain, Alias: testSenderAlias}, TemplateID: tpl, Attachments: atts, Headers: hdrs})
 		require.NoError(t, err)
 
 		err = repo.Create(ctx, b)
@@ -71,6 +73,37 @@ func testCreate(t *testing.T, repo Repository, helper RepoTestHelper) {
 		assert.Equal(t, []string{"to@" + domain}, fetched.Headers().To)
 		assert.Equal(t, []string{"cc@" + domain}, fetched.Headers().Cc)
 	})
+
+	t.Run("WithOneClickUnsubscribe", func(t *testing.T) {
+		ctx := t.Context()
+		domain := helper.CreateDomain(t)
+		tpl := helper.CreateTemplate(t, domain)
+
+		u := OneClickUnsubscribe{URLTemplate: "https://sender.example/unsub?email={{ email }}"}
+		b, err := New(NewParams{Domain: domain, Subject: testSubject, Sender: Sender{Email: "from@" + domain, Alias: testSenderAlias}, TemplateID: tpl, OneClickUnsubscribe: u})
+		require.NoError(t, err)
+		require.NoError(t, repo.Create(ctx, b))
+
+		fetched, err := repo.GetByID(ctx, b.ID())
+		require.NoError(t, err)
+		assert.Equal(t, u, fetched.OneClickUnsubscribe())
+	})
+
+	t.Run("WithoutOneClickUnsubscribe", func(t *testing.T) {
+		// The key is absent from the headers JSONB, which is the same state every
+		// Batch written before ADR 0005 is in — hence no migration.
+		ctx := t.Context()
+		domain := helper.CreateDomain(t)
+		tpl := helper.CreateTemplate(t, domain)
+
+		b, err := New(NewParams{Domain: domain, Subject: testSubject, Sender: Sender{Email: "from@" + domain, Alias: testSenderAlias}, TemplateID: tpl})
+		require.NoError(t, err)
+		require.NoError(t, repo.Create(ctx, b))
+
+		fetched, err := repo.GetByID(ctx, b.ID())
+		require.NoError(t, err)
+		assert.True(t, fetched.OneClickUnsubscribe().IsZero())
+	})
 }
 
 func testGetByID(t *testing.T, repo Repository, helper RepoTestHelper) {
@@ -79,7 +112,7 @@ func testGetByID(t *testing.T, repo Repository, helper RepoTestHelper) {
 		domain := helper.CreateDomain(t)
 		tpl := helper.CreateTemplate(t, domain)
 
-		b, err := New(domain, "hello", Sender{Email: "from@" + domain, Alias: "Alias"}, tpl, nil, Headers{}, tracking.Policy{})
+		b, err := New(NewParams{Domain: domain, Subject: testSubject, Sender: Sender{Email: "from@" + domain, Alias: "Alias"}, TemplateID: tpl})
 		require.NoError(t, err)
 		require.NoError(t, repo.Create(ctx, b))
 
@@ -113,7 +146,7 @@ func testTrackingPolicyProvenance(t *testing.T, repo Repository, helper RepoTest
 		tpl := helper.CreateTemplate(t, domain)
 
 		stated := tracking.Policy{Opens: tracking.ModeFull, Links: tracking.ModeOff}
-		b, err := New(domain, "hello", Sender{Email: "from@" + domain, Alias: testSenderAlias}, tpl, nil, Headers{}, stated)
+		b, err := New(NewParams{Domain: domain, Subject: testSubject, Sender: Sender{Email: "from@" + domain, Alias: testSenderAlias}, TemplateID: tpl, Tracking: stated})
 		require.NoError(t, err)
 		require.NoError(t, repo.Create(ctx, b))
 
@@ -132,7 +165,7 @@ func testTrackingPolicyProvenance(t *testing.T, repo Repository, helper RepoTest
 		// Only opens is stated; links states nothing. Unlike the Domain
 		// ceiling, the Batch provenance column must not normalise this away.
 		stated := tracking.Policy{Opens: tracking.ModeAnonymous}
-		b, err := New(domain, "hello", Sender{Email: "from@" + domain, Alias: testSenderAlias}, tpl, nil, Headers{}, stated)
+		b, err := New(NewParams{Domain: domain, Subject: testSubject, Sender: Sender{Email: "from@" + domain, Alias: testSenderAlias}, TemplateID: tpl, Tracking: stated})
 		require.NoError(t, err)
 		require.NoError(t, repo.Create(ctx, b))
 

--- a/internal/db/batch_repo.go
+++ b/internal/db/batch_repo.go
@@ -30,7 +30,7 @@ func (r *batchRepository) Create(ctx context.Context, b *batch.Batch) error {
 		TemplateID:  b.TemplateID(),
 		Domain:      b.Domain(),
 		Attachments: toSQLCAttachments(b.Attachments()),
-		Headers:     toSQLCHeaders(b.Headers()),
+		Headers:     toSQLCHeaders(b.Headers(), b.OneClickUnsubscribe()),
 		Tracking:    b.TrackingPolicy(),
 	})
 	return err
@@ -56,11 +56,12 @@ func rowToBatch(row Message) *batch.Batch {
 			Email: row.SenderEmail,
 			Alias: row.SenderAlias,
 		},
-		TemplateID:  row.TemplateID,
-		Domain:      row.Domain,
-		Attachments: fromSQLCAttachments(row.Attachments),
-		Headers:     fromSQLCHeaders(row.Headers),
-		Tracking:    row.Tracking,
+		TemplateID:          row.TemplateID,
+		Domain:              row.Domain,
+		Attachments:         fromSQLCAttachments(row.Attachments),
+		Headers:             fromSQLCHeaders(row.Headers),
+		OneClickUnsubscribe: fromSQLCUnsubscribe(row.Headers),
+		Tracking:            row.Tracking,
 	})
 }
 
@@ -86,10 +87,26 @@ func fromSQLCAttachments(a Attachments) batch.Attachments {
 	return out
 }
 
-func toSQLCHeaders(h batch.Headers) Headers {
-	return Headers{To: h.To, Cc: h.Cc}
+// toSQLCHeaders folds both header-shaped statements of a Batch into the single
+// JSONB column that holds them. They are separate concepts in the domain but
+// share one column, so the mapping is the one place that knows it.
+func toSQLCHeaders(h batch.Headers, u batch.OneClickUnsubscribe) Headers {
+	out := Headers{To: h.To, Cc: h.Cc}
+	if !u.IsZero() {
+		out.OneClickUnsubscribe = &OneClickUnsubscribe{URLTemplate: u.URLTemplate}
+	}
+	return out
 }
 
 func fromSQLCHeaders(h Headers) batch.Headers {
 	return batch.Headers{To: h.To, Cc: h.Cc}
+}
+
+// fromSQLCUnsubscribe returns the zero value for a Batch stored before the key
+// existed, which is the same thing as a Batch that states no endpoint.
+func fromSQLCUnsubscribe(h Headers) batch.OneClickUnsubscribe {
+	if h.OneClickUnsubscribe == nil {
+		return batch.OneClickUnsubscribe{}
+	}
+	return batch.OneClickUnsubscribe{URLTemplate: h.OneClickUnsubscribe.URLTemplate}
 }

--- a/internal/db/headers.go
+++ b/internal/db/headers.go
@@ -1,6 +1,17 @@
 package sqlc
 
+// Headers is the JSONB payload of messages.headers: everything a Batch states
+// about the headers of its outgoing messages. Adding a key here needs no
+// migration — rows written before the key existed simply decode without it.
 type Headers struct {
 	To []string `json:"to"`
 	Cc []string `json:"cc"`
+	// OneClickUnsubscribe is absent on every Batch written before ADR 0005, and
+	// on every Batch whose caller states no unsubscribe endpoint.
+	OneClickUnsubscribe *OneClickUnsubscribe `json:"one_click_unsubscribe,omitempty"`
+}
+
+// OneClickUnsubscribe is the stored form of the sender's unsubscribe endpoint.
+type OneClickUnsubscribe struct {
+	URLTemplate string `json:"url_template"`
 }

--- a/internal/dkim/oversign_test.go
+++ b/internal/dkim/oversign_test.go
@@ -1,0 +1,110 @@
+package dkim_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	msgauth "github.com/emersion/go-msgauth/dkim"
+	"github.com/kannon-email/kannon/internal/dkim"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// signedHeaders mirrors the set the Envelope Builder signs: fixed, naming
+// headers whether or not the message carries them, and naming the two RFC 8058
+// headers twice (ADR 0005).
+var signedHeaders = []string{
+	"From", "To", "Cc", "Subject", "Message-ID",
+	"List-Unsubscribe", "List-Unsubscribe",
+	"List-Unsubscribe-Post", "List-Unsubscribe-Post",
+}
+
+const plainMessage = "From: Test <noreply@test.com>\r\n" +
+	"To: rcpt@example.com\r\n" +
+	"Subject: Hello\r\n" +
+	"Message-ID: <msg-1@test.com>\r\n" +
+	"\r\n" +
+	"hi\r\n"
+
+func signAndVerify(t *testing.T, msg string, tamper func(signed string) string) []*msgauth.Verification {
+	t.Helper()
+
+	keys, err := dkim.GenerateDKIMKeysPair()
+	require.NoError(t, err)
+
+	signed, err := dkim.SignMessage(dkim.SignData{
+		PrivateKey: keys.PrivateKey,
+		Domain:     "test.com",
+		Selector:   "kannon",
+		Headers:    signedHeaders,
+	}, bytes.NewReader([]byte(msg)))
+	require.NoError(t, err)
+
+	delivered := string(signed)
+	if tamper != nil {
+		delivered = tamper(delivered)
+	}
+
+	// The public key is served to the verifier directly, so the test needs no
+	// DNS.
+	verifications, err := msgauth.VerifyWithOptions(strings.NewReader(delivered), &msgauth.VerifyOptions{
+		LookupTXT: func(string) ([]string, error) {
+			return []string{"v=DKIM1; k=rsa; p=" + keys.PublicKey}, nil
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, verifications, 1)
+	return verifications
+}
+
+// TestSignatureOverAbsentHeadersVerifies is the load-bearing check for the
+// fixed h= list: a message carrying neither Cc nor the unsubscribe pair is
+// signed naming all of them, and that signature must still verify. Were it not
+// to, every message Kannon sends would arrive with dkim=fail.
+func TestSignatureOverAbsentHeadersVerifies(t *testing.T) {
+	v := signAndVerify(t, plainMessage, nil)
+
+	assert.NoError(t, v[0].Err, "a signature naming absent headers must verify")
+	assert.Equal(t, "test.com", v[0].Domain)
+}
+
+// TestAddingAnAbsentSignedHeaderBreaksTheSignature is the property the fixed
+// list buys: an unsubscribe header injected in transit can no longer ride along
+// unsigned, because the signer committed to its absence (RFC 6376 §5.4).
+func TestAddingAnAbsentSignedHeaderBreaksTheSignature(t *testing.T) {
+	v := signAndVerify(t, plainMessage, func(signed string) string {
+		return "List-Unsubscribe: <https://attacker.example/unsub>\r\n" + signed
+	})
+
+	assert.Error(t, v[0].Err,
+		"a List-Unsubscribe added after signing must invalidate the signature")
+}
+
+// TestAddingASecondCopyBreaksTheSignature is why the two List-* names appear
+// twice. Instances are matched bottom-up, so with a single mention the original
+// header would still hash correctly while an injected copy sat above it — and
+// that copy is the one a client reads first.
+func TestAddingASecondCopyBreaksTheSignature(t *testing.T) {
+	withUnsubscribe := strings.Replace(plainMessage,
+		"Subject: Hello\r\n",
+		"Subject: Hello\r\nList-Unsubscribe: <https://sender.example/unsub>\r\n", 1)
+
+	v := signAndVerify(t, withUnsubscribe, func(signed string) string {
+		return "List-Unsubscribe: <https://attacker.example/unsub>\r\n" + signed
+	})
+
+	assert.Error(t, v[0].Err,
+		"a second List-Unsubscribe prepended in transit must invalidate the signature")
+}
+
+// TestUnrelatedHeaderAdditionStillVerifies keeps the blast radius honest: only
+// the named headers are committed to, so the X-* headers a relay routinely adds
+// are still tolerated.
+func TestUnrelatedHeaderAdditionStillVerifies(t *testing.T) {
+	v := signAndVerify(t, plainMessage, func(signed string) string {
+		return "X-Spam-Score: 0.1\r\n" + signed
+	})
+
+	assert.NoError(t, v[0].Err)
+}

--- a/internal/envelope/builder.go
+++ b/internal/envelope/builder.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"log/slog"
 
 	"github.com/kannon-email/kannon/internal/batch"
 	sqlc "github.com/kannon-email/kannon/internal/db"
@@ -29,6 +30,9 @@ type SendingData struct {
 	DkimPrivateKey string
 	Attachments    map[string][]byte
 	Headers        batch.Headers
+	// OneClickUnsubscribe is the sender's unsubscribe endpoint as stated for the
+	// Batch, zero when it stated none.
+	OneClickUnsubscribe batch.OneClickUnsubscribe
 }
 
 // SendingDataSource looks up the rendering inputs for a Batch.
@@ -108,8 +112,7 @@ func (b *defaultBuilder) Build(ctx context.Context, d *delivery.Delivery) (*Enve
 		return nil, err
 	}
 
-	hasCc := len(data.Headers.Cc) > 0
-	signedMsg, err := signMessage(data.Domain, data.DkimPrivateKey, msg, hasCc)
+	signedMsg, err := signMessage(data.Domain, data.DkimPrivateKey, msg)
 	if err != nil {
 		return nil, err
 	}
@@ -126,28 +129,70 @@ func (b *defaultBuilder) Build(ctx context.Context, d *delivery.Delivery) (*Enve
 
 func (b *defaultBuilder) prepareMessage(ctx context.Context, d *delivery.Delivery, data SendingData, attachments Attachments) ([]byte, error) {
 	emailMessageID := buildEmailID(d.Email(), data.MessageID)
-	html, err := b.preparedHTML(ctx, d, data)
+	fields := utils.EffectiveFields(d.Email(), d.Fields())
+	html, err := b.preparedHTML(ctx, d, data, fields)
 	if err != nil {
 		return nil, err
 	}
-	subject := utils.ReplaceCustomFields(data.Subject, d.Fields())
+	subject := utils.ReplaceCustomFields(data.Subject, fields)
 
 	sender := batch.Sender{Email: data.SenderEmail, Alias: data.SenderAlias}
-	h := buildHeaders(subject, sender, d.Email(), data.MessageID, emailMessageID, b.baseHeaders, data.Headers)
+	h := buildHeaders(subject, sender, d.Email(), data.MessageID, emailMessageID, b.baseHeaders, data.Headers,
+		resolveUnsubscribeURL(data.OneClickUnsubscribe, fields))
 	return renderMsg(html, h, attachments)
 }
 
-func signMessage(domain, dkimPrivateKey string, msg []byte, hasCc bool) ([]byte, error) {
-	dkimHeaders := []string{"From", "To", "Subject", "Message-ID"}
-	if hasCc {
-		dkimHeaders = append(dkimHeaders, "Cc")
+// resolveUnsubscribeURL personalises the Batch's unsubscribe endpoint for one
+// Delivery, returning "" when no header should be emitted.
+//
+// Intake already refused every Recipient whose fields leave a placeholder
+// unresolved (ADR 0005), so reaching the empty case here means the check did not
+// run — a Delivery queued before this feature existed, or a future path into the
+// Pool that bypasses the Mailer API. This is the backstop for that: a message
+// without an unsubscribe header costs deliverability, while one advertising an
+// authenticated one-click endpoint that turns out to be a URL with braces in it
+// costs a recipient who believes they have unsubscribed and has not.
+func resolveUnsubscribeURL(u batch.OneClickUnsubscribe, fields map[string]string) string {
+	if u.IsZero() {
+		return ""
 	}
+	resolved := utils.ReplaceCustomFieldsInURL(u.URLTemplate, fields)
+	if utils.HasUnresolvedPlaceholders(resolved) {
+		slog.Warn("omitting one-click unsubscribe header: URL has unresolved placeholders")
+		return ""
+	}
+	return resolved
+}
 
+// dkimSignedHeaders is the header set every Envelope is signed over, whether or
+// not each header is present on the message.
+//
+// Naming a header that does not exist is what RFC 6376 §5.4 calls signing a null
+// header, and it lets a verifier detect one inserted after signing. The list is
+// therefore fixed rather than derived from the message: a Cc, or an unsubscribe
+// pair, added in transit now breaks the signature instead of riding along
+// unsigned.
+//
+// The two List-* headers are named **twice**, which extends the same protection
+// to a message that already carries them: instances are matched bottom-up, so a
+// second copy prepended in transit would otherwise stay outside the signature
+// while being the one a client reads first. There it is worth the divergence
+// from what most senders emit, because an injected copy redirects an
+// unauthenticated POST to an endpoint of the attacker's choosing — the attack
+// RFC 8058's signing requirement exists to prevent. The other headers are named
+// once; see ADR 0005 for why the thorough reading was not taken everywhere.
+var dkimSignedHeaders = []string{
+	"From", "To", "Cc", "Subject", "Message-ID",
+	headerListUnsubscribe, headerListUnsubscribe,
+	headerListUnsubscribePost, headerListUnsubscribePost,
+}
+
+func signMessage(domain, dkimPrivateKey string, msg []byte) ([]byte, error) {
 	signData := dkim.SignData{
 		PrivateKey: dkimPrivateKey,
 		Domain:     domain,
 		Selector:   "kannon",
-		Headers:    dkimHeaders,
+		Headers:    dkimSignedHeaders,
 	}
 
 	return dkim.SignMessage(signData, bytes.NewReader(msg))
@@ -166,9 +211,9 @@ func signMessage(domain, dkimPrivateKey string, msg []byte, hasCc bool) ([]byte,
 // Whatever the Mode of a tracked axis is, it is minted into the token of that
 // axis, so the Tracker acts on the Policy frozen on this Delivery rather than on
 // whatever is configured when the engagement arrives.
-func (b *defaultBuilder) preparedHTML(ctx context.Context, d *delivery.Delivery, data SendingData) (string, error) {
+func (b *defaultBuilder) preparedHTML(ctx context.Context, d *delivery.Delivery, data SendingData, fields map[string]string) (string, error) {
 	policy := d.TrackingPolicy()
-	html := utils.ReplaceCustomFields(data.HTML, d.Fields())
+	html := utils.ReplaceCustomFields(data.HTML, fields)
 
 	if policy.Links != tracking.ModeOff {
 		rewritten, err := b.replaceAllLinks(ctx, html, trackTargetFor(d, data, policy.Links))
@@ -306,5 +351,16 @@ func (s sqlcSource) GetSendingData(ctx context.Context, batchID batch.ID) (Sendi
 			To: row.Headers.To,
 			Cc: row.Headers.Cc,
 		},
+		OneClickUnsubscribe: unsubscribeFromRow(row.Headers),
 	}, nil
+}
+
+// unsubscribeFromRow reads the unsubscribe endpoint out of the headers JSONB.
+// A Batch written before ADR 0005 has no such key, which is indistinguishable
+// from — and treated as — a Batch that states no endpoint.
+func unsubscribeFromRow(h sqlc.Headers) batch.OneClickUnsubscribe {
+	if h.OneClickUnsubscribe == nil {
+		return batch.OneClickUnsubscribe{}
+	}
+	return batch.OneClickUnsubscribe{URLTemplate: h.OneClickUnsubscribe.URLTemplate}
 }

--- a/internal/envelope/builder_test.go
+++ b/internal/envelope/builder_test.go
@@ -91,11 +91,16 @@ func (c *countingTokens) CreateOpenToken(ctx context.Context, messageID, email s
 	return c.next("open")
 }
 
+// testBatchID is the Batch every single-Batch test builds against. Tests that
+// care about the boundary between Batches state their own IDs and use
+// mustDeliveryTracked directly.
+const testBatchID = "msg-1@test.com"
+
 // mustDelivery builds a Delivery carrying the Tracking Policy a fresh Domain
 // resolves to, which is identified on both axes (ADR 0003).
-func mustDelivery(t *testing.T, batchID batch.ID, email string, fields map[string]string) *delivery.Delivery {
+func mustDelivery(t *testing.T, email string, fields map[string]string) *delivery.Delivery {
 	t.Helper()
-	return mustDeliveryTracked(t, batchID, email, fields, tracking.Policy{
+	return mustDeliveryTracked(t, batch.ID(testBatchID), email, fields, tracking.Policy{
 		Opens: tracking.ModeIdentified,
 		Links: tracking.ModeIdentified,
 	})
@@ -138,7 +143,7 @@ func TestBuilderRendersSubjectFromAndTo(t *testing.T) {
 	}}
 	b := envelope.NewBuilderWith(src, stubTokens{link: "ltok", open: "otok"})
 
-	d := mustDelivery(t, batch.ID("msg-1@test.com"), "rcpt@example.com", map[string]string{"name": "World"})
+	d := mustDelivery(t, "rcpt@example.com", map[string]string{"name": "World"})
 	env, err := b.Build(t.Context(), d)
 	assert.Nil(t, err)
 
@@ -166,7 +171,7 @@ func TestBuilderInsertsTrackingPixelAndRewritesLinks(t *testing.T) {
 	}}
 	b := envelope.NewBuilderWith(src, stubTokens{link: "LTOK", open: "OTOK"})
 
-	d := mustDelivery(t, batch.ID("msg-1@test.com"), "rcpt@example.com", nil)
+	d := mustDelivery(t, "rcpt@example.com", nil)
 	env, err := b.Build(t.Context(), d)
 	assert.Nil(t, err)
 
@@ -539,4 +544,76 @@ func TestEnvelopeToProto(t *testing.T) {
 	assert.Equal(t, "rp", pb.ReturnPath)
 	assert.Equal(t, []byte("body"), pb.Body)
 	assert.True(t, pb.ShouldRetry)
+}
+
+// TestBuilderCarriesTheUnsubscribeEndpoint checks the whole path: the Batch's
+// template is personalised for this Delivery, percent-encoded, and emitted as
+// the RFC 8058 pair.
+func TestBuilderCarriesTheUnsubscribeEndpoint(t *testing.T) {
+	priv := newDKIMKeys(t)
+	src := stubSource{data: envelope.SendingData{
+		Subject:        "Hello",
+		HTML:           "<html><body>hi</body></html>",
+		Domain:         "test.com",
+		MessageID:      "msg-1",
+		SenderEmail:    "noreply@test.com",
+		SenderAlias:    "Test",
+		DkimPrivateKey: priv,
+		OneClickUnsubscribe: batch.OneClickUnsubscribe{
+			URLTemplate: "https://sender.example/unsub?email={{ email }}",
+		},
+	}}
+	b := envelope.NewBuilderWith(src, stubTokens{link: "ltok", open: "otok"})
+
+	d := mustDelivery(t, "mario+rossi@example.com", nil)
+	env, err := b.Build(t.Context(), d)
+	require.NoError(t, err)
+
+	parsed, err := mail.ReadMessage(bytes.NewReader(env.Body()))
+	require.NoError(t, err)
+
+	// The address is injected as the `email` field and escaped for a query, so
+	// the '+' survives as %2B rather than reaching the endpoint as a space.
+	assert.Equal(t, "<https://sender.example/unsub?email=mario%2Brossi%40example.com>",
+		parsed.Header.Get("List-Unsubscribe"))
+	assert.Equal(t, "List-Unsubscribe=One-Click", parsed.Header.Get("List-Unsubscribe-Post"))
+}
+
+// TestBuilderSignsAFixedHeaderSet pins the h= tag. It is fixed rather than
+// derived from the message so that a header added in transit breaks the
+// signature (RFC 6376 §5.4), and the two List-* names appear twice so that the
+// protection extends to a message that already carries them.
+func TestBuilderSignsAFixedHeaderSet(t *testing.T) {
+	priv := newDKIMKeys(t)
+	src := stubSource{data: envelope.SendingData{
+		Subject:        "Hello",
+		HTML:           "<html><body>hi</body></html>",
+		Domain:         "test.com",
+		MessageID:      "msg-1",
+		SenderEmail:    "noreply@test.com",
+		SenderAlias:    "Test",
+		DkimPrivateKey: priv,
+	}}
+	b := envelope.NewBuilderWith(src, stubTokens{link: "ltok", open: "otok"})
+
+	// No Cc and no unsubscribe on this message: they must still be signed.
+	d := mustDelivery(t, "rcpt@example.com", nil)
+	env, err := b.Build(t.Context(), d)
+	require.NoError(t, err)
+
+	parsed, err := mail.ReadMessage(bytes.NewReader(env.Body()))
+	require.NoError(t, err)
+
+	sig := parsed.Header.Get("DKIM-Signature")
+	require.NotEmpty(t, sig)
+	// Anchored on the tag separator, so this does not match the bh= body hash.
+	m := regexp.MustCompile(`(?:^|;)\s*h=([^;]+)`).FindStringSubmatch(sig)
+	require.Len(t, m, 2, "DKIM-Signature must carry an h= tag")
+	signed := strings.Split(strings.ReplaceAll(m[1], " ", ""), ":")
+
+	assert.Equal(t, []string{
+		"From", "To", "Cc", "Subject", "Message-ID",
+		"List-Unsubscribe", "List-Unsubscribe",
+		"List-Unsubscribe-Post", "List-Unsubscribe-Post",
+	}, signed)
 }

--- a/internal/envelope/message.go
+++ b/internal/envelope/message.go
@@ -16,6 +16,14 @@ import (
 
 type headers map[string][]string
 
+// The RFC 8058 pair. The URL is wrapped in angle brackets per RFC 2369, which
+// is what delimits a URI that may itself contain a comma or a space, and the
+// Post value is the fixed token the specification defines — not a variable.
+const (
+	headerListUnsubscribe     = "List-Unsubscribe"
+	headerListUnsubscribePost = "List-Unsubscribe-Post"
+)
+
 // Attachments maps an attachment filename to a reader producing its bytes.
 type Attachments map[string]io.Reader
 
@@ -31,7 +39,7 @@ func buildReturnPath(to, messageID string) string {
 	return fmt.Sprintf("bump_%v+%v", emailBase64, messageID)
 }
 
-func buildHeaders(subject string, sender batch.Sender, to, poolMessageID, messageID string, baseHeaders headers, customHeaders batch.Headers) headers {
+func buildHeaders(subject string, sender batch.Sender, to, poolMessageID, messageID string, baseHeaders headers, customHeaders batch.Headers, unsubscribeURL string) headers {
 	h := make(headers)
 	for k, v := range baseHeaders {
 		h[k] = make([]string, len(v))
@@ -49,6 +57,13 @@ func buildHeaders(subject string, sender batch.Sender, to, poolMessageID, messag
 	}
 	if len(customHeaders.Cc) > 0 {
 		h["Cc"] = customHeaders.Cc
+	}
+
+	// The two travel together or not at all: List-Unsubscribe-Post is what makes
+	// the URL a one-click endpoint, and on its own it says nothing.
+	if unsubscribeURL != "" {
+		h[headerListUnsubscribe] = []string{fmt.Sprintf("<%s>", unsubscribeURL)}
+		h[headerListUnsubscribePost] = []string{"List-Unsubscribe=One-Click"}
 	}
 
 	return h

--- a/internal/envelope/message_test.go
+++ b/internal/envelope/message_test.go
@@ -22,7 +22,7 @@ func TestBuildHeaders(t *testing.T) {
 	sender := batch.Sender{Email: "from@email.com", Alias: "email"}
 
 	baseHeaders := headers{"testH": {"testH"}}
-	h := buildHeaders("test subject", sender, "to@email.com", "132@email.com", "<msg-123@email.com>", baseHeaders, batch.Headers{})
+	h := buildHeaders("test subject", sender, "to@email.com", "132@email.com", "<msg-123@email.com>", baseHeaders, batch.Headers{}, "")
 
 	assert.Equal(t, "testH", h["testH"][0])
 	assert.Equal(t, "test subject", h["Subject"][0])
@@ -34,14 +34,14 @@ func TestBuildHeadersShouldCopyBaseHeader(t *testing.T) {
 	baseHeaders := headers{"testH": {"testH"}}
 	sender := batch.Sender{Email: "from@email.com", Alias: "email"}
 
-	buildHeaders("test subject", sender, "to@email.com", "132@email.com", "<msg-123@email.com>", baseHeaders, batch.Headers{})
+	buildHeaders("test subject", sender, "to@email.com", "132@email.com", "<msg-123@email.com>", baseHeaders, batch.Headers{}, "")
 	assert.Equal(t, 1, len(baseHeaders))
 }
 
 func TestBuildHeadersCustomTo(t *testing.T) {
 	sender := batch.Sender{Email: "from@email.com", Alias: "email"}
 	ch := batch.Headers{To: []string{"visible@example.com"}}
-	h := buildHeaders("test subject", sender, "to@email.com", "132@email.com", "<msg-123@email.com>", headers{}, ch)
+	h := buildHeaders("test subject", sender, "to@email.com", "132@email.com", "<msg-123@email.com>", headers{}, ch, "")
 
 	assert.Equal(t, []string{"visible@example.com"}, h["To"])
 	_, hasCC := h["Cc"]
@@ -51,7 +51,7 @@ func TestBuildHeadersCustomTo(t *testing.T) {
 func TestBuildHeadersWithCC(t *testing.T) {
 	sender := batch.Sender{Email: "from@email.com", Alias: "email"}
 	ch := batch.Headers{Cc: []string{"cc1@example.com", "cc2@example.com"}}
-	h := buildHeaders("test subject", sender, "to@email.com", "132@email.com", "<msg-123@email.com>", headers{}, ch)
+	h := buildHeaders("test subject", sender, "to@email.com", "132@email.com", "<msg-123@email.com>", headers{}, ch, "")
 
 	assert.Equal(t, []string{"to@email.com"}, h["To"])
 	assert.Equal(t, []string{"cc1@example.com", "cc2@example.com"}, h["Cc"])
@@ -63,7 +63,7 @@ func TestBuildHeadersBothToAndCC(t *testing.T) {
 		To: []string{"visible@example.com", "visible2@example.com"},
 		Cc: []string{"cc@example.com"},
 	}
-	h := buildHeaders("test subject", sender, "to@email.com", "132@email.com", "<msg-123@email.com>", headers{}, ch)
+	h := buildHeaders("test subject", sender, "to@email.com", "132@email.com", "<msg-123@email.com>", headers{}, ch, "")
 
 	assert.Equal(t, []string{"visible@example.com", "visible2@example.com"}, h["To"])
 	assert.Equal(t, []string{"cc@example.com"}, h["Cc"])

--- a/internal/envelope/unsubscribe_test.go
+++ b/internal/envelope/unsubscribe_test.go
@@ -1,0 +1,54 @@
+package envelope
+
+import (
+	"testing"
+
+	"github.com/kannon-email/kannon/internal/batch"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildHeadersEmitsTheRFC8058Pair(t *testing.T) {
+	sender := batch.Sender{Email: "noreply@test.com", Alias: "Test"}
+	h := buildHeaders("subject", sender, "to@test.com", "132@test.com", "<msg-123@test.com>",
+		headers{}, batch.Headers{}, "https://test.com/unsub?u=abc")
+
+	assert.Equal(t, []string{"<https://test.com/unsub?u=abc>"}, h["List-Unsubscribe"],
+		"RFC 2369 delimits the URI with angle brackets")
+	assert.Equal(t, []string{"List-Unsubscribe=One-Click"}, h["List-Unsubscribe-Post"])
+}
+
+func TestBuildHeadersOmitsBothWhenNoEndpointIsStated(t *testing.T) {
+	sender := batch.Sender{Email: "noreply@test.com", Alias: "Test"}
+	h := buildHeaders("subject", sender, "to@test.com", "132@test.com", "<msg-123@test.com>",
+		headers{}, batch.Headers{}, "")
+
+	assert.NotContains(t, h, "List-Unsubscribe")
+	assert.NotContains(t, h, "List-Unsubscribe-Post",
+		"the Post header says nothing on its own and must never travel alone")
+}
+
+func TestResolveUnsubscribeURLPersonalisesPerDelivery(t *testing.T) {
+	u := batch.OneClickUnsubscribe{URLTemplate: "https://test.com/unsub?email={{ email }}"}
+
+	got := resolveUnsubscribeURL(u, map[string]string{"email": "mario+rossi@test.com"})
+
+	assert.Equal(t, "https://test.com/unsub?email=mario%2Brossi%40test.com", got)
+}
+
+func TestResolveUnsubscribeURLOmitsRatherThanShipBroken(t *testing.T) {
+	// The backstop of ADR 0005: intake should have refused this Recipient, so
+	// reaching here means the check did not run. A message with no unsubscribe
+	// header beats one advertising an authenticated endpoint that has braces in
+	// it.
+	u := batch.OneClickUnsubscribe{URLTemplate: "https://test.com/unsub?t={{ token }}"}
+
+	got := resolveUnsubscribeURL(u, map[string]string{"email": "rcpt@test.com"})
+
+	assert.Empty(t, got)
+}
+
+func TestResolveUnsubscribeURLIsEmptyWhenNoneIsStated(t *testing.T) {
+	got := resolveUnsubscribeURL(batch.OneClickUnsubscribe{}, map[string]string{})
+
+	assert.Empty(t, got)
+}

--- a/internal/utils/template.go
+++ b/internal/utils/template.go
@@ -2,17 +2,76 @@ package utils
 
 import (
 	"fmt"
+	"net/url"
 	"regexp"
 )
 
 func ReplaceCustomFields(str string, fields map[string]string) string {
+	return replaceCustomFields(str, fields, func(v string) string { return v })
+}
+
+// ReplaceCustomFieldsInURL substitutes the same placeholders as
+// ReplaceCustomFields, percent-encoding every value it puts in.
+//
+// Encoding happens here and not in ReplaceCustomFields because this is the one
+// caller that knows the context of the result. In a body the same placeholder
+// may be prose, an attribute or a URL, so escaping it would corrupt as often as
+// it would help; here the string is a URL by construction. Without it, an
+// address like `mario+rossi@example.com` reaches the endpoint as
+// `mario rossi@example.com`, and a value containing `&` silently appends a
+// parameter to someone else's URL.
+//
+// Values are escaped for a query component, which is where a placeholder in an
+// unsubscribe URL sits in practice. A value substituted into a path segment is
+// still safe, but a space in one arrives as `+` rather than `%20`.
+func ReplaceCustomFieldsInURL(str string, fields map[string]string) string {
+	return replaceCustomFields(str, fields, url.QueryEscape)
+}
+
+func replaceCustomFields(str string, fields map[string]string, escape func(string) string) string {
 	for key, value := range fields {
 		regExp := fmt.Sprintf(`\{\{ *%s *\}\}`, key)
 		reg, err := regexp.Compile(regExp)
 		if err != nil {
 			continue
 		}
-		str = reg.ReplaceAllString(str, value)
+		str = reg.ReplaceAllString(str, escape(value))
 	}
 	return str
+}
+
+// placeholderReg matches a placeholder in the shape replaceCustomFields
+// substitutes: `{{ name }}`, with optional spaces and no nesting.
+var placeholderReg = regexp.MustCompile(`\{\{ *[^{}]* *\}\}`)
+
+// HasUnresolvedPlaceholders reports whether a substituted string still contains
+// a placeholder — meaning the fields on hand did not name it.
+//
+// ReplaceCustomFields leaves such a placeholder verbatim rather than blanking
+// it. In a body that is cosmetic; in a header that drives an unauthenticated
+// POST it is the difference between an unsubscribe that works and one that only
+// claims to, so the callers that build headers check for it.
+func HasUnresolvedPlaceholders(str string) bool {
+	return placeholderReg.MatchString(str)
+}
+
+// EffectiveFields is the field map one Delivery is rendered with: the
+// Recipient's own fields, plus `email` holding the Recipient's address.
+//
+// The injected value is a **default**, not an override. A caller that passes an
+// `email` field of its own keeps its value, because silently replacing it would
+// change what templates already in production render, with nothing to tell the
+// caller why.
+//
+// This is the single definition of "the fields available to this Delivery", and
+// it is deliberately shared by the intake check and the renderer: were they to
+// disagree, intake would accept a Recipient the Builder cannot resolve, or
+// refuse one it could.
+func EffectiveFields(email string, fields map[string]string) map[string]string {
+	out := make(map[string]string, len(fields)+1)
+	out["email"] = email
+	for k, v := range fields {
+		out[k] = v
+	}
+	return out
 }

--- a/internal/utils/template_test.go
+++ b/internal/utils/template_test.go
@@ -27,3 +27,56 @@ func TestReplaceCustomFieldsInLinks(t *testing.T) {
 	res := utils.ReplaceCustomFields(str, fields)
 	assert.Equal(t, "Hello <a href=\"https://mylink.com\" />", res)
 }
+
+func TestReplaceCustomFieldsInURLEncodesValues(t *testing.T) {
+	// The '+' is the case that matters most: injected automatically as the
+	// `email` field, it would otherwise reach the endpoint decoded as a space.
+	str := "https://test.com/unsub?email={{ email }}"
+	fields := map[string]string{"email": "mario+rossi@test.com"}
+
+	res := utils.ReplaceCustomFieldsInURL(str, fields)
+	assert.Equal(t, "https://test.com/unsub?email=mario%2Brossi%40test.com", res)
+}
+
+func TestReplaceCustomFieldsInURLPreventsParameterInjection(t *testing.T) {
+	str := "https://test.com/unsub?u={{ token }}"
+	fields := map[string]string{"token": "abc&admin=1"}
+
+	res := utils.ReplaceCustomFieldsInURL(str, fields)
+	assert.Equal(t, "https://test.com/unsub?u=abc%26admin%3D1", res,
+		"a field value must not be able to append a parameter to someone else's URL")
+}
+
+func TestReplaceCustomFieldsLeavesBodyValuesUnescaped(t *testing.T) {
+	// The body has no single context to escape for, so it stays as it was.
+	res := utils.ReplaceCustomFields("Hello {{ name }}", map[string]string{"name": "Mario Rossi"})
+	assert.Equal(t, "Hello Mario Rossi", res)
+}
+
+func TestHasUnresolvedPlaceholders(t *testing.T) {
+	assert.True(t, utils.HasUnresolvedPlaceholders("https://t.com/u?t={{ token }}"))
+	assert.True(t, utils.HasUnresolvedPlaceholders("https://t.com/u?t={{token}}"))
+	assert.False(t, utils.HasUnresolvedPlaceholders("https://t.com/u?t=abc"))
+}
+
+func TestEffectiveFieldsInjectsRecipientAddress(t *testing.T) {
+	fields := utils.EffectiveFields("rcpt@test.com", map[string]string{"name": "Mario"})
+
+	assert.Equal(t, "rcpt@test.com", fields["email"])
+	assert.Equal(t, "Mario", fields["name"])
+}
+
+func TestEffectiveFieldsDoesNotOverrideACallerSuppliedEmail(t *testing.T) {
+	// A caller that already passes an `email` field keeps its value: silently
+	// replacing it would change what templates already in production render.
+	fields := utils.EffectiveFields("rcpt@test.com", map[string]string{"email": "billing@test.com"})
+
+	assert.Equal(t, "billing@test.com", fields["email"])
+}
+
+func TestEffectiveFieldsDoesNotMutateTheCallersMap(t *testing.T) {
+	original := map[string]string{"name": "Mario"}
+	utils.EffectiveFields("rcpt@test.com", original)
+
+	assert.Equal(t, map[string]string{"name": "Mario"}, original)
+}

--- a/pkg/api/mailapi/mailer.go
+++ b/pkg/api/mailapi/mailer.go
@@ -53,15 +53,16 @@ func (s mailAPIService) SendHTML(ctx context.Context, req *connect.Request[pb.Se
 	}
 
 	res := &pb.SendTemplateReq{
-		Sender:        req.Msg.Sender,
-		Subject:       req.Msg.Subject,
-		TemplateId:    template.TemplateID(),
-		ScheduledTime: req.Msg.ScheduledTime,
-		Recipients:    req.Msg.Recipients,
-		Attachments:   req.Msg.Attachments,
-		GlobalFields:  nil,
-		Headers:       req.Msg.Headers,
-		Tracking:      req.Msg.Tracking,
+		Sender:              req.Msg.Sender,
+		Subject:             req.Msg.Subject,
+		TemplateId:          template.TemplateID(),
+		ScheduledTime:       req.Msg.ScheduledTime,
+		Recipients:          req.Msg.Recipients,
+		Attachments:         req.Msg.Attachments,
+		GlobalFields:        nil,
+		Headers:             req.Msg.Headers,
+		Tracking:            req.Msg.Tracking,
+		OneClickUnsubscribe: req.Msg.OneClickUnsubscribe,
 	}
 
 	return s.sendTemplate(ctx, domain, connect.NewRequest(res))
@@ -128,7 +129,19 @@ func (s mailAPIService) sendTemplate(ctx context.Context, domain *domains.Domain
 		return nil, batchTrackingCeilingError(violations)
 	}
 
-	b, err := batch.New(domain.Domain(), req.Msg.Subject, sender, template.TemplateID(), attachments, customHeaders, batchPolicy)
+	// A malformed or non-https endpoint is a fault in the request as a whole,
+	// not in one of its rows, so it fails the call rather than refusing
+	// Recipients one by one (ADR 0005). batch.New holds the invariant.
+	b, err := batch.New(batch.NewParams{
+		Domain:              domain.Domain(),
+		Subject:             req.Msg.Subject,
+		Sender:              sender,
+		TemplateID:          template.TemplateID(),
+		Attachments:         attachments,
+		Headers:             customHeaders,
+		OneClickUnsubscribe: unsubscribeFromRequest(req.Msg.OneClickUnsubscribe),
+		Tracking:            batchPolicy,
+	})
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
@@ -179,6 +192,12 @@ const (
 	// newer schema. Both leave the caller the same work — restate the Policy —
 	// so they share one reason.
 	reasonUnsupportedTrackingMode rejectionReason = "unsupported_tracking_mode"
+	// reasonUnsubscribeURLUnresolved is a Recipient whose fields leave a
+	// placeholder in the Batch's one-click unsubscribe URL unresolved. Refusing
+	// it beats sending it: the alternative is a DKIM-signed header advertising an
+	// authenticated one-click endpoint that is in fact a URL with braces in it,
+	// and a recipient who presses the button and stays subscribed (ADR 0005).
+	reasonUnsubscribeURLUnresolved rejectionReason = "unsubscribe_url_unresolved"
 )
 
 // intake is what became of a Batch's Recipients as they were taken in: those
@@ -228,6 +247,10 @@ func (s mailAPIService) scheduleBatch(ctx context.Context, domain *domains.Domai
 			taken.reject(r.Email, rejection.reason, rejection.detail)
 			continue
 		}
+		if detail, ok := unresolvedUnsubscribeURL(b.OneClickUnsubscribe(), r.Email, r.Fields); !ok {
+			taken.reject(r.Email, reasonUnsubscribeURLUnresolved, detail)
+			continue
+		}
 		d, err := delivery.New(delivery.NewParams{
 			BatchID:       b.ID(),
 			Email:         r.Email,
@@ -250,6 +273,34 @@ func (s mailAPIService) scheduleBatch(ctx context.Context, domain *domains.Domai
 		return nil, fmt.Errorf("cannot schedule deliveries for batch %s: %w", b.ID().String(), err)
 	}
 	return taken, nil
+}
+
+// unsubscribeFromRequest maps the wire type onto the domain value object. A
+// caller stating nothing yields the zero value, and no unsubscribe header.
+func unsubscribeFromRequest(u *mailertypes.OneClickUnsubscribe) batch.OneClickUnsubscribe {
+	if u == nil {
+		return batch.OneClickUnsubscribe{}
+	}
+	return batch.OneClickUnsubscribe{URLTemplate: u.UrlTemplate}
+}
+
+// unresolvedUnsubscribeURL reports whether one Recipient's fields can resolve
+// the Batch's unsubscribe URL, returning an operator-facing detail when they
+// cannot.
+//
+// The check runs against utils.EffectiveFields, the same map the Builder will
+// render with, so that a Recipient accepted here is one the Builder can resolve.
+// Anything else would either queue a Delivery that silently loses its
+// unsubscribe header, or refuse a Recipient that would have been fine.
+func unresolvedUnsubscribeURL(u batch.OneClickUnsubscribe, email string, fields map[string]string) (string, bool) {
+	if u.IsZero() {
+		return "", true
+	}
+	resolved := utils.ReplaceCustomFieldsInURL(u.URLTemplate, utils.EffectiveFields(email, fields))
+	if utils.HasUnresolvedPlaceholders(resolved) {
+		return fmt.Sprintf("unsubscribe URL still holds a placeholder after substitution: %q", resolved), false
+	}
+	return "", true
 }
 
 // recipientRejection is why one Recipient was refused, split into the stable

--- a/pkg/api/mailapi/unsubscribe_test.go
+++ b/pkg/api/mailapi/unsubscribe_test.go
@@ -1,0 +1,111 @@
+package mailapi_test
+
+import (
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/kannon-email/kannon/internal/tests"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	mailerv1 "github.com/kannon-email/kannon/proto/kannon/mailer/apiv1"
+	types "github.com/kannon-email/kannon/proto/kannon/mailer/types"
+)
+
+// sendWithUnsubscribe performs one send stating an unsubscribe endpoint, and
+// returns whatever the API returned — success or failure — so a test can assert
+// on either.
+func sendWithUnsubscribe(t *testing.T, d *tests.DomainWithKey, urlTemplate string, recipients ...*types.Recipient) (*mailerv1.SendRes, error) {
+	t.Helper()
+	req := connect.NewRequest(&mailerv1.SendHTMLReq{
+		Sender: &types.Sender{
+			Email: "test@" + d.Domain.Domain,
+			Alias: "Test",
+		},
+		Recipients:          recipients,
+		Subject:             "Test",
+		Html:                `<p>Hello</p>`,
+		ScheduledTime:       timestamppb.Now(),
+		OneClickUnsubscribe: &types.OneClickUnsubscribe{UrlTemplate: urlTemplate},
+	})
+	authRequest(req, d)
+
+	res, err := ts.SendHTML(t.Context(), req)
+	if err != nil {
+		return nil, err
+	}
+	return res.Msg, nil
+}
+
+// TestSendAcceptsAnUnsubscribeResolvableFromTheInjectedAddress covers the case
+// that needs no per-Recipient data at all: `email` is supplied by Kannon.
+func TestSendAcceptsAnUnsubscribeResolvableFromTheInjectedAddress(t *testing.T) {
+	defer cleanDB(t)
+
+	d := createTestDomain(t)
+
+	res, err := sendWithUnsubscribe(t, d, "https://sender.example/unsub?email={{ email }}",
+		&types.Recipient{Email: "first@email.com"},
+		&types.Recipient{Email: "second@email.com"},
+	)
+	require.NoError(t, err)
+
+	assert.EqualValues(t, 2, res.AcceptedCount)
+	assert.Empty(t, res.RejectedRecipients)
+	assert.ElementsMatch(t, []string{"first@email.com", "second@email.com"},
+		poolEmails(t, res.MessageId))
+}
+
+// TestSendRejectsOnlyTheRecipientsThatCannotResolveTheUnsubscribe is the ADR
+// 0005 intake rule: one row missing a field does not fail a send of thousands,
+// and the caller is told which rows and why.
+func TestSendRejectsOnlyTheRecipientsThatCannotResolveTheUnsubscribe(t *testing.T) {
+	defer cleanDB(t)
+
+	d := createTestDomain(t)
+
+	res, err := sendWithUnsubscribe(t, d, "https://sender.example/unsub?t={{ token }}",
+		&types.Recipient{Email: "has@email.com", Fields: map[string]string{"token": "abc"}},
+		&types.Recipient{Email: "missing@email.com"},
+	)
+	require.NoError(t, err)
+
+	assert.EqualValues(t, 1, res.AcceptedCount)
+	assert.Equal(t, map[string]string{
+		"missing@email.com": "unsubscribe_url_unresolved",
+	}, rejections(t, res))
+	assert.Equal(t, []string{"has@email.com"}, poolEmails(t, res.MessageId))
+}
+
+// TestSendFailsEntirelyOnAMalformedUnsubscribeURL separates the two levels of
+// validation: a bad template is a fault in the request, not in one of its rows.
+func TestSendFailsEntirelyOnAMalformedUnsubscribeURL(t *testing.T) {
+	defer cleanDB(t)
+
+	d := createTestDomain(t)
+
+	for _, urlTemplate := range []string{
+		"http://sender.example/unsub",
+		"mailto:unsub@sender.example",
+		"/unsub",
+	} {
+		_, err := sendWithUnsubscribe(t, d, urlTemplate, &types.Recipient{Email: "first@email.com"})
+
+		require.Error(t, err, "expected %q to fail the call", urlTemplate)
+		assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+	}
+}
+
+// TestSendWithoutAnUnsubscribeIsUnaffected pins the default: Kannon never adds
+// an unsubscribe endpoint a caller did not state.
+func TestSendWithoutAnUnsubscribeIsUnaffected(t *testing.T) {
+	defer cleanDB(t)
+
+	d := createTestDomain(t)
+
+	res := requireSend(t, d, nil, &types.Recipient{Email: "first@email.com"})
+
+	assert.EqualValues(t, 1, res.AcceptedCount)
+	assert.Empty(t, res.RejectedRecipients)
+}

--- a/pkg/dispatcher/dispatch_cycle_incident_test.go
+++ b/pkg/dispatcher/dispatch_cycle_incident_test.go
@@ -139,9 +139,13 @@ func TestDispatchCycle_BudgetDeathMidPage_NoDeliveryLost(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	b, err := batch.New(domain, "incident repro",
-		batch.Sender{Email: "noreply@" + domain, Alias: "Incident"},
-		tpl.TemplateID, batch.Attachments{}, batch.Headers{}, tracking.Policy{})
+	b, err := batch.New(batch.NewParams{
+		Domain:      domain,
+		Subject:     "incident repro",
+		Sender:      batch.Sender{Email: "noreply@" + domain, Alias: "Incident"},
+		TemplateID:  tpl.TemplateID,
+		Attachments: batch.Attachments{},
+	})
 	require.NoError(t, err)
 	require.NoError(t, sqlc.NewBatchRepository(testDB).Create(ctx, b))
 

--- a/proto/kannon/mailer/apiv1/mailerapiv1.pb.go
+++ b/proto/kannon/mailer/apiv1/mailerapiv1.pb.go
@@ -89,9 +89,13 @@ type SendHTMLReq struct {
 	// The Batch-level Tracking Policy. States nothing when omitted, which
 	// imposes no restriction of its own and resolves to the Domain's ceiling
 	// (ADR 0003). A Mode above that ceiling fails the call.
-	Tracking      *types1.TrackingPolicy `protobuf:"bytes,10,opt,name=tracking,proto3,oneof" json:"tracking,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	Tracking *types1.TrackingPolicy `protobuf:"bytes,10,opt,name=tracking,proto3,oneof" json:"tracking,omitempty"`
+	// The sender's own one-click unsubscribe endpoint, emitted as
+	// List-Unsubscribe + List-Unsubscribe-Post on every Delivery of this Batch.
+	// Omitted when absent: Kannon never adds one of its own.
+	OneClickUnsubscribe *types.OneClickUnsubscribe `protobuf:"bytes,11,opt,name=one_click_unsubscribe,json=oneClickUnsubscribe,proto3,oneof" json:"one_click_unsubscribe,omitempty"`
+	unknownFields       protoimpl.UnknownFields
+	sizeCache           protoimpl.SizeCache
 }
 
 func (x *SendHTMLReq) Reset() {
@@ -187,6 +191,13 @@ func (x *SendHTMLReq) GetTracking() *types1.TrackingPolicy {
 	return nil
 }
 
+func (x *SendHTMLReq) GetOneClickUnsubscribe() *types.OneClickUnsubscribe {
+	if x != nil {
+		return x.OneClickUnsubscribe
+	}
+	return nil
+}
+
 type SendTemplateReq struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Sender        *types.Sender          `protobuf:"bytes,1,opt,name=sender,proto3" json:"sender,omitempty"`
@@ -200,9 +211,13 @@ type SendTemplateReq struct {
 	// The Batch-level Tracking Policy. States nothing when omitted, which
 	// imposes no restriction of its own and resolves to the Domain's ceiling
 	// (ADR 0003). A Mode above that ceiling fails the call.
-	Tracking      *types1.TrackingPolicy `protobuf:"bytes,10,opt,name=tracking,proto3,oneof" json:"tracking,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	Tracking *types1.TrackingPolicy `protobuf:"bytes,10,opt,name=tracking,proto3,oneof" json:"tracking,omitempty"`
+	// The sender's own one-click unsubscribe endpoint, emitted as
+	// List-Unsubscribe + List-Unsubscribe-Post on every Delivery of this Batch.
+	// Omitted when absent: Kannon never adds one of its own.
+	OneClickUnsubscribe *types.OneClickUnsubscribe `protobuf:"bytes,11,opt,name=one_click_unsubscribe,json=oneClickUnsubscribe,proto3,oneof" json:"one_click_unsubscribe,omitempty"`
+	unknownFields       protoimpl.UnknownFields
+	sizeCache           protoimpl.SizeCache
 }
 
 func (x *SendTemplateReq) Reset() {
@@ -294,6 +309,13 @@ func (x *SendTemplateReq) GetHeaders() *types.Headers {
 func (x *SendTemplateReq) GetTracking() *types1.TrackingPolicy {
 	if x != nil {
 		return x.Tracking
+	}
+	return nil
+}
+
+func (x *SendTemplateReq) GetOneClickUnsubscribe() *types.OneClickUnsubscribe {
+	if x != nil {
+		return x.OneClickUnsubscribe
 	}
 	return nil
 }
@@ -404,6 +426,10 @@ type RejectedRecipient struct {
 	//	unsupported_tracking_mode  the Recipient stated a Tracking Mode this
 	//	                           build will not act on — the reserved
 	//	                           `pseudonymous`, or a value from a newer schema
+	//	unsubscribe_url_unresolved this Recipient's fields leave a placeholder in
+	//	                           one_click_unsubscribe.url_template unresolved,
+	//	                           so its unsubscribe endpoint would be advertised
+	//	                           as authenticated while being unreachable
 	//
 	// Treat an unrecognised value as a refusal of unknown cause: the set grows as
 	// new causes are added.
@@ -464,7 +490,7 @@ const file_kannon_mailer_apiv1_mailerapiv1_proto_rawDesc = "" +
 	"\n" +
 	"Attachment\x12\x1a\n" +
 	"\bfilename\x18\x01 \x01(\tR\bfilename\x12\x18\n" +
-	"\acontent\x18\x02 \x01(\fR\acontent\"\x9e\x05\n" +
+	"\acontent\x18\x02 \x01(\fR\acontent\"\x9f\x06\n" +
 	"\vSendHTMLReq\x127\n" +
 	"\x06sender\x18\x01 \x01(\v2\x1f.pkg.kannon.mailer.types.SenderR\x06sender\x12\x18\n" +
 	"\asubject\x18\x03 \x01(\tR\asubject\x12\x12\n" +
@@ -477,14 +503,16 @@ const file_kannon_mailer_apiv1_mailerapiv1_proto_rawDesc = "" +
 	"\rglobal_fields\x18\b \x03(\v26.pkg.kannon.mailer.apiv1.SendHTMLReq.GlobalFieldsEntryR\fglobalFields\x12?\n" +
 	"\aheaders\x18\t \x01(\v2 .pkg.kannon.mailer.types.HeadersH\x01R\aheaders\x88\x01\x01\x12J\n" +
 	"\btracking\x18\n" +
-	" \x01(\v2).pkg.kannon.tracking.types.TrackingPolicyH\x02R\btracking\x88\x01\x01\x1a?\n" +
+	" \x01(\v2).pkg.kannon.tracking.types.TrackingPolicyH\x02R\btracking\x88\x01\x01\x12e\n" +
+	"\x15one_click_unsubscribe\x18\v \x01(\v2,.pkg.kannon.mailer.types.OneClickUnsubscribeH\x03R\x13oneClickUnsubscribe\x88\x01\x01\x1a?\n" +
 	"\x11GlobalFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01B\x11\n" +
 	"\x0f_scheduled_timeB\n" +
 	"\n" +
 	"\b_headersB\v\n" +
-	"\t_tracking\"\xb3\x05\n" +
+	"\t_trackingB\x18\n" +
+	"\x16_one_click_unsubscribe\"\xb4\x06\n" +
 	"\x0fSendTemplateReq\x127\n" +
 	"\x06sender\x18\x01 \x01(\v2\x1f.pkg.kannon.mailer.types.SenderR\x06sender\x12\x18\n" +
 	"\asubject\x18\x03 \x01(\tR\asubject\x12\x1f\n" +
@@ -498,14 +526,16 @@ const file_kannon_mailer_apiv1_mailerapiv1_proto_rawDesc = "" +
 	"\rglobal_fields\x18\b \x03(\v2:.pkg.kannon.mailer.apiv1.SendTemplateReq.GlobalFieldsEntryR\fglobalFields\x12?\n" +
 	"\aheaders\x18\t \x01(\v2 .pkg.kannon.mailer.types.HeadersH\x01R\aheaders\x88\x01\x01\x12J\n" +
 	"\btracking\x18\n" +
-	" \x01(\v2).pkg.kannon.tracking.types.TrackingPolicyH\x02R\btracking\x88\x01\x01\x1a?\n" +
+	" \x01(\v2).pkg.kannon.tracking.types.TrackingPolicyH\x02R\btracking\x88\x01\x01\x12e\n" +
+	"\x15one_click_unsubscribe\x18\v \x01(\v2,.pkg.kannon.mailer.types.OneClickUnsubscribeH\x03R\x13oneClickUnsubscribe\x88\x01\x01\x1a?\n" +
 	"\x11GlobalFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01B\x11\n" +
 	"\x0f_scheduled_timeB\n" +
 	"\n" +
 	"\b_headersB\v\n" +
-	"\t_tracking\"\xb7\x02\n" +
+	"\t_trackingB\x18\n" +
+	"\x16_one_click_unsubscribe\"\xb7\x02\n" +
 	"\aSendRes\x12\x1d\n" +
 	"\n" +
 	"message_id\x18\x01 \x01(\tR\tmessageId\x12\x1f\n" +
@@ -537,18 +567,19 @@ func file_kannon_mailer_apiv1_mailerapiv1_proto_rawDescGZIP() []byte {
 
 var file_kannon_mailer_apiv1_mailerapiv1_proto_msgTypes = make([]protoimpl.MessageInfo, 7)
 var file_kannon_mailer_apiv1_mailerapiv1_proto_goTypes = []any{
-	(*Attachment)(nil),            // 0: pkg.kannon.mailer.apiv1.Attachment
-	(*SendHTMLReq)(nil),           // 1: pkg.kannon.mailer.apiv1.SendHTMLReq
-	(*SendTemplateReq)(nil),       // 2: pkg.kannon.mailer.apiv1.SendTemplateReq
-	(*SendRes)(nil),               // 3: pkg.kannon.mailer.apiv1.SendRes
-	(*RejectedRecipient)(nil),     // 4: pkg.kannon.mailer.apiv1.RejectedRecipient
-	nil,                           // 5: pkg.kannon.mailer.apiv1.SendHTMLReq.GlobalFieldsEntry
-	nil,                           // 6: pkg.kannon.mailer.apiv1.SendTemplateReq.GlobalFieldsEntry
-	(*types.Sender)(nil),          // 7: pkg.kannon.mailer.types.Sender
-	(*timestamppb.Timestamp)(nil), // 8: google.protobuf.Timestamp
-	(*types.Recipient)(nil),       // 9: pkg.kannon.mailer.types.Recipient
-	(*types.Headers)(nil),         // 10: pkg.kannon.mailer.types.Headers
-	(*types1.TrackingPolicy)(nil), // 11: pkg.kannon.tracking.types.TrackingPolicy
+	(*Attachment)(nil),                // 0: pkg.kannon.mailer.apiv1.Attachment
+	(*SendHTMLReq)(nil),               // 1: pkg.kannon.mailer.apiv1.SendHTMLReq
+	(*SendTemplateReq)(nil),           // 2: pkg.kannon.mailer.apiv1.SendTemplateReq
+	(*SendRes)(nil),                   // 3: pkg.kannon.mailer.apiv1.SendRes
+	(*RejectedRecipient)(nil),         // 4: pkg.kannon.mailer.apiv1.RejectedRecipient
+	nil,                               // 5: pkg.kannon.mailer.apiv1.SendHTMLReq.GlobalFieldsEntry
+	nil,                               // 6: pkg.kannon.mailer.apiv1.SendTemplateReq.GlobalFieldsEntry
+	(*types.Sender)(nil),              // 7: pkg.kannon.mailer.types.Sender
+	(*timestamppb.Timestamp)(nil),     // 8: google.protobuf.Timestamp
+	(*types.Recipient)(nil),           // 9: pkg.kannon.mailer.types.Recipient
+	(*types.Headers)(nil),             // 10: pkg.kannon.mailer.types.Headers
+	(*types1.TrackingPolicy)(nil),     // 11: pkg.kannon.tracking.types.TrackingPolicy
+	(*types.OneClickUnsubscribe)(nil), // 12: pkg.kannon.mailer.types.OneClickUnsubscribe
 }
 var file_kannon_mailer_apiv1_mailerapiv1_proto_depIdxs = []int32{
 	7,  // 0: pkg.kannon.mailer.apiv1.SendHTMLReq.sender:type_name -> pkg.kannon.mailer.types.Sender
@@ -558,24 +589,26 @@ var file_kannon_mailer_apiv1_mailerapiv1_proto_depIdxs = []int32{
 	5,  // 4: pkg.kannon.mailer.apiv1.SendHTMLReq.global_fields:type_name -> pkg.kannon.mailer.apiv1.SendHTMLReq.GlobalFieldsEntry
 	10, // 5: pkg.kannon.mailer.apiv1.SendHTMLReq.headers:type_name -> pkg.kannon.mailer.types.Headers
 	11, // 6: pkg.kannon.mailer.apiv1.SendHTMLReq.tracking:type_name -> pkg.kannon.tracking.types.TrackingPolicy
-	7,  // 7: pkg.kannon.mailer.apiv1.SendTemplateReq.sender:type_name -> pkg.kannon.mailer.types.Sender
-	8,  // 8: pkg.kannon.mailer.apiv1.SendTemplateReq.scheduled_time:type_name -> google.protobuf.Timestamp
-	9,  // 9: pkg.kannon.mailer.apiv1.SendTemplateReq.recipients:type_name -> pkg.kannon.mailer.types.Recipient
-	0,  // 10: pkg.kannon.mailer.apiv1.SendTemplateReq.attachments:type_name -> pkg.kannon.mailer.apiv1.Attachment
-	6,  // 11: pkg.kannon.mailer.apiv1.SendTemplateReq.global_fields:type_name -> pkg.kannon.mailer.apiv1.SendTemplateReq.GlobalFieldsEntry
-	10, // 12: pkg.kannon.mailer.apiv1.SendTemplateReq.headers:type_name -> pkg.kannon.mailer.types.Headers
-	11, // 13: pkg.kannon.mailer.apiv1.SendTemplateReq.tracking:type_name -> pkg.kannon.tracking.types.TrackingPolicy
-	8,  // 14: pkg.kannon.mailer.apiv1.SendRes.scheduled_time:type_name -> google.protobuf.Timestamp
-	4,  // 15: pkg.kannon.mailer.apiv1.SendRes.rejected_recipients:type_name -> pkg.kannon.mailer.apiv1.RejectedRecipient
-	1,  // 16: pkg.kannon.mailer.apiv1.Mailer.SendHTML:input_type -> pkg.kannon.mailer.apiv1.SendHTMLReq
-	2,  // 17: pkg.kannon.mailer.apiv1.Mailer.SendTemplate:input_type -> pkg.kannon.mailer.apiv1.SendTemplateReq
-	3,  // 18: pkg.kannon.mailer.apiv1.Mailer.SendHTML:output_type -> pkg.kannon.mailer.apiv1.SendRes
-	3,  // 19: pkg.kannon.mailer.apiv1.Mailer.SendTemplate:output_type -> pkg.kannon.mailer.apiv1.SendRes
-	18, // [18:20] is the sub-list for method output_type
-	16, // [16:18] is the sub-list for method input_type
-	16, // [16:16] is the sub-list for extension type_name
-	16, // [16:16] is the sub-list for extension extendee
-	0,  // [0:16] is the sub-list for field type_name
+	12, // 7: pkg.kannon.mailer.apiv1.SendHTMLReq.one_click_unsubscribe:type_name -> pkg.kannon.mailer.types.OneClickUnsubscribe
+	7,  // 8: pkg.kannon.mailer.apiv1.SendTemplateReq.sender:type_name -> pkg.kannon.mailer.types.Sender
+	8,  // 9: pkg.kannon.mailer.apiv1.SendTemplateReq.scheduled_time:type_name -> google.protobuf.Timestamp
+	9,  // 10: pkg.kannon.mailer.apiv1.SendTemplateReq.recipients:type_name -> pkg.kannon.mailer.types.Recipient
+	0,  // 11: pkg.kannon.mailer.apiv1.SendTemplateReq.attachments:type_name -> pkg.kannon.mailer.apiv1.Attachment
+	6,  // 12: pkg.kannon.mailer.apiv1.SendTemplateReq.global_fields:type_name -> pkg.kannon.mailer.apiv1.SendTemplateReq.GlobalFieldsEntry
+	10, // 13: pkg.kannon.mailer.apiv1.SendTemplateReq.headers:type_name -> pkg.kannon.mailer.types.Headers
+	11, // 14: pkg.kannon.mailer.apiv1.SendTemplateReq.tracking:type_name -> pkg.kannon.tracking.types.TrackingPolicy
+	12, // 15: pkg.kannon.mailer.apiv1.SendTemplateReq.one_click_unsubscribe:type_name -> pkg.kannon.mailer.types.OneClickUnsubscribe
+	8,  // 16: pkg.kannon.mailer.apiv1.SendRes.scheduled_time:type_name -> google.protobuf.Timestamp
+	4,  // 17: pkg.kannon.mailer.apiv1.SendRes.rejected_recipients:type_name -> pkg.kannon.mailer.apiv1.RejectedRecipient
+	1,  // 18: pkg.kannon.mailer.apiv1.Mailer.SendHTML:input_type -> pkg.kannon.mailer.apiv1.SendHTMLReq
+	2,  // 19: pkg.kannon.mailer.apiv1.Mailer.SendTemplate:input_type -> pkg.kannon.mailer.apiv1.SendTemplateReq
+	3,  // 20: pkg.kannon.mailer.apiv1.Mailer.SendHTML:output_type -> pkg.kannon.mailer.apiv1.SendRes
+	3,  // 21: pkg.kannon.mailer.apiv1.Mailer.SendTemplate:output_type -> pkg.kannon.mailer.apiv1.SendRes
+	20, // [20:22] is the sub-list for method output_type
+	18, // [18:20] is the sub-list for method input_type
+	18, // [18:18] is the sub-list for extension type_name
+	18, // [18:18] is the sub-list for extension extendee
+	0,  // [0:18] is the sub-list for field type_name
 }
 
 func init() { file_kannon_mailer_apiv1_mailerapiv1_proto_init() }

--- a/proto/kannon/mailer/types/send.pb.go
+++ b/proto/kannon/mailer/types/send.pb.go
@@ -196,6 +196,79 @@ func (x *Headers) GetCc() []string {
 	return nil
 }
 
+// OneClickUnsubscribe is the sender's own unsubscribe endpoint, carried in the
+// List-Unsubscribe and List-Unsubscribe-Post headers (RFC 8058).
+//
+// Kannon personalises, emits and DKIM-signs it, and does nothing else with it:
+// it never calls the endpoint, keeps no suppression list, and records no
+// engagement when a recipient uses it. The URL travels in a header, so it is
+// never rewritten for click tracking.
+//
+// Stated per Batch. There is no Domain-level default and no Recipient-level
+// override — an unsubscribe on a password reset offers something the sender
+// cannot honour, and personalising the template is already what makes the
+// endpoint per-Recipient.
+type OneClickUnsubscribe struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The https URL of the endpoint, as a template.
+	//
+	// The endpoint MUST accept POST with body `List-Unsubscribe=One-Click` and
+	// unsubscribe the recipient with no further confirmation. Supplying a URL
+	// here asserts that: Kannon cannot verify it, and a message advertising
+	// one-click that does not honour it is worse than one that never advertised
+	// it, since the recipient believes they have unsubscribed.
+	//
+	// `{{ field }}` placeholders are substituted per Delivery from the
+	// Recipient's fields, plus `email`, which Kannon supplies as the Recipient's
+	// address unless the caller passes a field of that name itself. Substituted
+	// values are percent-encoded, so pass raw values rather than pre-encoded
+	// ones.
+	//
+	// A template that is unparseable or not https fails the whole call. A
+	// Recipient whose fields leave a placeholder unresolved is Rejected on its
+	// own, with reason `unsubscribe_url_unresolved`.
+	UrlTemplate   string `protobuf:"bytes,1,opt,name=url_template,json=urlTemplate,proto3" json:"url_template,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *OneClickUnsubscribe) Reset() {
+	*x = OneClickUnsubscribe{}
+	mi := &file_kannon_mailer_types_send_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *OneClickUnsubscribe) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*OneClickUnsubscribe) ProtoMessage() {}
+
+func (x *OneClickUnsubscribe) ProtoReflect() protoreflect.Message {
+	mi := &file_kannon_mailer_types_send_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use OneClickUnsubscribe.ProtoReflect.Descriptor instead.
+func (*OneClickUnsubscribe) Descriptor() ([]byte, []int) {
+	return file_kannon_mailer_types_send_proto_rawDescGZIP(), []int{3}
+}
+
+func (x *OneClickUnsubscribe) GetUrlTemplate() string {
+	if x != nil {
+		return x.UrlTemplate
+	}
+	return ""
+}
+
 var File_kannon_mailer_types_send_proto protoreflect.FileDescriptor
 
 const file_kannon_mailer_types_send_proto_rawDesc = "" +
@@ -214,7 +287,9 @@ const file_kannon_mailer_types_send_proto_rawDesc = "" +
 	"\t_tracking\")\n" +
 	"\aHeaders\x12\x0e\n" +
 	"\x02to\x18\x01 \x03(\tR\x02to\x12\x0e\n" +
-	"\x02cc\x18\x02 \x03(\tR\x02ccB\xe2\x01\n" +
+	"\x02cc\x18\x02 \x03(\tR\x02cc\"8\n" +
+	"\x13OneClickUnsubscribe\x12!\n" +
+	"\furl_template\x18\x01 \x01(\tR\vurlTemplateB\xe2\x01\n" +
 	"\x1bcom.pkg.kannon.mailer.typesB\tSendProtoP\x01Z8github.com/kannon-email/kannon/proto/kannon/mailer/types\xa2\x02\x04PKMT\xaa\x02\x17Pkg.Kannon.Mailer.Types\xca\x02\x17Pkg\\Kannon\\Mailer\\Types\xe2\x02#Pkg\\Kannon\\Mailer\\Types\\GPBMetadata\xea\x02\x1aPkg::Kannon::Mailer::Typesb\x06proto3"
 
 var (
@@ -229,17 +304,18 @@ func file_kannon_mailer_types_send_proto_rawDescGZIP() []byte {
 	return file_kannon_mailer_types_send_proto_rawDescData
 }
 
-var file_kannon_mailer_types_send_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
+var file_kannon_mailer_types_send_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
 var file_kannon_mailer_types_send_proto_goTypes = []any{
 	(*Sender)(nil),               // 0: pkg.kannon.mailer.types.Sender
 	(*Recipient)(nil),            // 1: pkg.kannon.mailer.types.Recipient
 	(*Headers)(nil),              // 2: pkg.kannon.mailer.types.Headers
-	nil,                          // 3: pkg.kannon.mailer.types.Recipient.FieldsEntry
-	(*types.TrackingPolicy)(nil), // 4: pkg.kannon.tracking.types.TrackingPolicy
+	(*OneClickUnsubscribe)(nil),  // 3: pkg.kannon.mailer.types.OneClickUnsubscribe
+	nil,                          // 4: pkg.kannon.mailer.types.Recipient.FieldsEntry
+	(*types.TrackingPolicy)(nil), // 5: pkg.kannon.tracking.types.TrackingPolicy
 }
 var file_kannon_mailer_types_send_proto_depIdxs = []int32{
-	3, // 0: pkg.kannon.mailer.types.Recipient.fields:type_name -> pkg.kannon.mailer.types.Recipient.FieldsEntry
-	4, // 1: pkg.kannon.mailer.types.Recipient.tracking:type_name -> pkg.kannon.tracking.types.TrackingPolicy
+	4, // 0: pkg.kannon.mailer.types.Recipient.fields:type_name -> pkg.kannon.mailer.types.Recipient.FieldsEntry
+	5, // 1: pkg.kannon.mailer.types.Recipient.tracking:type_name -> pkg.kannon.tracking.types.TrackingPolicy
 	2, // [2:2] is the sub-list for method output_type
 	2, // [2:2] is the sub-list for method input_type
 	2, // [2:2] is the sub-list for extension type_name
@@ -259,7 +335,7 @@ func file_kannon_mailer_types_send_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_kannon_mailer_types_send_proto_rawDesc), len(file_kannon_mailer_types_send_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   4,
+			NumMessages:   5,
 			NumExtensions: 0,
 			NumServices:   0,
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:

Kannon emits no `List-Unsubscribe` header of any kind today, so a sender's only option is a link in the body — where it is click-tracked like any other. Since the large receivers started requiring one-click unsubscribe of bulk senders, a sender that cannot emit the header is a sender whose mail is filtered.

A caller may now state its own endpoint per Batch:

```json
{ "one_click_unsubscribe": { "url_template": "https://yourdomain.com/unsub?email={{ email }}" } }
```

The endpoint **belongs to the sender**. Kannon personalises the URL, emits it and DKIM-signs it, and does nothing else with it: it never calls it, keeps no suppression list, and records no engagement when a recipient uses it — leaving is not engagement. Since the URL travels in a header, the click rewriter never sees it, so the "never tracked" property holds by construction rather than by a rule someone has to remember.

Design decisions and the alternatives rejected are in [ADR 0005](docs/adr/0005-one-click-unsubscribe-and-signed-header-set.md); the term is in `CONTEXT.md`. In short:

- **One-click https only, no `mailto` fallback.** The field name carries the assertion about the sender's endpoint, rather than a `one_click` boolean that is easy to leave at its default. Advertising one-click without honouring it is worse than not advertising it — the recipient believes they unsubscribed and reports the next message as spam.
- **Batch level only**, no Domain default and no Recipient override: this is a transactional sender, and an unsubscribe header does not belong on a password reset.
- **Two levels of validation.** A malformed or non-https template fails the whole call; a Recipient whose fields leave a placeholder unresolved is Rejected on its own with the new `unsubscribe_url_unresolved` reason, and the Builder keeps a backstop that omits the headers rather than ship an authenticated one-click that cannot work.
- **No migration** — the declaration is a key in the existing `headers` JSONB column.

### Two changes reach mail already being sent

- **`{{ email }}` now resolves in subject and body**, to the Recipient's address, where before it rendered as literal braces. A caller passing its own `email` field keeps its value, so nothing already in production changes meaning.
- **DKIM now signs a fixed header set** — `From, To, Cc, Subject, Message-ID` plus the two `List-*` — whether or not each is present, with the `List-*` names given twice. Signing an absent header is what lets a receiver detect one inserted in transit (RFC 6376 §5.4); doubling extends that to a message that already carries the header, where instances are matched bottom-up and an injected copy would otherwise stay outside the signature while being the one a client reads first.

  The consequence worth reviewing: a relay that *adds* one of those headers now produces `dkim=fail` where before its addition rode along unsigned. A list expander that inserts its own `List-*` headers is the realistic case, and it already broke DKIM by tagging subjects and appending footers. `internal/dkim/oversign_test.go` pins all of this by verifying real signatures rather than asserting on the `h=` string: a signature naming absent headers verifies, an added header breaks it, a second copy breaks it, and an unrelated `X-*` header still passes.

Operator-facing notes are in `docs/UPGRADING.md`, caller-facing ones in `README.md`.

**Which issue(s) this PR fixes**
n/a