### PR TITLE
feat(tracking): implement the pseudonymous Tracking Mode

### DIFF
--- a/.proto/kannon/mailer/apiv1/mailerapiv1.proto
+++ b/.proto/kannon/mailer/apiv1/mailerapiv1.proto
@@ -83,8 +83,8 @@ message RejectedRecipient {
   //                              than its Domain's Policy allows; consent may
   //                              narrow what is collected, never widen it
   //   unsupported_tracking_mode  the Recipient stated a Tracking Mode this
-  //                              build will not act on — the reserved
-  //                              `pseudonymous`, or a value from a newer schema
+  //                              build will not act on — a value from a newer
+  //                              schema
   //   unsubscribe_url_unresolved this Recipient's fields leave a placeholder in
   //                              one_click_unsubscribe.url_template unresolved,
   //                              so its unsubscribe endpoint would be advertised

--- a/.proto/kannon/tracking/types/tracking.proto
+++ b/.proto/kannon/tracking/types/tracking.proto
@@ -15,8 +15,8 @@ enum TrackingMode {
   TRACKING_MODE_OFF = 1;
   // Counted in aggregate only; nothing retained that isolates one recipient.
   TRACKING_MODE_ANONYMOUS = 2;
-  // Linkable within a single batch, carrying no recipient identity.
-  // Reserved: selecting it is rejected as unsupported.
+  // Linkable within a single batch, carrying no recipient identity: events are
+  // attributed to a pseudonym drawn afresh for every batch and stored nowhere.
   TRACKING_MODE_PSEUDONYMOUS = 3;
   // Attributed to the recipient.
   TRACKING_MODE_IDENTIFIED = 4;

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -38,7 +38,7 @@ Kannon is a cloud-native, scalable SMTP mail sender designed for Kubernetes and 
 
 #### `internal/envelope/`
 
-- Defines the Envelope domain entity and `envelope.Builder`: the deep module that renders a `Delivery` into an outgoing Envelope. Hides template lookup, per-recipient custom-field rendering, DKIM signing, tracking-pixel injection, click-link rewriting, and custom To/Cc header handling. The Envelope translates to the `EmailToSend` proto at the NATS publish boundary. The Builder reads the Tracking Policy already frozen on the Delivery and never re-resolves it: under `off` it injects no pixel and rewrites no link, so no tracking hostname reaches the message at all, and under a Mode that names no Recipient the minted token is identical for every Recipient of a Batch and is therefore signed once per Batch instead of once per link per Delivery. Two kinds of href survive a tracked Batch unrewritten: one whose `<a>` tag opts out with `data-no-track`, which the Builder strips before delivery so it never reaches the recipient, and one no redirect could serve — `mailto:`, `tel:`, `sms:`, or an in-page anchor.
+- Defines the Envelope domain entity and `envelope.Builder`: the deep module that renders a `Delivery` into an outgoing Envelope. Hides template lookup, per-recipient custom-field rendering, DKIM signing, tracking-pixel injection, click-link rewriting, and custom To/Cc header handling. The Envelope translates to the `EmailToSend` proto at the NATS publish boundary. The Builder reads the Tracking Policy already frozen on the Delivery and never re-resolves it: under `off` it injects no pixel and rewrites no link, so no tracking hostname reaches the message at all; under `pseudonymous` it draws one random identifier per Delivery and hands that same one to the pixel token and to every link token of the Delivery, which is what makes a Recipient's events linkable to each other within the Batch and to nothing outside it; and under `anonymous` — the one Mode whose tokens cannot tell one Recipient of a Batch from another — the minted token is identical for every Recipient and is therefore signed once per Batch instead of once per link per Delivery. Two kinds of href survive a tracked Batch unrewritten: one whose `<a>` tag opts out with `data-no-track`, which the Builder strips before delivery so it never reaches the recipient, and one no redirect could serve — `mailto:`, `tel:`, `sms:`, or an in-page anchor.
 
 #### `internal/pool/`
 
@@ -58,7 +58,7 @@ Kannon is a cloud-native, scalable SMTP mail sender designed for Kubernetes and 
 
 #### `internal/statssec/`
 
-- Handles secure generation and verification of tracking tokens for opens/clicks (JWT-based), and manages stats keys. The Tracking Mode that governs an event is a signed claim in the token: Pool rows are deleted on terminal outcomes, so by the time an open arrives there is no Delivery to consult, and signing is what stops a Recipient choosing how much is retained about them. A token minted under a Mode that names no Recipient carries no identity at all.
+- Handles secure generation and verification of tracking tokens for opens/clicks (JWT-based), and manages stats keys. The Tracking Mode that governs an event is a signed claim in the token: Pool rows are deleted on terminal outcomes, so by the time an open arrives there is no Delivery to consult, and signing is what stops a Recipient choosing how much is retained about them. The identity is a signed claim too, and is always an address: the Recipient's own under `identified` and `full`, the Delivery's pseudonym under `pseudonymous`, and the constant `anonymous@track.<domain>` below that (ADR 0006). The mint is the chokepoint where the reservation is enforced — a `pseudonymous` token whose identity does not sit under `track.<domain>` is refused rather than shipped, so no caller can name somebody by forgetting to blank a field first — which makes that subdomain an operator-facing requirement: no real mail may be delivered under `track.<domain>`, since a real mailbox there would collide with the sentinel space. Tokens minted before the sentinels existed carry no identity at all under the Modes that name nobody, and keep verifying until they expire.
 
 #### `internal/templates/`
 
@@ -95,14 +95,20 @@ Kannon is a cloud-native, scalable SMTP mail sender designed for Kubernetes and 
   depend on it without a cycle, and depends on nothing itself — in particular
   not on the protobuf packages. The rank order is plain Go, deliberately not
   the protobuf enum numbers, so a Mode can be inserted mid-scale without
-  renumbering the wire. See ADR 0002 and ADR 0003.
+  renumbering the wire. Also owns the identities the Modes that name nobody
+  carry: the `track.<fqdn>` namespace reserved for them, the constant Anonymous
+  sentinel inside it, and the 128-bit `crypto/rand` pseudonym, along with the
+  namespace test the mint applies. See ADR 0002, ADR 0003 and ADR 0006.
 
 #### `internal/trackingpb/`
 
 - Translates Tracking Policies between the wire enums and the
   `internal/tracking` domain types. The only place that knows both, so that
-  every API boundary accepting a Policy refuses the same values — notably the
-  reserved `pseudonymous`, which is ranked but not implemented.
+  every API boundary accepting a Policy refuses the same values — a Mode this
+  build does not know, which is a client built against a newer schema. It is
+  strict in that direction only: a Mode arriving from inside Kannon is read
+  leniently, since an unknown one reads as stating nothing and an unstated Mode
+  can only ever restrict.
 
 ### Service/Worker Modules (`pkg/`)
 
@@ -132,7 +138,7 @@ Kannon is a cloud-native, scalable SMTP mail sender designed for Kubernetes and 
 
 #### `pkg/tracker/`
 
-- Handles HTTP endpoints for open/click tracking. Publishes stats to NATS, carrying the Tracking Mode it read from the token's verified claims. That Mode is the single gate on what the request leaves behind: the IP address and user agent are read only under `full`, and the Recipient is named only from `identified` upwards.
+- Handles HTTP endpoints for open/click tracking. Publishes stats to NATS, carrying the Tracking Mode it read from the token's verified claims. That Mode is the single gate on what the request leaves behind: the IP address and user agent are read only under `full`, the Recipient is named only from `identified` upwards, and under `pseudonymous` the event carries the token's pseudonym instead — enough to link one Delivery's events to each other, and nothing more. Under `anonymous` the sentinel is dropped rather than published, so the event names nobody and reaches no stat row.
 
 #### `pkg/dispatcher/`
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -37,7 +37,7 @@ How much a single engagement channel may be observed, on an **ordered** scale of
 
 - **Off** — not observed at all.
 - **Anonymous** — counted in aggregate only. Nothing is retained that could isolate one Recipient from another: the event moves the Domain's aggregate counters and leaves no per-Delivery record, and the token it arrives on names no Recipient and is therefore the *same* token for every Recipient of a Batch — per Batch for the pixel, and per Batch-and-URL pair for a link. A link whose URL is itself personalised with custom fields is a different URL per Recipient by construction, so it cannot share a token; nothing per-Recipient is retained either way, but such a message is distinguishable to whoever handles it in transit.
-- **Pseudonymous** — events are linkable to each other within a single Batch via an identifier that is regenerated for every Batch and never reused across Batches, but carry no Recipient identity. *Reserved, not yet implemented.*
+- **Pseudonymous** — events are linkable to each other within a single Batch via an identifier that is regenerated for every Batch and never reused across Batches, but carry no Recipient identity. The identifier takes the form `<rand>@track.<sending-domain>`: a random local part under a subdomain reserved for tracking identities, stored nowhere and derived from nothing, so no one — Kannon included — can link it back to the Recipient.
 - **Identified** — attributed to the Recipient.
 - **Full** — attributed, plus the IP address and user agent of the request.
 

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -5,6 +5,75 @@ releases that change behaviour of an installation already in production appear
 here; everything else is in [`CHANGELOG.md`](../CHANGELOG.md), which is
 generated from commits.
 
+## Unreleased — Pseudonymous tracking
+
+### What changes
+
+The Tracking Mode `pseudonymous` is now selectable. It has been on the scale
+since Tracking Policies were introduced, ranked between `anonymous` and
+`identified`, but stating it was refused; it is now honoured at Domain, Batch
+and Recipient level like every other Mode. Nothing changes for an installation
+that does not select it.
+
+It is the rung for a sender who wants open and click *rates* per Batch, and the
+ability to tell one recipient's engagement from another's, without recording
+who those recipients are. Events are linkable to each other within a single
+Batch and to nothing outside it: no recipient address reaches the tracking URL,
+the Tracker's access logs, or the `stats` table.
+
+### The `track.<domain>` subdomain is reserved
+
+**Do not deliver mail under `track.<yourdomain.com>`.** Under `pseudonymous` and
+`anonymous`, the identity a tracking token carries is a *sentinel address* in
+that namespace — `<random>@track.yourdomain.com` and
+`anonymous@track.yourdomain.com` respectively — rather than the recipient's own.
+A real mailbox under that subdomain would collide with the sentinel space and be
+indistinguishable from it in your statistics.
+
+The reservation costs nothing to honour: **no DNS record is required**. These
+addresses are identifiers, never envelope recipients — Kannon never delivers to
+one, never resolves it, and never looks it up. See
+[ADR 0006](adr/0006-tracking-identity-in-the-token-sentinel-addresses.md).
+
+### What your statistics look like
+
+A pseudonymous Opened or Clicked is recorded exactly like an identified one, so
+every existing query keeps working — but the `email` it is recorded under is the
+pseudonym, not the recipient. Two consequences worth planning for:
+
+- **Counting distinct addresses still counts distinct recipients** within a
+  Batch, which is what open and click rates need.
+- **A pseudonym is drawn fresh for every Batch**, from `crypto/rand`, stored
+  nowhere and derived from nothing. Engagement therefore cannot be joined across
+  Batches, or back to a recipient, by anyone — Kannon included. That is the
+  point of the rung, and it is not recoverable after the fact: if you need
+  per-recipient history over time, state `identified` instead.
+
+Aggregate counters are unaffected: they never looked at the identity.
+
+### Selecting it
+
+Through the Admin API's `SetTrackingPolicy`, per axis, as with any other Mode:
+
+```json
+{
+  "domain": "yourdomain.com",
+  "tracking": {
+    "opens": "TRACKING_MODE_PSEUDONYMOUS",
+    "links": "TRACKING_MODE_PSEUDONYMOUS"
+  }
+}
+```
+
+As always, a Domain's Policy is a ceiling and a Batch or Recipient may only
+restrict it further, and a Policy is frozen onto each Delivery when its Batch is
+created — so Deliveries already queued keep the Policy they were accepted under.
+
+One operational note: `pseudonymous` names a different identity per Delivery, so
+it signs one token per Delivery like `identified` does, rather than sharing a
+single token across the Batch the way `anonymous` can. Expect the same dispatch
+cost as `identified`, not the cheaper `anonymous` one.
+
 ## Unreleased — One-Click Unsubscribe
 
 ### What changes
@@ -145,6 +214,7 @@ Domain can rewrite links without embedding a pixel, or the reverse:
 | --- | --- |
 | `off` | Nothing. No pixel is injected, no link is rewritten, and no tracking hostname appears in the delivered message at all. |
 | `anonymous` | Aggregate counters only. Nothing that could isolate one recipient from another. |
+| `pseudonymous` | A pseudonym, drawn per recipient per Batch. Engagement is linkable within one Batch and nowhere else; no recipient address is retained. |
 | `identified` | The recipient's identity. No IP address, no user agent. **The new default.** |
 | `full` | The recipient's identity, plus the IP address and user agent of the request. The pre-0.6.0 behaviour. |
 

--- a/docs/adr/0006-tracking-identity-in-the-token-sentinel-addresses.md
+++ b/docs/adr/0006-tracking-identity-in-the-token-sentinel-addresses.md
@@ -1,0 +1,188 @@
+# ADR 0006: Tracking identity travels in the token, as an address — sentinel addresses for the Modes that name nobody
+
+## Status
+
+Accepted (2026-08-02).
+
+## Context
+
+Issue #411 observed that every tracking URL carries the recipient address in a
+decodable form: the open and click tokens are RS512-signed JWTs, a JWT payload
+is readable base64, and the token *is* the URL. The parties that matter are not
+the ones holding the message — a mailbox provider proxying the pixel already
+has the address in `To:`, next to the token — but the ones that see the URL
+*alone*: the Tracker's access logs and whatever ships them, a CDN or ingress in
+front of it, the destination site via `Referer`. A mailbox leak costs one
+address; a log leak costs the list. The issue weighed a server-side mapping
+table, an encrypted claim, and a keyed hash.
+
+Issue #424 tracked the other half: the **Pseudonymous** Tracking Mode is
+defined and ranked in `CONTEXT.md` but reserved — rejected at every API
+boundary — pending "the per-Batch identifier work", which was #411's decision
+to make. The two issues were mutually blocking.
+
+Constraints fixed by earlier decisions:
+
+- Pool rows are deleted on terminal outcomes, so an engagement arriving months
+  later has no Delivery row to resolve against. Whatever the Tracker needs must
+  travel in the token, whose life is `tokenExpirePeriod` (three months) —
+  `CONTEXT.md`: "The Mode reaches the Tracker as a signed claim in the token,
+  not from a database lookup". That sentence names the invariant this ADR
+  preserves: the Mode is fixed at send time and the request that carries it
+  cannot widen it. It protects against the *Recipient*, not against the
+  operator — the operator already owns every table the Policy lives in, and is
+  the party responsible for the Mode in the first place (ADR 0002).
+- ADR 0003: the Policy is stated per axis, resolved most-restrictive, frozen
+  per Delivery.
+
+## Decision
+
+### The tokens stay stateless, and the JWT stays as it is
+
+No identity table, no link catalog, no encrypted claim. The token envelope is
+untouched: RS512 over RSA-4096 with `kid` rotation via `stats_keys`, the
+channel-binding audiences, `exp` at three months, keys living twice that and
+destroyed by the existing cleanup cycle.
+
+The deciding argument is data minimisation as an architectural property. The
+complete inventory of recipient addresses at rest in Kannon is:
+
+1. `sending_pool_emails.email` — transient, deleted on the Delivery's terminal
+   outcome;
+2. `stats.email` — retention-bounded, only for events the Mode attributes.
+
+Tracking adds no third store. Every stateful design evaluated (see Rejected
+alternatives) would have created a new at-rest address collection — written on
+the build hot path, sized in the tens of gigabytes for a large sender — in the
+course of removing addresses from URLs. The audit story of the stateless
+design is one sentence: addresses are stored to send, deleted, and stored again
+only as retention-bounded statistics.
+
+### The identity claim is decided by the Mode, and is always an address
+
+| Mode | identity claim in the token |
+| --- | --- |
+| Identified, Full | the recipient address, as today |
+| Pseudonymous | `<rand>@track.<sending-domain>` |
+| Anonymous | `anonymous@track.<sending-domain>` — and never a stat row |
+
+Because every identity is email-shaped, the Stats worker, the `stats` schema
+(`email` is `NOT NULL`) and the API surface change not at all: a Pseudonymous
+event flows through the existing per-recipient write path, and counting
+distinct addresses keeps meaning distinct recipients. The discriminator is the
+Mode, which every stat event already carries.
+
+The pseudonym is **128 bits from `crypto/rand`, lowercase hex local part**
+(email pipelines case-fold; a case-sensitive alphabet would let a lowercase in
+transit merge pseudonyms), generated **once per Delivery in the Builder**, so
+the pixel token and every link token of the Delivery carry the same value —
+that intra-Delivery coherence is what makes events linkable within the Batch,
+which is the rung's definition. It is regenerated for every Batch, stored
+nowhere, and derived from nothing: no one, Kannon included, can link it across
+Batches or back to the address. It is deliberately *not* an HMAC of the
+address — a deterministic derivation would let any holder of the key confirm a
+guessed (address, pseudonym) pairing, the exact weakness #411 charged against
+its keyed-hash option.
+
+`track.<sending-domain>` is a **reserved namespace**, and the reservation is
+machine-checkable at the one place every token passes through: `statssec`
+refuses to mint a Pseudonymous token whose identity does not end in
+`@track.<domain>`, so a caller that passes the real address with a Pseudonymous
+Mode is caught at the chokepoint rather than shipped. This preserves the
+existing design property that no caller can name somebody by forgetting to
+blank a field first.
+
+The Anonymous sentinel exists for uniformity of the claim type and nothing
+else. It is constant per domain, so the shared per-Batch token — one RSA
+signature covering the whole Batch — survives. It is never written to the
+`stats` table: the Mode-based skip in the Stats worker keeps `CONTEXT.md`'s
+"leaves no per-Delivery record" true, and the "event names nobody yet is not
+Anonymous" bug check becomes a sentinel-shape check.
+
+### Identified means identified — #411 is answered by the scale, not by cryptography
+
+Under Identified and Full the address stays in the URL, deliberately. Kannon
+executes tracking instructions (ADR 0002): a Domain that attributes engagement
+to recipients has stated so, owns the lawful basis for it, and its logs hold
+what its instruction implies. The operator that must keep addresses out of
+URLs and logs now has a rung of the existing scale that does exactly that —
+**Pseudonymous** — instead of a cryptographic wrapper around Identified.
+#411 is closed on these terms rather than left half-open.
+
+### The axes stay independent
+
+`opens` and `links` remain independently stated, per ADR 0003. A proposed
+coupling (`opens >= links`, on the intuition that click tracking implies open
+tracking) was rejected: see Rejected alternatives.
+
+### Erasure, if it ever arrives, is a denylist
+
+Kannon has no per-recipient erasure anywhere today (stat rows expire by
+retention only). If an erasure instruction is ever added, the stateless design
+answers it with a denylist checked by the Tracker — keyed as
+`HMAC(key, address)` so the list of the erased is not itself a cleartext
+address collection. State proportional to the exceptions, not to the sends.
+
+## Consequences
+
+- **#424 is unblocked and fully specified**; #411 is closed as answered by the
+  Pseudonymous rung.
+- **Zero schema, migration, or API changes.** The Stats worker and `stats`
+  table are untouched.
+- The implementation surface is the mint and the Tracker: the Builder
+  generates the per-Delivery pseudonym; `statssec` validates the reserved
+  namespace; `retained()` keeps the pseudonym while still dropping IP and user
+  agent (Pseudonymous sits below Identified on the scale, but its events must
+  carry the pseudonym or the rung records nothing); `toStatedMode` stops
+  rejecting Pseudonymous.
+- **Pseudonymous costs like Identified at the mint.** Per-recipient identity
+  means per-Delivery tokens: the shared-Batch signature that Anonymous enjoys
+  does not apply. The RSA-4096 bill this keeps (~4.2 ms per signature,
+  measured) is today's bill, accepted knowingly; reducing it belongs to the
+  dispatch-performance work (#380) and is orthogonal to this decision.
+- **Addresses under Identified/Full remain readable in access logs.** That is
+  the operator's stated instruction. Operators for whom that is not acceptable
+  state Pseudonymous.
+- The longest-lived address store in Kannon is now the `stats` table's default
+  retention (one year). Any privacy audit should look there first.
+- Legacy tokens minted before this change (blank identity under non-identifying
+  Modes) keep verifying until they expire; the empty-identity path cannot be
+  deleted for one `tokenExpirePeriod`.
+- When #424 lands, `CONTEXT.md`'s Pseudonymous entry loses its *reserved* note
+  and gains the sentinel format as part of the Mode's definition, and the
+  `track.<domain>` reservation must be documented for operators (a real mailbox
+  under that subdomain would collide with the sentinel space).
+
+## Rejected alternatives
+
+- **Identity rows in the database** (a row per (Batch, Recipient, axis),
+  resolved by an opaque URL id, plus a per-Batch link catalog). Designed in
+  full before rejection. It solves #411's letter and hands #424 its identifier
+  for free, but it creates the third at-rest address store — two rows per
+  Delivery written on the exact hot path the dispatch-performance work is
+  trying to relieve, ~60 GB at steady state for a 1M/day sender — and its
+  read-side advantage evaporated on inspection: the verify path already pays a
+  per-hit key lookup today.
+- **An encrypted identity claim** (AEAD value inside the existing JWT, or a
+  compact AEAD token replacing it). Solves #411's letter with no new tables,
+  and defeats URL-only observers. Rejected because the ciphertext travels in
+  every sent message and every log line as a copy that can never be rotated:
+  one key compromise retroactively unmasks every archived tracking URL held by
+  anyone, and the key must live at least as long as the tokens. The chosen
+  design achieves the same operator-facing goal — no address in the URL — by
+  Mode selection, with no key custody at all.
+- **A pseudonym derived as `HMAC(key, batch‖address)`.** Deterministic, hence
+  confirmable by any key holder; randomness with no stored mapping is strictly
+  stronger and simpler.
+- **Coupling the axes (`opens >= links`).** Forbids the most defensible
+  configuration in practice (opens off or anonymous, links identified — clicks
+  are deliberate acts, opens are proxy-inflated noise, see #412), fails to
+  eliminate mixed-axis Policies (the allowed direction still mixes), and is
+  inexpressible in ADR 0003's per-axis most-restrictive cascade: a Recipient
+  stating only `opens=off` under a permissive Domain would either be rejected
+  for restricting, or have a restriction applied to an axis nobody stated.
+- **Bare-domain sentinels** (`anonymous@<sending-domain>`). `anonymous@` can
+  be a real mailbox; the reserved subdomain exists so the sentinel space and
+  the deliverable space cannot collide.
+- **Keeping Pseudonymous reserved.** The rung was blocked on #411's identifier
+  decision; this ADR is that decision, and the rung is the answer to #411.

--- a/internal/envelope/builder.go
+++ b/internal/envelope/builder.go
@@ -45,12 +45,14 @@ type SendingDataSource interface {
 // open token, the links Mode on a link token — signed, so the Tracker can trust
 // it without a Delivery row to look it up in.
 //
-// A Mode that does not identify the Recipient mints no identity into the token,
-// so the Builder asks for such a token once per Batch and reuses it for every
-// Delivery — see sharedtokens.go.
+// The identity argument is whatever that axis's Mode is entitled to name: the
+// Recipient's address, or the Delivery's pseudonym under Pseudonymous. Under a
+// Mode that cannot tell one Recipient of a Batch from another the issuer ignores
+// it entirely, so the Builder asks for such a token once per Batch and reuses it
+// for every Delivery — see sharedtokens.go.
 type TokenIssuer interface {
-	CreateLinkToken(ctx context.Context, messageID, email, url string, mode tracking.Mode) (string, error)
-	CreateOpenToken(ctx context.Context, messageID, email string, mode tracking.Mode) (string, error)
+	CreateLinkToken(ctx context.Context, messageID, identity, url string, mode tracking.Mode) (string, error)
+	CreateOpenToken(ctx context.Context, messageID, identity string, mode tracking.Mode) (string, error)
 }
 
 // Builder renders a Delivery into an outgoing Envelope.
@@ -215,8 +217,13 @@ func (b *defaultBuilder) preparedHTML(ctx context.Context, d *delivery.Delivery,
 	policy := d.TrackingPolicy()
 	html := utils.ReplaceCustomFields(data.HTML, fields)
 
+	identity, err := newTrackingIdentity(policy, d.Email(), data.Domain)
+	if err != nil {
+		return "", err
+	}
+
 	if policy.Links != tracking.ModeOff {
-		rewritten, err := b.replaceAllLinks(ctx, html, trackTargetFor(d, data, policy.Links))
+		rewritten, err := b.replaceAllLinks(ctx, html, trackTargetFor(identity, data, policy.Links))
 		if err != nil {
 			return "", err
 		}
@@ -233,15 +240,58 @@ func (b *defaultBuilder) preparedHTML(ctx context.Context, d *delivery.Delivery,
 	if policy.Opens == tracking.ModeOff {
 		return html, nil
 	}
-	return b.addTrackPixel(ctx, html, trackTargetFor(d, data, policy.Opens))
+	return b.addTrackPixel(ctx, html, trackTargetFor(identity, data, policy.Opens))
+}
+
+// trackingIdentity is who one Delivery's tracking tokens name, which is not one
+// answer but one per axis: the two axes are stated independently (ADR 0003), so a
+// Delivery may well have its opens pseudonymous and its links identified.
+//
+// The pseudonym is drawn **once per Delivery** and held here for both axes. That
+// is the whole content of the Pseudonymous rung: the pixel token and every link
+// token of a Delivery carry the same value, so its engagement events are linkable
+// to each other within the Batch, and to nothing outside it. Drawing one per token
+// instead would leave every event a singleton and quietly record less than the
+// Mode promises, while looking identical from the outside.
+type trackingIdentity struct {
+	email     string
+	pseudonym string
+}
+
+// newTrackingIdentity resolves the identities for one Delivery, drawing a
+// pseudonym only if an axis asks for one — a Batch that states no Pseudonymous
+// axis pays nothing for the rung.
+func newTrackingIdentity(policy tracking.Policy, email string, domain string) (trackingIdentity, error) {
+	id := trackingIdentity{email: email}
+	if policy.Opens != tracking.ModePseudonymous && policy.Links != tracking.ModePseudonymous {
+		return id, nil
+	}
+
+	pseudonym, err := tracking.NewPseudonym(domain)
+	if err != nil {
+		return trackingIdentity{}, err
+	}
+	id.pseudonym = pseudonym
+	return id, nil
+}
+
+// under returns the identity an axis governed by mode may be tracked against.
+// Only Pseudonymous swaps the address out here; every other Mode is handed the
+// address and the mint decides what survives into the claim, which is where that
+// decision has to live so no caller can skip it (internal/statssec.identityUnder).
+func (i trackingIdentity) under(mode tracking.Mode) string {
+	if mode == tracking.ModePseudonymous {
+		return i.pseudonym
+	}
+	return i.email
 }
 
 // trackTarget is what one channel's tracking URL is minted against: which
-// Recipient, in which Batch and Domain, under which Mode. The four travel
+// identity, in which Batch and Domain, under which Mode. The four travel
 // together through every step of rewriting, and the Mode is the one that decides
 // whether the resulting token may be shared across the Batch.
 type trackTarget struct {
-	email     string
+	identity  string
 	messageID string
 	domain    string
 	mode      tracking.Mode
@@ -251,9 +301,9 @@ type trackTarget struct {
 // that axis from the Policy frozen on it — so the Tracker acts on the Policy that
 // governed this Delivery rather than on whatever is configured when the
 // engagement arrives.
-func trackTargetFor(d *delivery.Delivery, data SendingData, mode tracking.Mode) trackTarget {
+func trackTargetFor(identity trackingIdentity, data SendingData, mode tracking.Mode) trackTarget {
 	return trackTarget{
-		email:     d.Email(),
+		identity:  identity.under(mode),
 		messageID: data.MessageID,
 		domain:    data.Domain,
 		mode:      mode,
@@ -282,7 +332,7 @@ func (b *defaultBuilder) buildTrackClickLink(ctx context.Context, url string, t 
 		url:       url,
 		mode:      t.mode,
 	}, func() (string, error) {
-		return b.tokens.CreateLinkToken(ctx, t.messageID, t.email, url, t.mode)
+		return b.tokens.CreateLinkToken(ctx, t.messageID, t.identity, url, t.mode)
 	})
 	if err != nil {
 		return "", err
@@ -297,7 +347,7 @@ func (b *defaultBuilder) buildTrackOpenLink(ctx context.Context, t trackTarget) 
 		messageID: t.messageID,
 		mode:      t.mode,
 	}, func() (string, error) {
-		return b.tokens.CreateOpenToken(ctx, t.messageID, t.email, t.mode)
+		return b.tokens.CreateOpenToken(ctx, t.messageID, t.identity, t.mode)
 	})
 	if err != nil {
 		return "", err
@@ -305,17 +355,20 @@ func (b *defaultBuilder) buildTrackOpenLink(ctx context.Context, t trackTarget) 
 	return fmt.Sprintf("https://stats.%v/o/%v", t.domain, token), nil
 }
 
-// token returns the token for one channel of one Delivery. Under a Mode that
-// names the Recipient it is minted per Delivery, because that is what it commits
-// to. Under a Mode that names nobody it commits only to what the key holds, so
-// every Delivery of the Batch carries the very same token — the privacy property
-// of such a Mode, and the reason one signature covers a whole Batch.
+// token returns the token for one channel of one Delivery. Under a Mode that can
+// tell one Recipient of a Batch from another it is minted per Delivery, because
+// that is what it commits to — whether it names the Recipient (Identified, Full)
+// or merely distinguishes them (Pseudonymous) makes no difference to the sharing
+// question, which is why it is asked as IsolatesRecipient. Under a Mode that
+// cannot, the token commits only to what the key holds, so every Delivery of the
+// Batch carries the very same token — the privacy property of such a Mode, and
+// the reason one signature covers a whole Batch.
 //
 // The rule lives here once, for both channels, so that the key and the decision
 // to share cannot drift apart: a key missing anything the token commits to would
 // hand one Recipient's token to another.
 func (b *defaultBuilder) token(key sharedTokenKey, mint func() (string, error)) (string, error) {
-	if key.mode.IdentifiesRecipient() {
+	if key.mode.IsolatesRecipient() {
 		return mint()
 	}
 	return b.shared.reuse(key, mint)

--- a/internal/envelope/builder.go
+++ b/internal/envelope/builder.go
@@ -253,6 +253,12 @@ func (b *defaultBuilder) preparedHTML(ctx context.Context, d *delivery.Delivery,
 // to each other within the Batch, and to nothing outside it. Drawing one per token
 // instead would leave every event a singleton and quietly record less than the
 // Mode promises, while looking identical from the outside.
+//
+// It is drawn per *build*, so a Delivery rebuilt after a failed send attempt goes
+// out under a fresh one. Holding it steady would mean storing it, which is the
+// at-rest identity store ADR 0006 declines to create; and the two copies of such a
+// Delivery are unlinkable to each other rather than to anybody, which is the
+// harmless direction to err in.
 type trackingIdentity struct {
 	email     string
 	pseudonym string

--- a/internal/envelope/builder_test.go
+++ b/internal/envelope/builder_test.go
@@ -356,10 +356,17 @@ func TestBuilderMintsTokensCarryingTheFrozenMode(t *testing.T) {
 
 // deliveredTokens are the tracking tokens one rendered message carries, read back
 // out of the delivered body — the same place a recipient's mail client reads them.
+// The decoded body comes along, for the assertions that are about what is *not*
+// in it.
 type deliveredTokens struct {
+	body  string
 	open  string
 	links []string
 }
+
+// all is every token the message carries, for an assertion that holds of each
+// regardless of which endpoint it belongs to.
+func (d deliveredTokens) all() []string { return append([]string{d.open}, d.links...) }
 
 var (
 	pixelTokenRe = regexp.MustCompile(`/o/([A-Za-z0-9._-]+)`)
@@ -373,18 +380,24 @@ func deliverTo(t *testing.T, b envelope.Builder, batchID batch.ID, email string,
 
 	env, err := b.Build(t.Context(), mustDeliveryTracked(t, batchID, email, nil, p))
 	require.NoError(t, err)
+	return readDeliveredTokens(t, env.Body())
+}
 
-	parsed, err := mail.ReadMessage(bytes.NewReader(env.Body()))
+// readDeliveredTokens reads the tracking tokens out of one built message.
+func readDeliveredTokens(t *testing.T, raw []byte) deliveredTokens {
+	t.Helper()
+
+	parsed, err := mail.ReadMessage(bytes.NewReader(raw))
 	require.NoError(t, err)
-	raw, err := io.ReadAll(parsed.Body)
+	body, err := io.ReadAll(parsed.Body)
 	require.NoError(t, err)
-	decoded, err := decodeQuotedPrintable(raw)
+	decoded, err := decodeQuotedPrintable(body)
 	require.NoError(t, err)
 
 	pixels := pixelTokenRe.FindAllStringSubmatch(decoded, -1)
 	require.Len(t, pixels, 1, "a tracked message carries exactly one pixel, got %q", decoded)
 
-	out := deliveredTokens{open: pixels[0][1]}
+	out := deliveredTokens{body: decoded, open: pixels[0][1]}
 	for _, m := range linkTokenRe.FindAllStringSubmatch(decoded, -1) {
 		out.links = append(out.links, m[1])
 	}
@@ -401,6 +414,13 @@ var identifiedPolicy = tracking.Policy{Opens: tracking.ModeIdentified, Links: tr
 // links, minting a distinct token per request so reuse is visible in the output.
 func trackedBuilder(t *testing.T, links ...string) envelope.Builder {
 	t.Helper()
+	return trackedBuilderWith(t, &countingTokens{}, links...)
+}
+
+// trackedBuilderWith is trackedBuilder over a stated token issuer, for the tests
+// that read what the Builder asked for rather than what came back.
+func trackedBuilderWith(t *testing.T, tokens envelope.TokenIssuer, links ...string) envelope.Builder {
+	t.Helper()
 
 	body := &strings.Builder{}
 	body.WriteString("<html><body><h1>Hello!</h1>")
@@ -416,7 +436,7 @@ func trackedBuilder(t *testing.T, links ...string) envelope.Builder {
 		SenderEmail:    "noreply@test.com",
 		SenderAlias:    "Test",
 		DkimPrivateKey: newDKIMKeys(t),
-	}}, &countingTokens{})
+	}}, tokens)
 }
 
 // TestBuilderSharesAnonymousTokensAcrossABatch is the Anonymous privacy property

--- a/internal/envelope/pseudonymous_integration_test.go
+++ b/internal/envelope/pseudonymous_integration_test.go
@@ -1,0 +1,200 @@
+package envelope_test
+
+import (
+	"bytes"
+	"io"
+	"mime/quotedprintable"
+	"net/mail"
+	"regexp"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/kannon-email/kannon/internal/batch"
+	"github.com/kannon-email/kannon/internal/statssec"
+	"github.com/kannon-email/kannon/internal/tracking"
+	pb "github.com/kannon-email/kannon/proto/kannon/mailer/types"
+	trackingtypes "github.com/kannon-email/kannon/proto/kannon/tracking/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	adminapiv1 "github.com/kannon-email/kannon/proto/kannon/admin/apiv1"
+	mailerapiv1 "github.com/kannon-email/kannon/proto/kannon/mailer/apiv1"
+)
+
+// TestPseudonymousDeliveryEndToEnd walks the rung from the Mailer API call that
+// states it to the tokens a recipient actually receives, through the real mint,
+// because that is the only place its guarantees can be checked as a whole: the
+// Builder decides what identity to draw, statssec decides what survives into the
+// claim, and neither on its own proves what ends up in the URL.
+//
+// It pins the four things ADR 0006 promises an operator who states pseudonymous:
+// no recipient address in any tracking URL, one pseudonym shared by the pixel and
+// every link of a Delivery, and pseudonyms that collide neither between two
+// Recipients of a Batch nor between two Batches of one Recipient.
+func TestPseudonymousDeliveryEndToEnd(t *testing.T) {
+	const fqdn = "pseudonymous-test.com"
+	const first = "first@emailtest.com"
+	const second = "second@emailtest.com"
+
+	sender := newPseudonymousSender(t, fqdn)
+	ss := statssec.NewStatsService(q)
+
+	batchOne := sender.send(t, first, second)
+	one := batchOne[first]
+	two := batchOne[second]
+
+	t.Run("NoTrackingURLNamesTheRecipient", func(t *testing.T) {
+		// The claim is what a log-only observer reads, so it is asserted on the
+		// verified claim rather than on the URL string alone; the URL is checked
+		// too, since a JWT payload is readable base64 and the token *is* the URL.
+		assert.NotContains(t, one.rawBody, first)
+		for _, token := range one.all() {
+			claims := verifyAny(t, ss, token)
+			assert.NotEqual(t, first, claims.identity)
+			assert.True(t, tracking.InReservedNamespace(claims.identity, fqdn),
+				"a pseudonymous token must name a sentinel of %q, got %q", fqdn, claims.identity)
+			assert.Equal(t, tracking.ModePseudonymous, claims.mode)
+		}
+	})
+
+	t.Run("ThePixelAndEveryLinkShareOnePseudonym", func(t *testing.T) {
+		// This is what makes two engagement events of one Recipient linkable
+		// inside the Batch, which is the whole definition of the rung.
+		want := verifyAny(t, ss, one.open).identity
+		require.NotEmpty(t, one.links)
+		for _, token := range one.links {
+			assert.Equal(t, want, verifyAny(t, ss, token).identity)
+		}
+	})
+
+	t.Run("TwoRecipientsOfOneBatchAreNotLinkable", func(t *testing.T) {
+		assert.NotEqual(t, verifyAny(t, ss, one.open).identity, verifyAny(t, ss, two.open).identity)
+	})
+
+	t.Run("OneRecipientInTwoBatchesIsNotLinkable", func(t *testing.T) {
+		// Nothing derives a pseudonym, so this holds against Kannon itself and
+		// not merely against an outside observer: there is no key that would let
+		// the two be joined.
+		batchTwo := sender.send(t, first)
+		assert.NotEqual(t,
+			verifyAny(t, ss, one.open).identity,
+			verifyAny(t, ss, batchTwo[first].open).identity)
+	})
+}
+
+// pseudonymousSender is an authenticated Domain that sends Batches stating
+// pseudonymous on both axes.
+type pseudonymousSender struct {
+	domain *adminapiv1.Domain
+	apiKey string
+}
+
+func newPseudonymousSender(t *testing.T, fqdn string) pseudonymousSender {
+	t.Helper()
+
+	d, err := adminAPI.CreateDomain(t.Context(), connect.NewRequest(&adminapiv1.CreateDomainRequest{Domain: fqdn}))
+	require.NoError(t, err)
+
+	key, err := adminAPI.CreateAPIKey(t.Context(), connect.NewRequest(&adminapiv1.CreateAPIKeyRequest{
+		Domain: d.Msg.Domain,
+		Name:   "pseudonymous-key",
+	}))
+	require.NoError(t, err)
+
+	return pseudonymousSender{domain: d.Msg, apiKey: key.Msg.Key}
+}
+
+// send submits one Batch to the recipients and returns, per recipient, the
+// tracking tokens their built message carries.
+func (s pseudonymousSender) send(t *testing.T, recipients ...string) map[string]deliveredBody {
+	t.Helper()
+
+	pseudonymous := &trackingtypes.TrackingPolicy{
+		Opens: trackingtypes.TrackingMode_TRACKING_MODE_PSEUDONYMOUS,
+		Links: trackingtypes.TrackingMode_TRACKING_MODE_PSEUDONYMOUS,
+	}
+
+	to := make([]*pb.Recipient, 0, len(recipients))
+	for _, r := range recipients {
+		to = append(to, &pb.Recipient{Email: r})
+	}
+
+	req := connect.NewRequest(&mailerapiv1.SendHTMLReq{
+		Sender:        &pb.Sender{Email: "noreply@" + s.domain.Domain, Alias: "Test"},
+		Subject:       "Pseudonymous",
+		Html:          `<html><body><a href="https://example.com/a">a</a><a href="https://example.com/b">b</a></body></html>`,
+		ScheduledTime: timestamppb.Now(),
+		Recipients:    to,
+		Tracking:      pseudonymous,
+	})
+	authRequest(req, s.domain, s.apiKey)
+
+	res, err := ma.SendHTML(t.Context(), req)
+	require.NoError(t, err)
+	require.Empty(t, res.Msg.RejectedRecipients, "pseudonymous must be accepted at intake")
+
+	out := make(map[string]deliveredBody, len(recipients))
+	for _, r := range recipients {
+		claimed := markValidatedAndClaim(t, batch.ID(res.Msg.MessageId), r)
+		require.Len(t, claimed, 1)
+		require.Equal(t, r, claimed[0].Email(), "the claim must return the Delivery just validated")
+
+		env, err := eb.Build(t.Context(), claimed[0])
+		require.NoError(t, err)
+		out[r] = readDeliveredBody(t, env.Body())
+	}
+	return out
+}
+
+// deliveredBody is one built message as the recipient receives it, plus the
+// tracking tokens read out of it.
+type deliveredBody struct {
+	rawBody string
+	open    string
+	links   []string
+}
+
+func (d deliveredBody) all() []string { return append([]string{d.open}, d.links...) }
+
+func readDeliveredBody(t *testing.T, raw []byte) deliveredBody {
+	t.Helper()
+
+	parsed, err := mail.ReadMessage(bytes.NewReader(raw))
+	require.NoError(t, err)
+	body, err := io.ReadAll(parsed.Body)
+	require.NoError(t, err)
+	decoded, err := io.ReadAll(quotedprintable.NewReader(bytes.NewReader(body)))
+	require.NoError(t, err)
+
+	out := deliveredBody{rawBody: string(decoded)}
+
+	pixels := regexp.MustCompile(`/o/([A-Za-z0-9._-]+)`).FindAllStringSubmatch(out.rawBody, -1)
+	require.Len(t, pixels, 1, "a tracked message carries exactly one pixel, got %q", out.rawBody)
+	out.open = pixels[0][1]
+
+	for _, m := range regexp.MustCompile(`/c/([A-Za-z0-9._-]+)`).FindAllStringSubmatch(out.rawBody, -1) {
+		out.links = append(out.links, m[1])
+	}
+	return out
+}
+
+// verifiedClaims is the part of a verified token both channels share, so a test
+// can assert on a Delivery's tokens without caring which endpoint each belongs to.
+type verifiedClaims struct {
+	identity string
+	mode     tracking.Mode
+}
+
+// verifyAny verifies a token against whichever channel it was minted for, since a
+// token is bound to its channel and the two are deliberately not interchangeable.
+func verifyAny(t *testing.T, ss statssec.StatsService, token string) verifiedClaims {
+	t.Helper()
+
+	if open, err := ss.VerifyOpenToken(t.Context(), token); err == nil {
+		return verifiedClaims{identity: open.Email, mode: open.Mode}
+	}
+	link, err := ss.VerifyLinkToken(t.Context(), token)
+	require.NoError(t, err, "a token must verify on one of the two channels")
+	return verifiedClaims{identity: link.Email, mode: link.Mode}
+}

--- a/internal/envelope/pseudonymous_integration_test.go
+++ b/internal/envelope/pseudonymous_integration_test.go
@@ -1,11 +1,6 @@
 package envelope_test
 
 import (
-	"bytes"
-	"io"
-	"mime/quotedprintable"
-	"net/mail"
-	"regexp"
 	"testing"
 
 	"connectrpc.com/connect"
@@ -48,7 +43,7 @@ func TestPseudonymousDeliveryEndToEnd(t *testing.T) {
 		// The claim is what a log-only observer reads, so it is asserted on the
 		// verified claim rather than on the URL string alone; the URL is checked
 		// too, since a JWT payload is readable base64 and the token *is* the URL.
-		assert.NotContains(t, one.rawBody, first)
+		assert.NotContains(t, one.body, first)
 		for _, token := range one.all() {
 			claims := verifyAny(t, ss, token)
 			assert.NotEqual(t, first, claims.identity)
@@ -107,7 +102,7 @@ func newPseudonymousSender(t *testing.T, fqdn string) pseudonymousSender {
 
 // send submits one Batch to the recipients and returns, per recipient, the
 // tracking tokens their built message carries.
-func (s pseudonymousSender) send(t *testing.T, recipients ...string) map[string]deliveredBody {
+func (s pseudonymousSender) send(t *testing.T, recipients ...string) map[string]deliveredTokens {
 	t.Helper()
 
 	pseudonymous := &trackingtypes.TrackingPolicy{
@@ -134,7 +129,7 @@ func (s pseudonymousSender) send(t *testing.T, recipients ...string) map[string]
 	require.NoError(t, err)
 	require.Empty(t, res.Msg.RejectedRecipients, "pseudonymous must be accepted at intake")
 
-	out := make(map[string]deliveredBody, len(recipients))
+	out := make(map[string]deliveredTokens, len(recipients))
 	for _, r := range recipients {
 		claimed := markValidatedAndClaim(t, batch.ID(res.Msg.MessageId), r)
 		require.Len(t, claimed, 1)
@@ -142,39 +137,7 @@ func (s pseudonymousSender) send(t *testing.T, recipients ...string) map[string]
 
 		env, err := eb.Build(t.Context(), claimed[0])
 		require.NoError(t, err)
-		out[r] = readDeliveredBody(t, env.Body())
-	}
-	return out
-}
-
-// deliveredBody is one built message as the recipient receives it, plus the
-// tracking tokens read out of it.
-type deliveredBody struct {
-	rawBody string
-	open    string
-	links   []string
-}
-
-func (d deliveredBody) all() []string { return append([]string{d.open}, d.links...) }
-
-func readDeliveredBody(t *testing.T, raw []byte) deliveredBody {
-	t.Helper()
-
-	parsed, err := mail.ReadMessage(bytes.NewReader(raw))
-	require.NoError(t, err)
-	body, err := io.ReadAll(parsed.Body)
-	require.NoError(t, err)
-	decoded, err := io.ReadAll(quotedprintable.NewReader(bytes.NewReader(body)))
-	require.NoError(t, err)
-
-	out := deliveredBody{rawBody: string(decoded)}
-
-	pixels := regexp.MustCompile(`/o/([A-Za-z0-9._-]+)`).FindAllStringSubmatch(out.rawBody, -1)
-	require.Len(t, pixels, 1, "a tracked message carries exactly one pixel, got %q", out.rawBody)
-	out.open = pixels[0][1]
-
-	for _, m := range regexp.MustCompile(`/c/([A-Za-z0-9._-]+)`).FindAllStringSubmatch(out.rawBody, -1) {
-		out.links = append(out.links, m[1])
+		out[r] = readDeliveredTokens(t, env.Body())
 	}
 	return out
 }

--- a/internal/envelope/pseudonymous_test.go
+++ b/internal/envelope/pseudonymous_test.go
@@ -1,0 +1,202 @@
+package envelope_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/kannon-email/kannon/internal/batch"
+	"github.com/kannon-email/kannon/internal/envelope"
+	"github.com/kannon-email/kannon/internal/tracking"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// pseudonymousPolicy tracks both axes under the rung that isolates a Recipient
+// without naming them.
+var pseudonymousPolicy = tracking.Policy{Opens: tracking.ModePseudonymous, Links: tracking.ModePseudonymous}
+
+// mintCall is one request the Builder made of the token issuer.
+type mintCall struct {
+	messageID string
+	identity  string
+	url       string
+	mode      tracking.Mode
+}
+
+// recordingTokens records the identity every mint was asked for. The tests below
+// are about *what the Builder names*, which the opaque token that comes back
+// cannot show — countingTokens answers the neighbouring question of whether a
+// token was reused.
+type recordingTokens struct {
+	mu    sync.Mutex
+	opens []mintCall
+	links []mintCall
+}
+
+func (r *recordingTokens) CreateOpenToken(_ context.Context, messageID, identity string, mode tracking.Mode) (string, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.opens = append(r.opens, mintCall{messageID: messageID, identity: identity, mode: mode})
+	return fmt.Sprintf("open-%d", len(r.opens)), nil
+}
+
+func (r *recordingTokens) CreateLinkToken(_ context.Context, messageID, identity, url string, mode tracking.Mode) (string, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.links = append(r.links, mintCall{messageID: messageID, identity: identity, url: url, mode: mode})
+	return fmt.Sprintf("link-%d", len(r.links)), nil
+}
+
+// recordingBuilder is trackedBuilder over a token issuer that remembers what it
+// was asked for.
+func recordingBuilder(t *testing.T, rec *recordingTokens, links ...string) envelope.Builder {
+	t.Helper()
+
+	body := &strings.Builder{}
+	body.WriteString("<html><body><h1>Hello!</h1>")
+	for _, l := range links {
+		fmt.Fprintf(body, "<a href=%q>x</a>", l)
+	}
+	body.WriteString("</body></html>")
+
+	return envelope.NewBuilderWith(batchSource{data: envelope.SendingData{
+		Subject:        "S",
+		HTML:           body.String(),
+		Domain:         "test.com",
+		SenderEmail:    "noreply@test.com",
+		SenderAlias:    "Test",
+		DkimPrivateKey: newDKIMKeys(t),
+	}}, rec)
+}
+
+func buildOne(t *testing.T, b envelope.Builder, batchID batch.ID, email string, p tracking.Policy) {
+	t.Helper()
+	_, err := b.Build(t.Context(), mustDeliveryTracked(t, batchID, email, nil, p))
+	require.NoError(t, err)
+}
+
+// TestBuilderDrawsOnePseudonymPerDelivery is the definition of the Pseudonymous
+// rung made observable: the pixel and *every* link of one Delivery are minted
+// against the same identity, so the Recipient's engagement events are linkable to
+// each other within the Batch. Drawing a pseudonym per token instead would leave
+// every event a singleton — the tokens would look exactly as they do here, and the
+// rung would silently record less than it promises.
+func TestBuilderDrawsOnePseudonymPerDelivery(t *testing.T) {
+	const first = "https://example.com/first"
+	const second = "https://example.com/second"
+
+	rec := &recordingTokens{}
+	buildOne(t, recordingBuilder(t, rec, first, second), batch.ID("msg-1@test.com"), "a@example.com", pseudonymousPolicy)
+
+	require.Len(t, rec.opens, 1)
+	require.Len(t, rec.links, 2)
+
+	pseudonym := rec.opens[0].identity
+	for _, call := range rec.links {
+		assert.Equal(t, pseudonym, call.identity,
+			"the pixel and every link of one Delivery must carry the same pseudonym")
+	}
+
+	assert.NotEqual(t, "a@example.com", pseudonym, "no tracking URL may carry the recipient address")
+	assert.True(t, tracking.InReservedNamespace(pseudonym, "test.com"),
+		"a pseudonym must sit in the Domain's reserved namespace, got %q", pseudonym)
+	assert.Equal(t, tracking.ModePseudonymous, rec.opens[0].mode)
+}
+
+// TestPseudonymsAreDrawnFreshEverywhere pins the other half of the rung: linkable
+// *within* a Batch, and nowhere else. Two Recipients of one Batch must not collide,
+// or their events would merge; and one Recipient across two Batches must not
+// repeat, or the pseudonyms would compose into a durable identifier — which nobody,
+// Kannon included, is able to resolve precisely because nothing derives them.
+func TestPseudonymsAreDrawnFreshEverywhere(t *testing.T) {
+	const landing = "https://example.com/landing"
+
+	t.Run("TwoRecipientsOfOneBatch", func(t *testing.T) {
+		rec := &recordingTokens{}
+		b := recordingBuilder(t, rec, landing)
+		batchID := batch.ID("msg-1@test.com")
+
+		buildOne(t, b, batchID, "a@example.com", pseudonymousPolicy)
+		buildOne(t, b, batchID, "b@example.com", pseudonymousPolicy)
+
+		require.Len(t, rec.opens, 2)
+		assert.NotEqual(t, rec.opens[0].identity, rec.opens[1].identity)
+	})
+
+	t.Run("OneRecipientInTwoBatches", func(t *testing.T) {
+		rec := &recordingTokens{}
+		b := recordingBuilder(t, rec, landing)
+
+		buildOne(t, b, batch.ID("msg-1@test.com"), "a@example.com", pseudonymousPolicy)
+		buildOne(t, b, batch.ID("msg-2@test.com"), "a@example.com", pseudonymousPolicy)
+
+		require.Len(t, rec.opens, 2)
+		assert.NotEqual(t, rec.opens[0].identity, rec.opens[1].identity)
+	})
+}
+
+// TestPseudonymsAreDrawnOnlyWhenAnAxisAsksForOne keeps the two axes independent
+// (ADR 0003) at the one place a Delivery now has two identities to choose between.
+// A Delivery with one pseudonymous axis and one identified axis must not leak the
+// pseudonym into the identified axis — which would lose the sender data they are
+// entitled to — nor the address into the pseudonymous one, which is the whole
+// point of the rung and is refused at the mint anyway.
+func TestPseudonymsAreDrawnOnlyWhenAnAxisAsksForOne(t *testing.T) {
+	const landing = "https://example.com/landing"
+
+	t.Run("MixedAxes", func(t *testing.T) {
+		rec := &recordingTokens{}
+		buildOne(t, recordingBuilder(t, rec, landing), batch.ID("msg-1@test.com"), "a@example.com",
+			tracking.Policy{Opens: tracking.ModePseudonymous, Links: tracking.ModeIdentified})
+
+		require.Len(t, rec.opens, 1)
+		require.Len(t, rec.links, 1)
+		assert.True(t, tracking.InReservedNamespace(rec.opens[0].identity, "test.com"),
+			"the pseudonymous axis carries a pseudonym")
+		assert.Equal(t, "a@example.com", rec.links[0].identity,
+			"the identified axis still names the Recipient")
+	})
+
+	t.Run("NoPseudonymousAxis", func(t *testing.T) {
+		rec := &recordingTokens{}
+		buildOne(t, recordingBuilder(t, rec, landing), batch.ID("msg-1@test.com"), "a@example.com", identifiedPolicy)
+
+		require.Len(t, rec.opens, 1)
+		require.Len(t, rec.links, 1)
+		assert.Equal(t, "a@example.com", rec.opens[0].identity)
+		assert.Equal(t, "a@example.com", rec.links[0].identity)
+	})
+
+	// The Builder hands the address over under Anonymous too and lets the mint
+	// drop it, so that the decision lives at the one place every token passes
+	// through rather than being made twice.
+	t.Run("AnonymousLeavesTheDropToTheMint", func(t *testing.T) {
+		rec := &recordingTokens{}
+		buildOne(t, recordingBuilder(t, rec, landing), batch.ID("msg-1@test.com"), "a@example.com", anonymousPolicy)
+
+		require.Len(t, rec.opens, 1)
+		assert.Equal(t, "a@example.com", rec.opens[0].identity)
+		assert.Equal(t, tracking.ModeAnonymous, rec.opens[0].mode)
+	})
+}
+
+// TestBuilderDoesNotSharePseudonymousTokens is the cost side of the rung, and the
+// bug it guards against is severe: the shared-token cache exists for the Modes
+// whose token is a function of the Batch, and a pseudonymous token is a function
+// of the Delivery. Handing a cached one to a second Recipient would file both
+// Recipients' engagement under a single pseudonym.
+func TestBuilderDoesNotSharePseudonymousTokens(t *testing.T) {
+	const landing = "https://example.com/landing"
+
+	b := trackedBuilder(t, landing)
+	batchID := batch.ID("msg-1@test.com")
+
+	one := deliverTo(t, b, batchID, "a@example.com", pseudonymousPolicy)
+	two := deliverTo(t, b, batchID, "b@example.com", pseudonymousPolicy)
+
+	assert.NotEqual(t, one.open, two.open, "a pseudonymous pixel is per-Delivery")
+	assert.NotEqual(t, one.links, two.links, "a pseudonymous link is per-Delivery")
+}

--- a/internal/envelope/pseudonymous_test.go
+++ b/internal/envelope/pseudonymous_test.go
@@ -3,7 +3,6 @@ package envelope_test
 import (
 	"context"
 	"fmt"
-	"strings"
 	"sync"
 	"testing"
 
@@ -54,22 +53,7 @@ func (r *recordingTokens) CreateLinkToken(_ context.Context, messageID, identity
 // was asked for.
 func recordingBuilder(t *testing.T, rec *recordingTokens, links ...string) envelope.Builder {
 	t.Helper()
-
-	body := &strings.Builder{}
-	body.WriteString("<html><body><h1>Hello!</h1>")
-	for _, l := range links {
-		fmt.Fprintf(body, "<a href=%q>x</a>", l)
-	}
-	body.WriteString("</body></html>")
-
-	return envelope.NewBuilderWith(batchSource{data: envelope.SendingData{
-		Subject:        "S",
-		HTML:           body.String(),
-		Domain:         "test.com",
-		SenderEmail:    "noreply@test.com",
-		SenderAlias:    "Test",
-		DkimPrivateKey: newDKIMKeys(t),
-	}}, rec)
+	return trackedBuilderWith(t, rec, links...)
 }
 
 func buildOne(t *testing.T, b envelope.Builder, batchID batch.ID, email string, p tracking.Policy) {

--- a/internal/statssec/keys.go
+++ b/internal/statssec/keys.go
@@ -14,6 +14,7 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 	sqlc "github.com/kannon-email/kannon/internal/db"
 	"github.com/kannon-email/kannon/internal/tracking"
+	"github.com/kannon-email/kannon/internal/utils"
 )
 
 const tokenExpirePeriod = time.Hour * 24 * 30 * 3 // 3 months
@@ -53,8 +54,11 @@ const (
 // nothing and therefore never reaches Full: the absence can only ever restrict
 // what the Tracker retains, never widen it.
 //
-// Email is empty under a Mode that does not identify the Recipient — see
-// identityUnder.
+// Email is the identity claim, always email-shaped and always decided by the
+// Mode: the Recipient's address under a Mode that names them, a sentinel address
+// under the Modes that name nobody — see identityUnder. A token minted before
+// sentinels existed carries none at all under those Modes, and the empty case
+// therefore has to keep working for one tokenExpirePeriod.
 type OpenClaims struct {
 	MessageID string        `json:"message_id"`
 	Email     string        `json:"email"`
@@ -73,24 +77,53 @@ type LinkClaims struct {
 	jwt.RegisteredClaims
 }
 
-// identityUnder returns the Recipient identity a token minted under mode may
-// carry: none at all under a Mode that does not identify the Recipient
-// (Anonymous, and the reserved Pseudonymous).
+// ErrIdentityOutsideNamespace is a mint refused because the identity offered for
+// a Mode that must name nobody is not a sentinel address of the Batch's Domain —
+// in practice, a caller passing the recipient's real address under Pseudonymous.
+var ErrIdentityOutsideNamespace = errors.New("tracking identity outside the reserved namespace")
+
+// identityUnder returns the identity a token minted under mode carries. It is
+// always email-shaped and the Mode alone decides which address it is (ADR 0006):
 //
-// That is the privacy property of Anonymous made true in fact rather than in
-// intent — a token holding no address cannot isolate one Recipient from another
-// even if it is captured — and it is what makes the token a function of the Batch
-// instead of the Delivery, so the same one can be issued to every Recipient of a
-// Batch instead of signing RSA-4096 once per Delivery.
+//   - a Mode that names the Recipient carries the Recipient's own address;
+//   - Pseudonymous carries the pseudonym the Builder drew for this Delivery,
+//     which must already sit in the Domain's reserved namespace;
+//   - every other Mode carries the Anonymous sentinel, which is constant per
+//     Domain, so the token stays a function of the Batch and one RSA-4096
+//     signature still covers all of it.
 //
-// The drop happens here, where the claim is assembled, rather than in the caller:
-// this is the one place every token passes through, so no caller can mint an
-// Anonymous token that names somebody by forgetting to blank the address first.
-func identityUnder(mode tracking.Mode, email string) string {
-	if !mode.IdentifiesRecipient() {
-		return ""
+// The decision is taken here, where the claim is assembled, rather than in the
+// caller: this is the one place every token passes through, so no caller can mint
+// a token that names somebody under a Mode that must not. Under Pseudonymous the
+// identity does have to come from the caller — only the Builder knows which
+// Delivery is which, and that is the whole content of the rung — so the property
+// is preserved by *checking* rather than by overwriting: an identity outside
+// `@track.<domain>` is refused instead of shipped.
+//
+// The namespace is derived from the Batch id rather than taken as an argument,
+// both because a caller cannot then widen it and because it is where the Tracker
+// reads the Domain from too, so mint and verify cannot disagree about which
+// Domain a sentinel belongs to.
+func identityUnder(mode tracking.Mode, offered string, messageID string) (string, error) {
+	if mode.IdentifiesRecipient() {
+		return offered, nil
 	}
-	return email
+
+	fqdn, err := utils.ExtractDomainFromMessageID(messageID)
+	if err != nil {
+		return "", fmt.Errorf("cannot resolve the reserved namespace: %w", err)
+	}
+
+	if !mode.IsolatesRecipient() {
+		return tracking.AnonymousIdentity(fqdn), nil
+	}
+
+	// Deliberately never logged or wrapped with the offending value: the whole
+	// point of the refusal is that the value may be a recipient address.
+	if !tracking.InReservedNamespace(offered, fqdn) {
+		return "", fmt.Errorf("%w: %s under %q", ErrIdentityOutsideNamespace, tracking.ReservedNamespace(fqdn), mode)
+	}
+	return offered, nil
 }
 
 func generateKeyPair() (*rsa.PrivateKey, *rsa.PublicKey, error) {
@@ -103,10 +136,15 @@ func generateKeyPair() (*rsa.PrivateKey, *rsa.PublicKey, error) {
 	return privatekey, publickey.(*rsa.PublicKey), nil //nolint:errcheck // RSA private key always returns *rsa.PublicKey
 }
 
-func createOpenToken(privateKey *rsa.PrivateKey, kid string, now time.Time, messageID string, email string, mode tracking.Mode) (string, error) {
+func createOpenToken(privateKey *rsa.PrivateKey, kid string, now time.Time, messageID string, offered string, mode tracking.Mode) (string, error) {
+	identity, err := identityUnder(mode, offered, messageID)
+	if err != nil {
+		return "", err
+	}
+
 	claims := &OpenClaims{
 		MessageID: messageID,
-		Email:     identityUnder(mode, email),
+		Email:     identity,
 		Mode:      mode,
 		RegisteredClaims: jwt.RegisteredClaims{
 			ExpiresAt: jwt.NewNumericDate(now.Add(tokenExpirePeriod)),
@@ -123,10 +161,15 @@ func createOpenToken(privateKey *rsa.PrivateKey, kid string, now time.Time, mess
 	return token, nil
 }
 
-func createLinkToken(privateKey *rsa.PrivateKey, kid string, now time.Time, messageID string, email string, url string, mode tracking.Mode) (string, error) {
+func createLinkToken(privateKey *rsa.PrivateKey, kid string, now time.Time, messageID string, offered string, url string, mode tracking.Mode) (string, error) {
+	identity, err := identityUnder(mode, offered, messageID)
+	if err != nil {
+		return "", err
+	}
+
 	claims := &LinkClaims{
 		MessageID: messageID,
-		Email:     identityUnder(mode, email),
+		Email:     identity,
 		URL:       url,
 		Mode:      mode,
 		RegisteredClaims: jwt.RegisteredClaims{

--- a/internal/statssec/keys.go
+++ b/internal/statssec/keys.go
@@ -120,7 +120,7 @@ func identityUnder(mode tracking.Mode, offered string, messageID string) (string
 
 	// Deliberately never logged or wrapped with the offending value: the whole
 	// point of the refusal is that the value may be a recipient address.
-	if !tracking.InReservedNamespace(offered, fqdn) {
+	if !tracking.IsPseudonym(offered, fqdn) {
 		return "", fmt.Errorf("%w: %s under %q", ErrIdentityOutsideNamespace, tracking.ReservedNamespace(fqdn), mode)
 	}
 	return offered, nil

--- a/internal/statssec/statssec.go
+++ b/internal/statssec/statssec.go
@@ -19,13 +19,16 @@ import (
 // a request is fixed by a signature at send time rather than looked up when the
 // engagement arrives.
 //
-// The Mode also decides whether the email address given to a Create call reaches
-// the token at all: under a Mode that does not identify the Recipient it is
-// dropped, so the minted token names nobody and is therefore the same token for
-// every Recipient of a Batch (see identityUnder).
+// The Mode also decides which address the email argument of a Create call becomes
+// in the token: the Recipient's own under a Mode that names them, a sentinel
+// address under the Modes that name nobody (see identityUnder). Under Anonymous
+// that sentinel is constant per Domain, so the minted token is the same one for
+// every Recipient of a Batch; under Pseudonymous it is the caller's per-Delivery
+// pseudonym, and a mint whose identity is not a sentinel of the Batch's Domain is
+// refused with ErrIdentityOutsideNamespace.
 type StatsService interface {
-	CreateOpenToken(ctx context.Context, messageID string, email string, mode tracking.Mode) (string, error)
-	CreateLinkToken(ctx context.Context, messageID string, email string, url string, mode tracking.Mode) (string, error)
+	CreateOpenToken(ctx context.Context, messageID string, identity string, mode tracking.Mode) (string, error)
+	CreateLinkToken(ctx context.Context, messageID string, identity string, url string, mode tracking.Mode) (string, error)
 	VerifyOpenToken(ctx context.Context, token string) (*OpenClaims, error)
 	VerifyLinkToken(ctx context.Context, token string) (*LinkClaims, error)
 }
@@ -42,13 +45,13 @@ type service struct {
 	now func() time.Time
 }
 
-func (s *service) CreateOpenToken(ctx context.Context, messageID string, email string, mode tracking.Mode) (string, error) {
+func (s *service) CreateOpenToken(ctx context.Context, messageID string, identity string, mode tracking.Mode) (string, error) {
 	privateKey, kid, err := s.getSignKeys(ctx)
 	if err != nil {
 		return "", err
 	}
 
-	token, err := createOpenToken(privateKey, kid, s.now(), messageID, email, mode)
+	token, err := createOpenToken(privateKey, kid, s.now(), messageID, identity, mode)
 	if err != nil {
 		return "", err
 	}
@@ -56,13 +59,13 @@ func (s *service) CreateOpenToken(ctx context.Context, messageID string, email s
 	return token, nil
 }
 
-func (s *service) CreateLinkToken(ctx context.Context, messageID string, email string, url string, mode tracking.Mode) (string, error) {
+func (s *service) CreateLinkToken(ctx context.Context, messageID string, identity string, url string, mode tracking.Mode) (string, error) {
 	privateKey, kid, err := s.getSignKeys(ctx)
 	if err != nil {
 		return "", err
 	}
 
-	token, err := createLinkToken(privateKey, kid, s.now(), messageID, email, url, mode)
+	token, err := createLinkToken(privateKey, kid, s.now(), messageID, identity, url, mode)
 	if err != nil {
 		return "", err
 	}

--- a/internal/statssec/statssec_test.go
+++ b/internal/statssec/statssec_test.go
@@ -167,6 +167,10 @@ func TestPseudonymousTokensCarryTheCallersSentinel(t *testing.T) {
 		{name: "nothing at all", identity: ""},
 		{name: "another Domain's namespace", identity: "abc@track.other.com"},
 		{name: "the bare sending Domain", identity: "abc@test.com"},
+		// In the namespace, but the one address the Stats worker reads as naming
+		// nobody: minting it would produce an event that is dropped downstream as
+		// an upstream bug.
+		{name: "the anonymous sentinel", identity: "anonymous@track.test.com"},
 	}
 
 	for _, tc := range outside {

--- a/internal/statssec/statssec_test.go
+++ b/internal/statssec/statssec_test.go
@@ -96,39 +96,86 @@ func TestTokensCarryTheMintedMode(t *testing.T) {
 	}
 }
 
-// TestTokensCarryNoIdentityWhenTheModeDoesNotIdentify is the Anonymous privacy
-// property at the mint: whatever address the caller hands over, an Anonymous
-// token names nobody. It is asserted through Verify, so the claim a Tracker will
+// batchID is a Batch id in the shape the Builder actually hands over,
+// `msg_<cuid>@<fqdn>` — the mint reads the Domain out of it to build the reserved
+// namespace, so a test id has to spell one out.
+const batchID = "msg_ck7m2n1p0000@test.com"
+
+// TestAnonymousTokensNameNobody is the Anonymous privacy property at the mint:
+// whatever address the caller hands over, an Anonymous token carries the Domain's
+// sentinel instead. It is asserted through Verify, so the claim a Tracker will
 // actually read is the one under test — and the two tokens are compared to each
 // other, because "the claims look the same" is weaker than "the Recipients cannot
 // be told apart".
-func TestTokensCarryNoIdentityWhenTheModeDoesNotIdentify(t *testing.T) {
-	const messageID = "<xxxx/test@test.com>"
+func TestAnonymousTokensNameNobody(t *testing.T) {
+	const url = "https://test.com"
+	const sentinel = "anonymous@track.test.com"
+
+	openClaims, err := s.VerifyOpenToken(t.Context(),
+		mustCreateOpenToken(t, batchID, "first@test.com", tracking.ModeAnonymous))
+	assert.Nil(t, err)
+	assert.Equal(t, sentinel, openClaims.Email, "an Anonymous open token must name nobody")
+	assert.Equal(t, batchID, openClaims.MessageID, "the Batch is still named")
+	assert.Equal(t, tracking.ModeAnonymous, openClaims.Mode)
+
+	otherClaims, err := s.VerifyOpenToken(t.Context(),
+		mustCreateOpenToken(t, batchID, "second@test.com", tracking.ModeAnonymous))
+	assert.Nil(t, err)
+	assert.Equal(t, openClaims.Email, otherClaims.Email,
+		"two Recipients of a Batch must be indistinguishable under Anonymous")
+
+	linkToken, err := s.CreateLinkToken(t.Context(), batchID, "first@test.com", url, tracking.ModeAnonymous)
+	assert.Nil(t, err)
+	linkClaims, err := s.VerifyLinkToken(t.Context(), linkToken)
+	assert.Nil(t, err)
+	assert.Equal(t, sentinel, linkClaims.Email, "an Anonymous link token must name nobody")
+	assert.Equal(t, url, linkClaims.URL, "the tracked URL is still named")
+	assert.Equal(t, tracking.ModeAnonymous, linkClaims.Mode)
+}
+
+// TestPseudonymousTokensCarryTheCallersSentinel pins what the mint does with the
+// one Mode whose identity it cannot invent for itself: it passes the Builder's
+// per-Delivery pseudonym through unchanged, so the pixel and every link of one
+// Delivery agree, and it refuses anything outside the Domain's reserved namespace.
+//
+// The refusal is the chokepoint property (ADR 0006): a caller that passes the real
+// address with a Pseudonymous Mode is caught here rather than shipped.
+func TestPseudonymousTokensCarryTheCallersSentinel(t *testing.T) {
+	const pseudonym = "0123456789abcdef0123456789abcdef@track.test.com"
 	const url = "https://test.com"
 
-	for _, mode := range []tracking.Mode{tracking.ModeAnonymous, tracking.ModePseudonymous} {
-		t.Run(string(mode), func(t *testing.T) {
-			openToken, err := s.CreateOpenToken(t.Context(), messageID, "first@test.com", mode)
-			assert.Nil(t, err)
-			openClaims, err := s.VerifyOpenToken(t.Context(), openToken)
-			assert.Nil(t, err)
-			assert.Empty(t, openClaims.Email, "an open token under %q must name nobody", mode)
-			assert.Equal(t, messageID, openClaims.MessageID, "the Batch is still named")
-			assert.Equal(t, mode, openClaims.Mode)
+	t.Run("A sentinel of the Batch's Domain is minted", func(t *testing.T) {
+		openClaims, err := s.VerifyOpenToken(t.Context(),
+			mustCreateOpenToken(t, batchID, pseudonym, tracking.ModePseudonymous))
+		assert.Nil(t, err)
+		assert.Equal(t, pseudonym, openClaims.Email)
+		assert.Equal(t, tracking.ModePseudonymous, openClaims.Mode)
 
-			otherClaims, err := s.VerifyOpenToken(t.Context(),
-				mustCreateOpenToken(t, messageID, "second@test.com", mode))
-			assert.Nil(t, err)
-			assert.Equal(t, openClaims.Email, otherClaims.Email,
-				"two Recipients of a Batch must be indistinguishable under %q", mode)
+		linkToken, err := s.CreateLinkToken(t.Context(), batchID, pseudonym, url, tracking.ModePseudonymous)
+		assert.Nil(t, err)
+		linkClaims, err := s.VerifyLinkToken(t.Context(), linkToken)
+		assert.Nil(t, err)
+		assert.Equal(t, pseudonym, linkClaims.Email,
+			"the pixel and the links of one Delivery must carry the same pseudonym")
+	})
 
-			linkToken, err := s.CreateLinkToken(t.Context(), messageID, "first@test.com", url, mode)
-			assert.Nil(t, err)
-			linkClaims, err := s.VerifyLinkToken(t.Context(), linkToken)
-			assert.Nil(t, err)
-			assert.Empty(t, linkClaims.Email, "a link token under %q must name nobody", mode)
-			assert.Equal(t, url, linkClaims.URL, "the tracked URL is still named")
-			assert.Equal(t, mode, linkClaims.Mode)
+	outside := []struct {
+		name     string
+		identity string
+	}{
+		{name: "the recipient's real address", identity: "first@test.com"},
+		{name: "nothing at all", identity: ""},
+		{name: "another Domain's namespace", identity: "abc@track.other.com"},
+		{name: "the bare sending Domain", identity: "abc@test.com"},
+	}
+
+	for _, tc := range outside {
+		t.Run("A Pseudonymous mint is refused for "+tc.name, func(t *testing.T) {
+			_, err := s.CreateOpenToken(t.Context(), batchID, tc.identity, tracking.ModePseudonymous)
+			assert.ErrorIs(t, err, statssec.ErrIdentityOutsideNamespace)
+
+			_, err = s.CreateLinkToken(t.Context(), batchID, tc.identity, url, tracking.ModePseudonymous)
+			assert.ErrorIs(t, err, statssec.ErrIdentityOutsideNamespace)
 		})
 	}
 }

--- a/internal/tracking/identity.go
+++ b/internal/tracking/identity.go
@@ -1,0 +1,85 @@
+package tracking
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"strings"
+)
+
+// The identity a tracking token carries is always email-shaped, and which
+// address it is, is decided by the Tracking Mode (ADR 0006): the Recipient's own
+// under a Mode that names them, and a **sentinel address** under the Modes that
+// name nobody. Keeping the claim one type is what lets the Stats worker, the
+// `stats` schema and the API surface stay untouched by the Modes that identify
+// no one — a Pseudonymous event flows through the same per-recipient write path
+// as an Identified one, and the Mode is the discriminator.
+//
+// The sentinels live under a reserved subdomain of the sending Domain rather
+// than at the bare Domain, because `anonymous@<fqdn>` can be a real mailbox: the
+// reservation exists so the sentinel space and the deliverable space cannot
+// collide.
+const (
+	// reservedLabel is the subdomain reserved for sentinel addresses. Operators
+	// must not deliver mail under it — see ARCHITECTURE.md.
+	reservedLabel = "track"
+	// anonymousLocalPart names the sentinel that stands for no one at all. It is
+	// constant per Domain by design; see AnonymousIdentity.
+	anonymousLocalPart = "anonymous"
+	// pseudonymBytes is the entropy behind one pseudonym: 128 bits, far past any
+	// birthday collision within the Batch a pseudonym is meaningful in.
+	pseudonymBytes = 16
+)
+
+// ReservedNamespace returns the domain part every sentinel address of fqdn lives
+// under.
+func ReservedNamespace(fqdn string) string {
+	return reservedLabel + "." + fqdn
+}
+
+// AnonymousIdentity returns the sentinel an Anonymous token carries for fqdn.
+//
+// It exists for uniformity of the claim type and nothing else: an Anonymous event
+// is counted in aggregate only and never reaches the `stats` table. Being constant
+// per Domain is the point — the token an Anonymous axis mints names nobody and is
+// therefore the same token for every Recipient of a Batch, one RSA-4096 signature
+// instead of one per Delivery.
+func AnonymousIdentity(fqdn string) string {
+	return anonymousLocalPart + "@" + ReservedNamespace(fqdn)
+}
+
+// NewPseudonym returns a fresh Pseudonymous identity under fqdn: 128 bits from
+// crypto/rand as a lowercase hex local part.
+//
+// Lowercase hex because email pipelines case-fold, and a case-sensitive alphabet
+// would let a lowercasing in transit merge two pseudonyms into one.
+//
+// It is drawn at random, stored nowhere and derived from nothing. That is what the
+// rung promises: the same Recipient in two Batches carries two pseudonyms nobody —
+// Kannon included — can link, and no key holder can confirm a guessed (address,
+// pseudonym) pairing, which a deterministic derivation such as an HMAC of the
+// address would allow (ADR 0006).
+//
+// The caller decides how often to call it, and that decision *is* the rung: one
+// pseudonym per Delivery makes a Delivery's events linkable to each other and to
+// nothing else. See internal/envelope.
+func NewPseudonym(fqdn string) (string, error) {
+	raw := make([]byte, pseudonymBytes)
+	if _, err := rand.Read(raw); err != nil {
+		return "", fmt.Errorf("cannot generate tracking pseudonym: %w", err)
+	}
+	return hex.EncodeToString(raw) + "@" + ReservedNamespace(fqdn), nil
+}
+
+// InReservedNamespace reports whether identity is a sentinel address of fqdn: a
+// non-empty local part directly under the reserved namespace.
+//
+// It is the machine-checkable form of the reservation, and the mint uses it to
+// refuse a token that claims to name nobody while carrying a real address. The
+// domain part is compared case-insensitively for the same reason pseudonyms are
+// lowercase hex; the local part is not inspected, since the check is about the
+// namespace an identity sits in and not about how it was drawn.
+func InReservedNamespace(identity, fqdn string) bool {
+	local, host, ok := strings.Cut(identity, "@")
+	return ok && local != "" && strings.EqualFold(host, ReservedNamespace(fqdn))
+}

--- a/internal/tracking/identity.go
+++ b/internal/tracking/identity.go
@@ -74,12 +74,36 @@ func NewPseudonym(fqdn string) (string, error) {
 // InReservedNamespace reports whether identity is a sentinel address of fqdn: a
 // non-empty local part directly under the reserved namespace.
 //
-// It is the machine-checkable form of the reservation, and the mint uses it to
-// refuse a token that claims to name nobody while carrying a real address. The
-// domain part is compared case-insensitively for the same reason pseudonyms are
-// lowercase hex; the local part is not inspected, since the check is about the
-// namespace an identity sits in and not about how it was drawn.
+// It is the machine-checkable form of the reservation. The domain part is
+// compared case-insensitively for the same reason pseudonyms are lowercase hex;
+// the local part is not inspected, since the question is which namespace an
+// identity sits in and not how it was drawn.
 func InReservedNamespace(identity, fqdn string) bool {
 	local, host, ok := strings.Cut(identity, "@")
 	return ok && local != "" && strings.EqualFold(host, ReservedNamespace(fqdn))
+}
+
+// IsPseudonym reports whether identity may be minted as a Pseudonymous identity
+// of fqdn: a sentinel address that is not the one standing for no one.
+//
+// The mint uses it to refuse a token claiming to be pseudonymous while carrying
+// a real address. Excluding the Anonymous sentinel is what keeps that refusal in
+// step with the Stats worker, which reads the same address as naming nobody and
+// would refuse to record it: without this, the two chokepoints would disagree
+// about the one address they both have an opinion on, and a Pseudonymous event
+// could be minted only to be dropped downstream as a bug.
+func IsPseudonym(identity, fqdn string) bool {
+	return InReservedNamespace(identity, fqdn) && !NamesNobody(identity, fqdn)
+}
+
+// NamesNobody reports whether identity attributes an event to no one: either the
+// Anonymous sentinel of fqdn, or nothing at all.
+//
+// The empty case is a token minted before the identity claim was always an
+// address, which keeps arriving for one token lifetime after this build ships.
+// A pseudonym is deliberately *not* one of these — it names nobody in the sense
+// that matters to a person, but it does name one Delivery, which is exactly what
+// the Pseudonymous rung records.
+func NamesNobody(identity, fqdn string) bool {
+	return identity == "" || strings.EqualFold(identity, AnonymousIdentity(fqdn))
 }

--- a/internal/tracking/identity_test.go
+++ b/internal/tracking/identity_test.go
@@ -1,0 +1,89 @@
+package tracking_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/kannon-email/kannon/internal/tracking"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestReservedNamespace pins the shape of the namespace an operator must keep
+// free of real mailboxes: one label under the sending Domain, so the sentinel
+// space and the deliverable space cannot collide (ADR 0006).
+func TestReservedNamespace(t *testing.T) {
+	assert.Equal(t, "track.kannon.dev", tracking.ReservedNamespace("kannon.dev"))
+}
+
+// TestAnonymousIdentity pins the one sentinel that is constant per Domain. It has
+// to be: the whole Batch shares a single Anonymous token, so an identity that
+// varied per Delivery would cost one RSA-4096 signature per Delivery to say
+// nothing.
+func TestAnonymousIdentity(t *testing.T) {
+	first := tracking.AnonymousIdentity("kannon.dev")
+	second := tracking.AnonymousIdentity("kannon.dev")
+
+	assert.Equal(t, "anonymous@track.kannon.dev", first)
+	assert.Equal(t, first, second)
+	assert.True(t, tracking.InReservedNamespace(first, "kannon.dev"))
+}
+
+// TestNewPseudonym pins the two properties the Pseudonymous rung rests on: the
+// pseudonym lives in the reserved namespace, and it is drawn fresh every time.
+// Nothing derives it from the address, so no one — Kannon included — can link two
+// of them or walk one back to a Recipient.
+func TestNewPseudonym(t *testing.T) {
+	first, err := tracking.NewPseudonym("kannon.dev")
+	require.NoError(t, err)
+	second, err := tracking.NewPseudonym("kannon.dev")
+	require.NoError(t, err)
+
+	assert.NotEqual(t, first, second)
+	assert.True(t, tracking.InReservedNamespace(first, "kannon.dev"))
+
+	local, host, ok := strings.Cut(first, "@")
+	require.True(t, ok)
+	assert.Equal(t, "track.kannon.dev", host)
+
+	// 128 bits as lowercase hex: email pipelines case-fold, and a case-sensitive
+	// alphabet would let a lowercasing in transit merge two pseudonyms into one.
+	assert.Len(t, local, 32)
+	assert.Equal(t, strings.ToLower(local), local)
+	assert.Regexp(t, `^[0-9a-f]{32}$`, local)
+}
+
+// TestInReservedNamespace covers the check that keeps a real address from being
+// minted under a Mode that must not name anybody.
+func TestInReservedNamespace(t *testing.T) {
+	cases := []struct {
+		name     string
+		identity string
+		want     bool
+	}{
+		{name: "a pseudonym", identity: "0123456789abcdef0123456789abcdef@track.kannon.dev", want: true},
+		{name: "the anonymous sentinel", identity: "anonymous@track.kannon.dev", want: true},
+		// The case an operator would notice: a caller passing the recipient address
+		// under a Mode that names nobody.
+		{name: "a real address at the Domain", identity: "someone@kannon.dev", want: false},
+		{name: "a real address elsewhere", identity: "someone@example.com", want: false},
+		{name: "empty", identity: "", want: false},
+		{name: "no local part", identity: "@track.kannon.dev", want: false},
+		{name: "no at sign", identity: "track.kannon.dev", want: false},
+		// A deeper subdomain is not the reserved namespace: only track.<fqdn> is
+		// reserved, so anything below it may hold real mailboxes.
+		{name: "a deeper subdomain", identity: "x@a.track.kannon.dev", want: false},
+		// Another Domain's namespace is another Domain's, and a token minted for
+		// this one may not carry it.
+		{name: "another Domain's namespace", identity: "x@track.other.dev", want: false},
+		// Email pipelines case-fold the domain part, so a sentinel that came back
+		// uppercased is still the same sentinel.
+		{name: "case-folded in transit", identity: "x@TRACK.KANNON.DEV", want: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, tracking.InReservedNamespace(tc.identity, "kannon.dev"))
+		})
+	}
+}

--- a/internal/tracking/identity_test.go
+++ b/internal/tracking/identity_test.go
@@ -87,3 +87,39 @@ func TestInReservedNamespace(t *testing.T) {
 		})
 	}
 }
+
+// TestIsPseudonymAndNamesNobodyPartitionTheNamespace covers the one address the
+// two chokepoints could have disagreed about. The mint asks "may this be minted
+// as a pseudonym?" and the Stats worker asks "does this name anybody?"; if the
+// Anonymous sentinel answered yes to both, a Pseudonymous token could be minted
+// naming it and then be dropped downstream as an upstream bug.
+func TestIsPseudonymAndNamesNobodyPartitionTheNamespace(t *testing.T) {
+	const fqdn = "kannon.dev"
+
+	cases := []struct {
+		name        string
+		identity    string
+		isPseudonym bool
+		namesNobody bool
+	}{
+		{name: "a pseudonym", identity: "0123456789abcdef0123456789abcdef@track.kannon.dev", isPseudonym: true, namesNobody: false},
+		{name: "the anonymous sentinel", identity: tracking.AnonymousIdentity(fqdn), isPseudonym: false, namesNobody: true},
+		// A token minted before the identity claim was always an address. Those
+		// stay in circulation for one token lifetime and must keep reading as
+		// naming nobody.
+		{name: "a legacy blank claim", identity: "", isPseudonym: false, namesNobody: true},
+		{name: "a real address", identity: "someone@kannon.dev", isPseudonym: false, namesNobody: false},
+		// Email pipelines case-fold, so a sentinel that came back uppercased is
+		// still the same sentinel on both questions.
+		{name: "the sentinel case-folded in transit", identity: "ANONYMOUS@TRACK.KANNON.DEV", isPseudonym: false, namesNobody: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.isPseudonym, tracking.IsPseudonym(tc.identity, fqdn))
+			assert.Equal(t, tc.namesNobody, tracking.NamesNobody(tc.identity, fqdn))
+			assert.False(t, tc.isPseudonym && tc.namesNobody,
+				"no identity may be both mintable as a pseudonym and unrecordable")
+		})
+	}
+}

--- a/internal/tracking/tracking.go
+++ b/internal/tracking/tracking.go
@@ -27,8 +27,8 @@ const (
 	// retained that could isolate one Recipient from another.
 	ModeAnonymous Mode = "anonymous"
 	// ModePseudonymous means events are linkable within a single Batch but
-	// carry no Recipient identity. Reserved, not implemented: it is ranked so
-	// the scale is complete, and rejected at the API boundary.
+	// carry no Recipient identity: they name a pseudonym drawn fresh for every
+	// Delivery of every Batch (see identity.go).
 	ModePseudonymous Mode = "pseudonymous"
 	// ModeIdentified means events are attributed to the Recipient.
 	ModeIdentified Mode = "identified"
@@ -101,6 +101,29 @@ func (m Mode) IdentifiesRecipient() bool {
 	}
 	_, rank := m.collection()
 	return rank >= modeRanks[ModeIdentified]
+}
+
+// IsolatesRecipient reports whether what is retained about an engagement governed
+// by m may tell one Recipient of a Batch from another. Pseudonymous is by
+// definition the rung at which that begins — its events name nobody yet are
+// linkable to each other within a Batch — and below it "nothing is retained that
+// could isolate one Recipient from another" (CONTEXT.md).
+//
+// It is the coarser of the two questions about identity, and answers three that
+// would otherwise be asked separately and could drift apart: whether the mint
+// draws a per-Delivery identity, whether the resulting token may be shared across
+// the Batch, and whether the Tracker keeps the identity the token claims. All
+// three turn on the same line, because a token that can isolate a Recipient is by
+// construction not the same token for every Recipient.
+//
+// ModeUnspecified isolates and an unreadable Mode does not, for the reasons given
+// on IdentifiesRecipient — this is the same rank comparison one rung lower.
+func (m Mode) IsolatesRecipient() bool {
+	if !m.states() {
+		return true
+	}
+	_, rank := m.collection()
+	return rank >= modeRanks[ModePseudonymous]
 }
 
 // Policy is a pair of Modes, one governing opens and one governing links,

--- a/internal/tracking/tracking.go
+++ b/internal/tracking/tracking.go
@@ -96,11 +96,7 @@ func (m Mode) collection() (Mode, int) {
 // permission to attribute would be the one direction that cannot be undone (see
 // Mode.collection).
 func (m Mode) IdentifiesRecipient() bool {
-	if !m.states() {
-		return true
-	}
-	_, rank := m.collection()
-	return rank >= modeRanks[ModeIdentified]
+	return m.reaches(ModeIdentified)
 }
 
 // IsolatesRecipient reports whether what is retained about an engagement governed
@@ -119,11 +115,19 @@ func (m Mode) IdentifiesRecipient() bool {
 // ModeUnspecified isolates and an unreadable Mode does not, for the reasons given
 // on IdentifiesRecipient — this is the same rank comparison one rung lower.
 func (m Mode) IsolatesRecipient() bool {
+	return m.reaches(ModePseudonymous)
+}
+
+// reaches reports whether m collects at least as much as rung. It is how every
+// question about the scale is answered, so that the two predicates above cannot
+// drift into disagreeing about what silence or an unreadable value mean: both
+// read the one scale, at two different rungs.
+func (m Mode) reaches(rung Mode) bool {
 	if !m.states() {
 		return true
 	}
 	_, rank := m.collection()
-	return rank >= modeRanks[ModePseudonymous]
+	return rank >= modeRanks[rung]
 }
 
 // Policy is a pair of Modes, one governing opens and one governing links,

--- a/internal/tracking/tracking_test.go
+++ b/internal/tracking/tracking_test.go
@@ -188,34 +188,52 @@ func TestPolicyNormalized(t *testing.T) {
 	}
 }
 
-// TestModeIdentifiesRecipient pins where on the scale attribution begins, which
-// is the line the aggregate-statistics carve-out from the consent requirement
-// follows: an event governed by a Mode below Identified may not name anybody.
-func TestModeIdentifiesRecipient(t *testing.T) {
+// TestWhereTheScaleDrawsItsIdentityLines pins the two rungs the rest of the
+// codebase reads the scale at, in one table because they are only meaningful
+// against each other.
+//
+// IdentifiesRecipient is where attribution begins, the line the aggregate-
+// statistics carve-out from the consent requirement follows: below Identified an
+// event may not name anybody. IsolatesRecipient is one rung lower, where an event
+// stops being indistinguishable from every other event of its Batch — below
+// Anonymous "nothing is retained that could isolate one Recipient from another"
+// (CONTEXT.md). Pseudonymous is the whole width of the gap: the rung that isolates
+// without naming.
+//
+// Reading them side by side is what makes the gap visible, and the invariant
+// asserted at the end — identifying implies isolating — is what keeps the mint
+// from ever drawing a Batch-shared token for a claim that names somebody.
+func TestWhereTheScaleDrawsItsIdentityLines(t *testing.T) {
 	cases := []struct {
-		name string
-		mode tracking.Mode
-		want bool
+		name       string
+		mode       tracking.Mode
+		identifies bool
+		isolates   bool
 	}{
-		{name: "Off", mode: tracking.ModeOff, want: false},
-		{name: "Anonymous", mode: tracking.ModeAnonymous, want: false},
-		{name: "Pseudonymous", mode: tracking.ModePseudonymous, want: false},
-		{name: "Identified", mode: tracking.ModeIdentified, want: true},
-		{name: "Full", mode: tracking.ModeFull, want: true},
+		{name: "Off", mode: tracking.ModeOff, identifies: false, isolates: false},
+		{name: "Anonymous", mode: tracking.ModeAnonymous, identifies: false, isolates: false},
+		{name: "Pseudonymous", mode: tracking.ModePseudonymous, identifies: false, isolates: true},
+		{name: "Identified", mode: tracking.ModeIdentified, identifies: true, isolates: true},
+		{name: "Full", mode: tracking.ModeFull, identifies: true, isolates: true},
 		// A Mode that states nothing imposes no restriction of its own, so it
-		// leaves attribution exactly as it found it — the case is a token
+		// leaves both questions exactly as it found them — the case is a token
 		// minted before the Mode became a claim.
-		{name: "Unspecified states nothing", mode: tracking.ModeUnspecified, want: true},
+		{name: "Unspecified states nothing", mode: tracking.ModeUnspecified, identifies: true, isolates: true},
 		// A Mode that states something unreadable is a different matter: it can
 		// only come from a newer build, whose Mode may be more restrictive than
 		// Identified, so it is read as the floor of the scale rather than as
 		// permission to attribute.
-		{name: "Unknown value", mode: tracking.Mode("shadow"), want: false},
+		{name: "Unknown value", mode: tracking.Mode("shadow"), identifies: false, isolates: false},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.want, tc.mode.IdentifiesRecipient())
+			assert.Equal(t, tc.identifies, tc.mode.IdentifiesRecipient())
+			assert.Equal(t, tc.isolates, tc.mode.IsolatesRecipient())
+
+			if tc.identifies {
+				assert.True(t, tc.isolates, "naming a Recipient is strictly more than telling them apart")
+			}
 		})
 	}
 }

--- a/internal/trackingpb/trackingpb.go
+++ b/internal/trackingpb/trackingpb.go
@@ -1,7 +1,7 @@
 // Package trackingpb translates Tracking Policies between the wire enums and
 // the internal/tracking domain types. It is the only place that knows both, so
 // that internal/tracking stays free of any protobuf dependency and every API
-// boundary that accepts a Policy rejects the same values.
+// boundary that accepts a Policy refuses the same wire values.
 package trackingpb
 
 import (
@@ -12,15 +12,9 @@ import (
 	pb "github.com/kannon-email/kannon/proto/kannon/tracking/types"
 )
 
-var (
-	// ErrUnknownMode is returned for a wire value this build does not know,
-	// which normally means a client built against a newer schema.
-	ErrUnknownMode = errors.New("unknown tracking mode")
-	// ErrUnsupportedMode is returned for a Mode that exists on the scale but
-	// is not implemented, so that selecting it fails loudly instead of being
-	// silently treated as something else.
-	ErrUnsupportedMode = errors.New("unsupported tracking mode")
-)
+// ErrUnknownMode is returned for a wire value this build does not know, which
+// normally means a client built against a newer schema.
+var ErrUnknownMode = errors.New("unknown tracking mode")
 
 // wireModes maps every wire value this build knows to its domain Mode.
 var wireModes = map[pb.TrackingMode]tracking.Mode{
@@ -33,8 +27,9 @@ var wireModes = map[pb.TrackingMode]tracking.Mode{
 }
 
 // ToPolicy translates a Policy stated on the wire into the domain type. A nil
-// message states nothing. Pseudonymous is rejected with ErrUnsupportedMode
-// because it is reserved and not implemented.
+// message states nothing, and so does an unspecified axis. A wire value this
+// build does not know is refused with ErrUnknownMode, naming the axis it was
+// stated on.
 func ToPolicy(p *pb.TrackingPolicy) (tracking.Policy, error) {
 	if p == nil {
 		return tracking.Policy{}, nil
@@ -84,24 +79,21 @@ func FromMode(m tracking.Mode) pb.TrackingMode {
 // Unlike a Mode a client states, this one was written by Kannon itself, so it is
 // read leniently rather than refused: a value this build does not know reads as a
 // Mode that states nothing, which is the safe reading for a consumer because an
-// unstated Mode can only ever restrict. Pseudonymous is likewise read rather than
-// rejected — a consumer's job is to handle what arrived, not to relitigate whether
-// it should have.
+// unstated Mode can only ever restrict.
 func ToMode(m pb.TrackingMode) tracking.Mode {
 	return wireModes[m]
 }
 
 // toStatedMode reads a Mode a client stated, and so is strict where ToMode is
-// lenient: a value this build does not know is a client built against a newer
-// schema, and Pseudonymous is reserved but not implemented. Either is refused at
-// the API boundary rather than silently treated as something else.
+// lenient: a value this build does not know comes from a client built against a
+// newer schema, and is refused at the API boundary rather than silently treated
+// as something else. A client that asks for a Mode Kannon cannot honour must be
+// told so, since guessing on its behalf would decide how much to retain about
+// somebody without being asked.
 func toStatedMode(m pb.TrackingMode) (tracking.Mode, error) {
 	mode, ok := wireModes[m]
 	if !ok {
 		return tracking.ModeUnspecified, fmt.Errorf("%w: %d", ErrUnknownMode, m)
-	}
-	if mode == tracking.ModePseudonymous {
-		return tracking.ModeUnspecified, fmt.Errorf("%w: %s", ErrUnsupportedMode, mode)
 	}
 	return mode, nil
 }

--- a/internal/trackingpb/trackingpb_test.go
+++ b/internal/trackingpb/trackingpb_test.go
@@ -1,0 +1,90 @@
+package trackingpb_test
+
+import (
+	"testing"
+
+	"github.com/kannon-email/kannon/internal/tracking"
+	"github.com/kannon-email/kannon/internal/trackingpb"
+	pb "github.com/kannon-email/kannon/proto/kannon/tracking/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// wireFromANewerSchema is an enum value no build of Kannon defines. Proto3 enums
+// are open, so a client built against a later schema can put one on the wire and
+// this build has to decide what to do with it — which is the only strictness
+// left in the translation once every Mode on the scale is honoured (#424).
+const wireFromANewerSchema = pb.TrackingMode(9999)
+
+// TestToPolicyReadsEveryModeOnTheScale pins that a Policy a client states is
+// translated rather than filtered: every rung is a Mode an operator may ask for,
+// including Pseudonymous, which was refused while it was reserved (ADR 0006).
+func TestToPolicyReadsEveryModeOnTheScale(t *testing.T) {
+	cases := []struct {
+		name string
+		wire pb.TrackingMode
+		want tracking.Mode
+	}{
+		{"Unspecified", pb.TrackingMode_TRACKING_MODE_UNSPECIFIED, tracking.ModeUnspecified},
+		{"Off", pb.TrackingMode_TRACKING_MODE_OFF, tracking.ModeOff},
+		{"Anonymous", pb.TrackingMode_TRACKING_MODE_ANONYMOUS, tracking.ModeAnonymous},
+		{"Pseudonymous", pb.TrackingMode_TRACKING_MODE_PSEUDONYMOUS, tracking.ModePseudonymous},
+		{"Identified", pb.TrackingMode_TRACKING_MODE_IDENTIFIED, tracking.ModeIdentified},
+		{"Full", pb.TrackingMode_TRACKING_MODE_FULL, tracking.ModeFull},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := trackingpb.ToPolicy(&pb.TrackingPolicy{Opens: tc.wire, Links: tc.wire})
+			require.NoError(t, err)
+			assert.Equal(t, tracking.Policy{Opens: tc.want, Links: tc.want}, got)
+
+			// The two directions are one mapping stated once, so a Mode that
+			// survives the round trip cannot drift between the APIs that read a
+			// Policy and the ones that report it back.
+			assert.Equal(t, tc.wire, trackingpb.FromMode(tc.want))
+		})
+	}
+}
+
+// TestToPolicyRefusesAModeFromANewerSchema covers the one value this build will
+// not read: guessing what it meant would decide how much to retain about
+// somebody without being asked, so the boundary refuses it and names the axis it
+// arrived on.
+func TestToPolicyRefusesAModeFromANewerSchema(t *testing.T) {
+	t.Run("Opens", func(t *testing.T) {
+		_, err := trackingpb.ToPolicy(&pb.TrackingPolicy{
+			Opens: wireFromANewerSchema,
+			Links: pb.TrackingMode_TRACKING_MODE_OFF,
+		})
+		require.ErrorIs(t, err, trackingpb.ErrUnknownMode)
+		assert.Contains(t, err.Error(), "opens")
+	})
+
+	t.Run("Links", func(t *testing.T) {
+		_, err := trackingpb.ToPolicy(&pb.TrackingPolicy{
+			Opens: pb.TrackingMode_TRACKING_MODE_OFF,
+			Links: wireFromANewerSchema,
+		})
+		require.ErrorIs(t, err, trackingpb.ErrUnknownMode)
+		assert.Contains(t, err.Error(), "links")
+	})
+}
+
+// TestToPolicyOfNilStatesNothing pins that an omitted Policy is silence, not a
+// Policy of Off: the difference decides whether the level above is deferred to
+// or overridden (ADR 0003).
+func TestToPolicyOfNilStatesNothing(t *testing.T) {
+	got, err := trackingpb.ToPolicy(nil)
+	require.NoError(t, err)
+	assert.Equal(t, tracking.Policy{}, got)
+}
+
+// TestToModeIsLenient pins the asymmetry with the stated side: a single Mode
+// read here was written by Kannon itself, and a consumer that refused it would
+// fail on data it cannot restate. An unreadable value reads as a Mode that
+// states nothing, which can only ever restrict.
+func TestToModeIsLenient(t *testing.T) {
+	assert.Equal(t, tracking.ModeUnspecified, trackingpb.ToMode(wireFromANewerSchema))
+	assert.Equal(t, tracking.ModePseudonymous, trackingpb.ToMode(pb.TrackingMode_TRACKING_MODE_PSEUDONYMOUS))
+}

--- a/pkg/api/adminapi/adminapi.go
+++ b/pkg/api/adminapi/adminapi.go
@@ -54,19 +54,17 @@ func (a *adminAPIConnectAdapter) SetTrackingPolicy(ctx context.Context, req *con
 }
 
 // trackingPolicyError maps the ways a Tracking Policy can be refused onto
-// Connect codes, so that a caller can tell a policy decision from a bug: a
-// reserved Mode is unimplemented, a Mode this build does not know is a bad
-// argument, and an unknown Domain is not found.
+// Connect codes, so that a caller can tell a policy decision from a bug: a Mode
+// this build does not know is a bad argument, and an unknown Domain is not
+// found.
 //
-// The Mailer API answers the same two `trackingpb` sentinels with the same two
-// codes, in `sendTrackingPolicyError` — the pair is deliberately kept in step so
-// that one bad Mode does not mean two different things depending on which API
-// was asked. Whatever else can go wrong differs: setting a Policy on a Domain
-// can fail to find the Domain, and taking one in on a send cannot.
+// The Mailer API answers the `trackingpb` sentinel with the same code, in
+// `sendTrackingPolicyError` — the pair is deliberately kept in step so that one
+// bad Mode does not mean two different things depending on which API was asked.
+// Whatever else can go wrong differs: setting a Policy on a Domain can fail to
+// find the Domain, and taking one in on a send cannot.
 func trackingPolicyError(err error) *connect.Error {
 	switch {
-	case errors.Is(err, trackingpb.ErrUnsupportedMode):
-		return connect.NewError(connect.CodeUnimplemented, err)
 	case errors.Is(err, trackingpb.ErrUnknownMode):
 		return connect.NewError(connect.CodeInvalidArgument, err)
 	case errors.Is(err, domains.ErrDomainNotFound):

--- a/pkg/api/adminapi/adminapi_test.go
+++ b/pkg/api/adminapi/adminapi_test.go
@@ -89,39 +89,66 @@ func TestTrackingPolicy(t *testing.T) {
 		assert.Equal(t, trackingtypes.TrackingMode_TRACKING_MODE_IDENTIFIED, domain.Tracking.GetLinks())
 	})
 
+	// Every rung of the scale is a Policy an operator may set, Pseudonymous
+	// included: it was refused while it was reserved, and since #424 (ADR 0006)
+	// it is stored and read back like any other Mode.
 	t.Run("A policy I set is readable back", func(t *testing.T) {
-		domain := createTestDomain(t)
-
-		res, err := testservice.SetTrackingPolicy(t.Context(), connect.NewRequest(&pb.SetTrackingPolicyReq{
-			Domain: domain.Domain,
-			Tracking: &trackingtypes.TrackingPolicy{
-				Opens: trackingtypes.TrackingMode_TRACKING_MODE_OFF,
-				Links: trackingtypes.TrackingMode_TRACKING_MODE_ANONYMOUS,
+		cases := []struct {
+			name  string
+			opens trackingtypes.TrackingMode
+			links trackingtypes.TrackingMode
+		}{
+			{
+				name:  "Off and anonymous",
+				opens: trackingtypes.TrackingMode_TRACKING_MODE_OFF,
+				links: trackingtypes.TrackingMode_TRACKING_MODE_ANONYMOUS,
 			},
-		}))
-		assert.Nil(t, err)
-		assert.Equal(t, trackingtypes.TrackingMode_TRACKING_MODE_OFF, res.Msg.Domain.Tracking.GetOpens())
-		assert.Equal(t, trackingtypes.TrackingMode_TRACKING_MODE_ANONYMOUS, res.Msg.Domain.Tracking.GetLinks())
+			{
+				name:  "Pseudonymous and off",
+				opens: trackingtypes.TrackingMode_TRACKING_MODE_PSEUDONYMOUS,
+				links: trackingtypes.TrackingMode_TRACKING_MODE_OFF,
+			},
+		}
 
-		got, err := testservice.GetDomain(t.Context(), connect.NewRequest(&pb.GetDomainReq{
-			Domain: domain.Domain,
-		}))
-		assert.Nil(t, err)
-		assert.Equal(t, trackingtypes.TrackingMode_TRACKING_MODE_OFF, got.Msg.Domain.Tracking.GetOpens())
-		assert.Equal(t, trackingtypes.TrackingMode_TRACKING_MODE_ANONYMOUS, got.Msg.Domain.Tracking.GetLinks())
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				domain := createTestDomain(t)
+
+				res, err := testservice.SetTrackingPolicy(t.Context(), connect.NewRequest(&pb.SetTrackingPolicyReq{
+					Domain: domain.Domain,
+					Tracking: &trackingtypes.TrackingPolicy{
+						Opens: tc.opens,
+						Links: tc.links,
+					},
+				}))
+				assert.Nil(t, err)
+				assert.Equal(t, tc.opens, res.Msg.Domain.Tracking.GetOpens())
+				assert.Equal(t, tc.links, res.Msg.Domain.Tracking.GetLinks())
+
+				got, err := testservice.GetDomain(t.Context(), connect.NewRequest(&pb.GetDomainReq{
+					Domain: domain.Domain,
+				}))
+				assert.Nil(t, err)
+				assert.Equal(t, tc.opens, got.Msg.Domain.Tracking.GetOpens())
+				assert.Equal(t, tc.links, got.Msg.Domain.Tracking.GetLinks())
+			})
+		}
 	})
 
-	t.Run("Pseudonymous is rejected as unsupported", func(t *testing.T) {
+	// A wire value this build cannot read comes from a client built against a
+	// newer schema. It is the one Mode the Admin API still refuses, because
+	// guessing what it meant would set a ceiling nobody asked for.
+	t.Run("A Mode this build does not know is an invalid argument", func(t *testing.T) {
 		domain := createTestDomain(t)
 
 		_, err := testservice.SetTrackingPolicy(t.Context(), connect.NewRequest(&pb.SetTrackingPolicyReq{
 			Domain: domain.Domain,
 			Tracking: &trackingtypes.TrackingPolicy{
-				Opens: trackingtypes.TrackingMode_TRACKING_MODE_PSEUDONYMOUS,
+				Opens: trackingtypes.TrackingMode(9999),
 				Links: trackingtypes.TrackingMode_TRACKING_MODE_OFF,
 			},
 		}))
-		assert.Equal(t, connect.CodeUnimplemented, connect.CodeOf(err))
+		assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
 
 		// The refused call must leave the domain as it was.
 		got, err := testservice.GetDomain(t.Context(), connect.NewRequest(&pb.GetDomainReq{

--- a/pkg/api/mailapi/mailer.go
+++ b/pkg/api/mailapi/mailer.go
@@ -188,9 +188,9 @@ const (
 	// more than its Domain allows (ADR 0003).
 	reasonTrackingAboveCeiling rejectionReason = "tracking_above_ceiling"
 	// reasonUnsupportedTrackingMode is a Recipient stating a Tracking Mode this
-	// build will not act on: the reserved `pseudonymous`, or a wire value from a
-	// newer schema. Both leave the caller the same work — restate the Policy —
-	// so they share one reason.
+	// build will not act on — in practice a wire value from a newer schema, since
+	// every Mode this build knows is one it honours. The work it leaves the
+	// caller is to restate the Policy in terms this build understands.
 	reasonUnsupportedTrackingMode rejectionReason = "unsupported_tracking_mode"
 	// reasonUnsubscribeURLUnresolved is a Recipient whose fields leave a
 	// placeholder in the Batch's one-click unsubscribe URL unresolved. Refusing
@@ -448,10 +448,10 @@ func assertHeaderSafe(field, v string) error {
 }
 
 // sendTrackingPolicyError maps a failure to translate a Batch's wire Tracking
-// Policy onto a Connect code: a reserved Mode (pseudonymous) is unimplemented,
-// and a Mode this build does not know is a bad argument.
+// Policy onto a Connect code: a Mode this build does not know is a bad
+// argument.
 //
-// It answers those two `trackingpb` sentinels exactly as
+// It answers that `trackingpb` sentinel exactly as
 // pkg/api/adminapi.trackingPolicyError does, deliberately, so that one bad Mode
 // does not mean two different things depending on which API was asked; the two
 // are a pair and should change together. It is named apart from that one
@@ -459,8 +459,6 @@ func assertHeaderSafe(field, v string) error {
 // the caller's argument, never a missing Domain.
 func sendTrackingPolicyError(err error) error {
 	switch {
-	case errors.Is(err, trackingpb.ErrUnsupportedMode):
-		return connect.NewError(connect.CodeUnimplemented, err)
 	case errors.Is(err, trackingpb.ErrUnknownMode):
 		return connect.NewError(connect.CodeInvalidArgument, err)
 	default:

--- a/pkg/api/mailapi/mailer_test.go
+++ b/pkg/api/mailapi/mailer_test.go
@@ -323,7 +323,7 @@ func TestSendMailFreezesResolvedTrackingPolicy(t *testing.T) {
 // Batch row as provenance; a Batch stating more than the ceiling allows fails
 // the call outright rather than being silently clamped, naming the offending
 // axis (ADR 0003); the two axes are evaluated independently; and a Batch
-// stating the reserved `pseudonymous` Mode is rejected as unimplemented.
+// stating a Mode this build cannot read fails the call as a bad argument.
 func TestSendMailBatchTrackingPolicy(t *testing.T) {
 	t.Run("AtOrBelowCeilingIsAcceptedAndApplied", func(t *testing.T) {
 		cases := []struct {
@@ -346,6 +346,17 @@ func TestSendMailBatchTrackingPolicy(t *testing.T) {
 					Links: trackingtypes.TrackingMode_TRACKING_MODE_ANONYMOUS,
 				},
 				want: tracking.Policy{Opens: tracking.ModeOff, Links: tracking.ModeAnonymous},
+			},
+			{
+				// Pseudonymous sits between Anonymous and Identified (#424,
+				// ADR 0006), so it is below the default ceiling and travels the
+				// cascade like every other rung — no longer refused as reserved.
+				name: "Pseudonymous",
+				batch: &trackingtypes.TrackingPolicy{
+					Opens: trackingtypes.TrackingMode_TRACKING_MODE_PSEUDONYMOUS,
+					Links: trackingtypes.TrackingMode_TRACKING_MODE_PSEUDONYMOUS,
+				},
+				want: tracking.Policy{Opens: tracking.ModePseudonymous, Links: tracking.ModePseudonymous},
 			},
 		}
 
@@ -467,7 +478,10 @@ func TestSendMailBatchTrackingPolicy(t *testing.T) {
 		assert.NotContains(t, err.Error(), "opens", "only the violating axis should be named")
 	})
 
-	t.Run("PseudonymousIsRejectedAsUnimplemented", func(t *testing.T) {
+	// A wire value this build cannot read is a client built against a newer
+	// schema. It is one instruction about the whole send, like a ceiling
+	// violation, so it fails the call rather than being read as something else.
+	t.Run("AModeFromANewerSchemaFailsTheCall", func(t *testing.T) {
 		defer cleanDB(t)
 
 		d := createTestDomain(t)
@@ -482,14 +496,19 @@ func TestSendMailBatchTrackingPolicy(t *testing.T) {
 			Html:          "<p>Hello</p>",
 			ScheduledTime: timestamppb.Now(),
 			Tracking: &trackingtypes.TrackingPolicy{
-				Opens: trackingtypes.TrackingMode_TRACKING_MODE_PSEUDONYMOUS,
+				Opens: trackingtypes.TrackingMode(9999),
 			},
 		})
 		authRequest(req, d)
 
 		_, err := ts.SendHTML(t.Context(), req)
 		assert.NotNil(t, err)
-		assert.Equal(t, connect.CodeUnimplemented, connect.CodeOf(err))
+		assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+
+		var msgCount int
+		err = db.QueryRow(t.Context(), "SELECT count(*) FROM messages WHERE domain = $1", d.Domain.Domain).Scan(&msgCount)
+		assert.Nil(t, err)
+		assert.Equal(t, 0, msgCount, "a Batch whose Policy could not be read must not be created")
 	})
 
 	t.Run("OmittingTheFieldBehavesExactlyAsBefore", func(t *testing.T) {
@@ -694,6 +713,14 @@ func TestSendMailRecipientTrackingPolicy(t *testing.T) {
 				domain:    wirePolicy(wireIdentified, wireOff),
 				recipient: wirePolicy(wireAnonymous, wireFull),
 			},
+			{
+				// Pseudonymous is honoured now (#424), but it is still a rung of
+				// the same scale: asked for above a Domain that allows only
+				// aggregate counting, it is refused like any other widening.
+				name:      "PseudonymousAboveAnAnonymousCeiling",
+				domain:    wirePolicy(wireAnonymous, wireAnonymous),
+				recipient: wirePolicy(wirePseudonymous, wireUnspecified),
+			},
 		}
 
 		for _, tc := range cases {
@@ -718,20 +745,42 @@ func TestSendMailRecipientTrackingPolicy(t *testing.T) {
 		}
 	})
 
-	// The reserved Mode is the one place the Recipient level and the Batch level
-	// differ in kind: a Batch stating it fails the whole call, a Recipient
-	// stating it is Rejected on its own.
-	t.Run("PseudonymousRejectsOnlyThatRecipient", func(t *testing.T) {
+	// Pseudonymous is a Mode a Recipient may state like any other since #424
+	// (ADR 0006): under the identified/identified default it is a narrowing, so
+	// it is accepted and frozen on that Recipient's Delivery alone — the axis it
+	// was not stated on, and the Recipients that stated nothing, are untouched.
+	t.Run("PseudonymousIsAcceptedAndFrozenOnThatRecipient", func(t *testing.T) {
+		defer cleanDB(t)
+
+		d := createTestDomain(t)
+
+		res := requireSend(t, d, nil,
+			&types.Recipient{Email: "unstated@email.com"},
+			&types.Recipient{Email: "pseudonymous@email.com", Tracking: wirePolicy(wirePseudonymous, wireUnspecified)},
+		)
+
+		assert.Empty(t, rejections(t, res))
+		assert.EqualValues(t, 2, res.AcceptedCount)
+		assert.Equal(t, map[string]tracking.Policy{
+			"unstated@email.com":     {Opens: tracking.ModeIdentified, Links: tracking.ModeIdentified},
+			"pseudonymous@email.com": {Opens: tracking.ModePseudonymous, Links: tracking.ModeIdentified},
+		}, frozenPolicies(t, res.MessageId))
+	})
+
+	// A Mode this build cannot read is the one place the Recipient level and the
+	// Batch level differ in kind: a Batch stating it fails the whole call, a
+	// Recipient stating it is Rejected on its own.
+	t.Run("AModeFromANewerSchemaRejectsOnlyThatRecipient", func(t *testing.T) {
 		defer cleanDB(t)
 
 		d := createTestDomain(t)
 
 		res := requireSend(t, d, nil,
 			&types.Recipient{Email: "fine@email.com"},
-			&types.Recipient{Email: "reserved@email.com", Tracking: wirePolicy(wirePseudonymous, wireUnspecified)},
+			&types.Recipient{Email: "unreadable@email.com", Tracking: wirePolicy(trackingtypes.TrackingMode(9999), wireUnspecified)},
 		)
 
-		assert.Equal(t, map[string]string{"reserved@email.com": "unsupported_tracking_mode"}, rejections(t, res))
+		assert.Equal(t, map[string]string{"unreadable@email.com": "unsupported_tracking_mode"}, rejections(t, res))
 		assert.EqualValues(t, 1, res.AcceptedCount)
 		assert.Equal(t, []string{"fine@email.com"}, poolEmails(t, res.MessageId))
 	})

--- a/pkg/stats/per_recipient_test.go
+++ b/pkg/stats/per_recipient_test.go
@@ -185,6 +185,15 @@ func TestPseudonymousEventIsRecordedUnderItsPseudonym(t *testing.T) {
 
 	assert.Equal(t, []string{pseudonym}, perRecipientIdentities(t, domain),
 		"a pseudonymous event must be recorded, and under the pseudonym it arrived with")
+
+	// The aggregate path reads only the Domain, the timestamp and the type, so it
+	// counts every Mode alike. Pinning it here is what makes "the Domain's
+	// counters work under pseudonymous as they do under every Mode" a fact rather
+	// than an inference from the code.
+	counted := engagementEvent(t, domain, pseudonym, tracking.ModePseudonymous)
+	require.NoError(t, h.handleAggregatedStatsMsg(t.Context(), counted))
+	assert.Equal(t, int64(1), aggregatedCount(t, domain, stats.TypeOpened),
+		"a pseudonymous event must move the Domain's aggregate counters")
 }
 
 // TestTwoPseudonymousEventsOfABatchStayApart is the other half of the rung, from

--- a/pkg/stats/per_recipient_test.go
+++ b/pkg/stats/per_recipient_test.go
@@ -44,7 +44,9 @@ func (m *fakeMsg) Nak() error   { m.naked++; return nil }
 func (m *fakeMsg) NakWithDelay(time.Duration) error { m.naked++; return nil }
 
 // engagementEvent is one Opened event as the Tracker publishes it, under the given
-// Mode and naming the given Recipient — or nobody, when the caller passes "".
+// Mode and carrying the given identity claim: the Recipient's address, a pseudonym,
+// the Anonymous sentinel of the Domain — or nothing at all, when the caller passes
+// "", which is what a token minted before the claim was always email-shaped carries.
 func engagementEvent(t *testing.T, domain, email string, mode tracking.Mode) *fakeMsg {
 	t.Helper()
 
@@ -80,6 +82,26 @@ func perRecipientRows(t *testing.T, domain string) int64 {
 	return total
 }
 
+// perRecipientIdentities returns the identity every row the per-recipient consumer
+// left behind for a Domain was written under — the addresses an operator reading
+// the stats table would find in it.
+func perRecipientIdentities(t *testing.T, domain string) []string {
+	t.Helper()
+
+	repo := sq.NewStatsRepository(db)
+	rows, err := repo.Query(t.Context(), domain, stats.TimeRange{
+		Start: time.Now().UTC().Add(-time.Hour),
+		Stop:  time.Now().UTC().Add(time.Hour),
+	}, stats.Pagination{Limit: 100, Offset: 0})
+	require.NoError(t, err)
+
+	identities := make([]string, 0, len(rows))
+	for _, row := range rows {
+		identities = append(identities, row.Email)
+	}
+	return identities
+}
+
 // aggregatedCount reports a Domain's aggregated counter for one stat type,
 // summed over the hourly buckets around now.
 func aggregatedCount(t *testing.T, domain string, statType stats.Type) int64 {
@@ -105,21 +127,85 @@ func aggregatedCount(t *testing.T, domain string, statType stats.Type) int64 {
 // made observable: a Domain on Anonymous keeps its open rate and retains no row
 // that could isolate one Recipient from another. Both consumers see the same
 // message, as they do in production, so the two halves are asserted together.
+//
+// It is run over both identity claims an Anonymous event can arrive with — the
+// Domain's sentinel, which is what a token minted by this build carries (ADR 0006),
+// and nothing at all, which is what a token minted before the claim was always
+// email-shaped carries and will keep carrying for one token lifetime. Neither may
+// become a row.
 func TestAnonymousEventIsCountedButNotRecorded(t *testing.T) {
+	cases := []struct {
+		name     string
+		identity func(domain string) string
+	}{
+		{name: "SentinelIdentity", identity: tracking.AnonymousIdentity},
+		{name: "LegacyTokenWithNoIdentity", identity: func(string) string { return "" }},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			domain := tests.FakeDomain(t)
+			h := newTestHandler()
+
+			msg := engagementEvent(t, domain, tc.identity(domain), tracking.ModeAnonymous)
+			require.NoError(t, h.handleStatsMsg(t.Context(), msg))
+			assert.Equal(t, 1, msg.acked, "an anonymous event is finished with, not left to come back")
+
+			assert.Zero(t, perRecipientRows(t, domain),
+				"an anonymous event must leave no per-recipient row")
+
+			counted := engagementEvent(t, domain, tc.identity(domain), tracking.ModeAnonymous)
+			require.NoError(t, h.handleAggregatedStatsMsg(t.Context(), counted))
+			assert.Equal(t, int64(1), aggregatedCount(t, domain, stats.TypeOpened),
+				"an anonymous event must still be counted in aggregate")
+		})
+	}
+}
+
+// TestPseudonymousEventIsRecordedUnderItsPseudonym is what separates the rung from
+// Anonymous at the write path. A Pseudonymous event names no Recipient, but it must
+// leave a per-Delivery row all the same: being linkable to the Batch's other events
+// is the whole content of the rung, and the pseudonym is the only thing that makes
+// them so.
+//
+// It takes the existing per-recipient path with no special case, which is what the
+// identity claim being email-shaped whichever Mode produced it buys (ADR 0006): the
+// row, the schema and counting distinct addresses are untouched by the Mode.
+func TestPseudonymousEventIsRecordedUnderItsPseudonym(t *testing.T) {
 	domain := tests.FakeDomain(t)
 	h := newTestHandler()
 
-	msg := engagementEvent(t, domain, "", tracking.ModeAnonymous)
+	pseudonym, err := tracking.NewPseudonym(domain)
+	require.NoError(t, err)
+
+	msg := engagementEvent(t, domain, pseudonym, tracking.ModePseudonymous)
 	require.NoError(t, h.handleStatsMsg(t.Context(), msg))
-	assert.Equal(t, 1, msg.acked, "an anonymous event is finished with, not left to come back")
+	assert.Equal(t, 1, msg.acked)
+	assert.Zero(t, msg.termed, "a pseudonym is an identity, not a missing one")
 
-	assert.Zero(t, perRecipientRows(t, domain),
-		"an anonymous event must leave no per-recipient row")
+	assert.Equal(t, []string{pseudonym}, perRecipientIdentities(t, domain),
+		"a pseudonymous event must be recorded, and under the pseudonym it arrived with")
+}
 
-	counted := engagementEvent(t, domain, "", tracking.ModeAnonymous)
-	require.NoError(t, h.handleAggregatedStatsMsg(t.Context(), counted))
-	assert.Equal(t, int64(1), aggregatedCount(t, domain, stats.TypeOpened),
-		"an anonymous event must still be counted in aggregate")
+// TestTwoPseudonymousEventsOfABatchStayApart is the other half of the rung, from
+// the operator's side: two Deliveries of one Batch carry two pseudonyms, so their
+// events are as distinguishable as identified ones would be — while naming nobody.
+func TestTwoPseudonymousEventsOfABatchStayApart(t *testing.T) {
+	domain := tests.FakeDomain(t)
+	h := newTestHandler()
+
+	first, err := tracking.NewPseudonym(domain)
+	require.NoError(t, err)
+	second, err := tracking.NewPseudonym(domain)
+	require.NoError(t, err)
+
+	for _, pseudonym := range []string{first, second} {
+		msg := engagementEvent(t, domain, pseudonym, tracking.ModePseudonymous)
+		require.NoError(t, h.handleStatsMsg(t.Context(), msg))
+	}
+
+	assert.ElementsMatch(t, []string{first, second}, perRecipientIdentities(t, domain),
+		"the two Deliveries must be told apart by their pseudonyms and nothing else")
 }
 
 // TestIdentifiedEventIsRecorded is the control: the skip is about Anonymous and
@@ -159,6 +245,30 @@ func TestNonAnonymousEventWithoutIdentityIsLoggedAsAnError(t *testing.T) {
 	out := logged()
 	assert.Contains(t, out, `"level":"ERROR"`, "the violation must be logged as an error, got %q", out)
 	assert.Contains(t, out, domain, "the log must say which Domain, got %q", out)
+}
+
+// TestNonAnonymousEventNamingTheAnonymousSentinelIsLoggedAsAnError is the same
+// invariant against the shape the identity claim now has. Since the Anonymous
+// sentinel is an ordinary address to the `stats` schema, an event carrying it under
+// a Mode that is not Anonymous would otherwise be written down as though somebody
+// were called `anonymous@track.<domain>` — a Recipient that does not exist, in a
+// table whose distinct addresses are supposed to count Recipients. Naming nobody is
+// therefore a question about the address, not merely about emptiness.
+func TestNonAnonymousEventNamingTheAnonymousSentinelIsLoggedAsAnError(t *testing.T) {
+	domain := tests.FakeDomain(t)
+	h := newTestHandler()
+
+	logged := captureLogs(t)
+
+	msg := engagementEvent(t, domain, tracking.AnonymousIdentity(domain), tracking.ModeIdentified)
+	require.NoError(t, h.handleStatsMsg(t.Context(), msg))
+
+	assert.Zero(t, msg.naked, "a permanent fault must not be sent round again")
+	assert.Equal(t, 1, msg.termed, "the message must be settled, not left in flight")
+	assert.Zero(t, perRecipientRows(t, domain), "the sentinel must never be recorded as a Recipient")
+
+	out := logged()
+	assert.Contains(t, out, `"level":"ERROR"`, "the violation must be logged as an error, got %q", out)
 }
 
 // captureLogs redirects the default logger for the duration of one test and

--- a/pkg/stats/stats.go
+++ b/pkg/stats/stats.go
@@ -207,7 +207,7 @@ func (h *statsHandler) handleStatsMsg(ctx context.Context, msg jetstream.Msg) er
 		return msg.Ack()
 	}
 
-	if namesNobody(data.Email, data.Domain) {
+	if tracking.NamesNobody(data.Email, data.Domain) {
 		slog.Error("stat event carries no recipient identity and is not anonymous",
 			"type", stat.Type, "batch", data.MessageId, "domain", data.Domain, "tracking_mode", mode)
 		return msg.Term()
@@ -220,18 +220,4 @@ func (h *statsHandler) handleStatsMsg(ctx context.Context, msg jetstream.Msg) er
 	}
 
 	return msg.Ack()
-}
-
-// namesNobody reports whether a stat event's identity claim stands for no one.
-// Two shapes say that: the Anonymous sentinel of the event's own Domain, which is
-// what a token minted under Anonymous carries today (ADR 0006), and an empty
-// claim, which is what a token minted before the claim was always email-shaped
-// carries — those stay in circulation for one token lifetime and cannot be
-// dropped from the check until they expire.
-//
-// A pseudonym is *not* one of them: it names nobody outside its Batch, but within
-// one it is exactly what tells two Recipients apart, and that is what the row
-// records.
-func namesNobody(email, domain string) bool {
-	return email == "" || email == tracking.AnonymousIdentity(domain)
 }

--- a/pkg/stats/stats.go
+++ b/pkg/stats/stats.go
@@ -170,15 +170,28 @@ func (h *statsHandler) handleAggregatedStatsMsg(ctx context.Context, msg jetstre
 //
 // Under Anonymous it writes none. That Mode is counted in aggregate only —
 // nothing is retained that could isolate one Recipient from another (CONTEXT.md) —
-// and the event carries no Recipient identity to write down in the first place.
-// handleAggregatedStats is an independent subscription on the same subject and
-// counts the event regardless, so the Domain keeps its open and click rates.
+// and the identity such an event carries names nobody by construction: the
+// Anonymous sentinel of its Domain, or nothing at all on a token minted before the
+// identity claim was always email-shaped. handleAggregatedStats is an independent
+// subscription on the same subject and counts the event regardless, so the Domain
+// keeps its open and click rates.
 //
-// Every other Mode names its Recipient, and so does every event that is not an
-// engagement. One that does not is a bug upstream, and in a compliance path a loud
-// failure beats a quietly lost row: it is logged as an error rather than dropped in
-// silence. It is Termed and not Nak'd, because the fault is in the message itself —
-// redelivering it could only reproduce the hot loop #396 fixed.
+// Every other Mode names somebody, and so does every event that is not an
+// engagement. Pseudonymous names a pseudonym rather than a Recipient —
+// `<rand>@track.<domain>`, drawn per Delivery and linkable to nothing outside its
+// Batch (ADR 0006) — and it takes this same path deliberately: the identity claim
+// is email-shaped whichever Mode produced it, so the row, the schema and counting
+// distinct addresses all keep working unchanged, and the Mode on the event is what
+// says which kind of address was written.
+//
+// An event that names nobody yet is not Anonymous is a bug upstream, and in a
+// compliance path a loud failure beats a quietly lost row: it is logged as an
+// error rather than dropped in silence. Naming nobody is a question about the
+// address and not merely about emptiness — the sentinel is an ordinary address to
+// the schema, so an event carrying it under any other Mode would otherwise be
+// recorded as though somebody were called `anonymous@track.<domain>`. It is Termed
+// and not Nak'd, because the fault is in the message itself — redelivering it could
+// only reproduce the hot loop #396 fixed.
 func (h *statsHandler) handleStatsMsg(ctx context.Context, msg jetstream.Msg) error {
 	data := &types.Stats{}
 	if err := proto.Unmarshal(msg.Data(), data); err != nil {
@@ -194,7 +207,7 @@ func (h *statsHandler) handleStatsMsg(ctx context.Context, msg jetstream.Msg) er
 		return msg.Ack()
 	}
 
-	if data.Email == "" {
+	if namesNobody(data.Email, data.Domain) {
 		slog.Error("stat event carries no recipient identity and is not anonymous",
 			"type", stat.Type, "batch", data.MessageId, "domain", data.Domain, "tracking_mode", mode)
 		return msg.Term()
@@ -207,4 +220,18 @@ func (h *statsHandler) handleStatsMsg(ctx context.Context, msg jetstream.Msg) er
 	}
 
 	return msg.Ack()
+}
+
+// namesNobody reports whether a stat event's identity claim stands for no one.
+// Two shapes say that: the Anonymous sentinel of the event's own Domain, which is
+// what a token minted under Anonymous carries today (ADR 0006), and an empty
+// claim, which is what a token minted before the claim was always email-shaped
+// carries — those stay in circulation for one token lifetime and cannot be
+// dropped from the check until they expire.
+//
+// A pseudonym is *not* one of them: it names nobody outside its Batch, but within
+// one it is exactly what tells two Recipients apart, and that is what the row
+// records.
+func namesNobody(email, domain string) bool {
+	return email == "" || email == tracking.AnonymousIdentity(domain)
 }

--- a/pkg/tracker/srv.go
+++ b/pkg/tracker/srv.go
@@ -96,14 +96,14 @@ type engagement struct {
 //
 // The Mode is read from the verified claims and never from the database, so this
 // is the single place the decision is made and the request cannot widen it.
-func retained(r *http.Request, claimedEmail string, mode tracking.Mode) engagement {
+func retained(r *http.Request, claimedIdentity string, mode tracking.Mode) engagement {
 	if !mode.IsolatesRecipient() {
 		return engagement{}
 	}
 	if mode != tracking.ModeFull {
-		return engagement{email: claimedEmail}
+		return engagement{email: claimedIdentity}
 	}
-	return engagement{email: claimedEmail, ip: readUserIP(r), userAgent: r.UserAgent()}
+	return engagement{email: claimedIdentity, ip: readUserIP(r), userAgent: r.UserAgent()}
 }
 
 func readUserIP(r *http.Request) string {

--- a/pkg/tracker/srv.go
+++ b/pkg/tracker/srv.go
@@ -77,19 +77,27 @@ type engagement struct {
 // retained returns what may be kept about an engagement, given the Tracking Mode
 // signed into its token.
 //
-// A Mode that does not identify the Recipient keeps nothing at all: Anonymous is
-// counted in aggregate only, so the event names nobody. The token it arrived on
-// already carries no address (internal/statssec drops it at the mint) — dropping
-// it here as well means even a token minted by an older build cannot put an
-// address on an anonymous event.
+// A Mode that cannot isolate one Recipient of a Batch from another keeps nothing
+// at all: Off and Anonymous are counted in aggregate only, so the event names
+// nobody. The token such an engagement arrives on already names nobody — under
+// Anonymous internal/statssec mints the sentinel address, and an older build left
+// the claim empty — and dropping the claim here as well means no token, however
+// it was minted, can put an identity on an event that must carry none.
+//
+// Pseudonymous is the first rung that does isolate, and it keeps the identity its
+// token claims for exactly that reason: the claim is a pseudonym drawn per
+// Delivery (ADR 0006), and an event that dropped it would be linkable to nothing,
+// which is the whole content of the rung. It still names no Recipient, so it sits
+// below Identified on the scale even though both keep their claim.
 //
 // Above that, only Full retains the IP address and user agent (CONTEXT.md), so
-// under Identified the event names the Recipient and nothing more.
+// under Pseudonymous and Identified the event carries its identity and nothing
+// more.
 //
 // The Mode is read from the verified claims and never from the database, so this
 // is the single place the decision is made and the request cannot widen it.
 func retained(r *http.Request, claimedEmail string, mode tracking.Mode) engagement {
-	if !mode.IdentifiesRecipient() {
+	if !mode.IsolatesRecipient() {
 		return engagement{}
 	}
 	if mode != tracking.ModeFull {

--- a/pkg/tracker/tracker_test.go
+++ b/pkg/tracker/tracker_test.go
@@ -44,6 +44,12 @@ const (
 	testLandingURL = "https://example.com/landing"
 	testUserAgent  = "kannon-test-agent/1.0"
 	testIP         = "203.0.113.7"
+	// testPseudonym has the shape ADR 0006 fixes for a Pseudonymous identity: 128
+	// random bits as a lowercase hex local part, under the sending Domain's
+	// reserved namespace. It is written out rather than drawn from
+	// tracking.NewPseudonym because what is under test is what survives a token,
+	// not how a pseudonym is generated.
+	testPseudonym = "0f8b9d3c2a1e4f5b6c7d8e9f0a1b2c3d@track." + testDomain
 )
 
 func TestMain(m *testing.M) {
@@ -119,13 +125,14 @@ func engage(t *testing.T, path string) (answer, []*statstypes.Stats) {
 }
 
 // TestOpenRetainsOnlyWhatItsModeAllows is the compliance property for opens:
-// Anonymous names nobody and keeps nothing about the request, Identified
-// attributes the event to the Recipient and still keeps nothing about the
-// request, and Full additionally keeps the IP address and user agent.
+// Anonymous names nobody and keeps nothing about the request, Pseudonymous names
+// the Delivery's pseudonym and nothing about the request, Identified attributes
+// the event to the Recipient and still keeps nothing about the request, and Full
+// additionally keeps the IP address and user agent.
 func TestOpenRetainsOnlyWhatItsModeAllows(t *testing.T) {
 	for _, tc := range retentionCases() {
 		t.Run(tc.name, func(t *testing.T) {
-			token, err := ss.CreateOpenToken(t.Context(), testMessageID, testRecipient, tc.mode)
+			token, err := ss.CreateOpenToken(t.Context(), testMessageID, tc.mint, tc.mode)
 			require.NoError(t, err)
 
 			resp, published := engage(t, "/o/"+token)
@@ -151,7 +158,7 @@ func TestOpenRetainsOnlyWhatItsModeAllows(t *testing.T) {
 func TestClickRetainsOnlyWhatItsModeAllows(t *testing.T) {
 	for _, tc := range retentionCases() {
 		t.Run(tc.name, func(t *testing.T) {
-			token, err := ss.CreateLinkToken(t.Context(), testMessageID, testRecipient, testLandingURL, tc.mode)
+			token, err := ss.CreateLinkToken(t.Context(), testMessageID, tc.mint, testLandingURL, tc.mode)
 			require.NoError(t, err)
 
 			resp, published := engage(t, "/c/"+token)
@@ -174,34 +181,55 @@ func TestClickRetainsOnlyWhatItsModeAllows(t *testing.T) {
 }
 
 type retentionCase struct {
-	name          string
-	mode          tracking.Mode
+	name string
+	mode tracking.Mode
+	// mint is the identity the Builder hands the mint under this Mode: the
+	// Recipient's own address, or — under Pseudonymous — the pseudonym drawn for
+	// this Delivery, which is the one Mode whose identity the caller supplies and
+	// statssec only validates (ADR 0006).
+	mint          string
 	wantWireMode  trackingtypes.TrackingMode
 	wantEmail     string
 	wantIP        string
 	wantUserAgent string
 }
 
-// retentionCases are the three Modes under which an engagement event exists, each
+// retentionCases are the four Modes under which an engagement event exists, each
 // with everything the event is allowed to carry. The empty fields are the point:
-// Anonymous names nobody at all, and Identified names the Recipient and nothing
-// else.
+// Anonymous names nobody at all, Pseudonymous names only the pseudonym its token
+// was minted with, and Identified names the Recipient and nothing else.
 func retentionCases() []retentionCase {
 	return []retentionCase{
 		{
+			// The real address is handed to the mint and reaches the event under
+			// neither name: the mint replaces it with the Domain's sentinel, and the
+			// Tracker drops even that.
 			name:         "Anonymous",
 			mode:         tracking.ModeAnonymous,
+			mint:         testRecipient,
 			wantWireMode: trackingtypes.TrackingMode_TRACKING_MODE_ANONYMOUS,
+		},
+		{
+			// The pseudonym does survive, and it is all that survives — that is the
+			// difference between this rung and Anonymous, and the events of a Batch
+			// are linkable to each other by nothing else.
+			name:         "Pseudonymous",
+			mode:         tracking.ModePseudonymous,
+			mint:         testPseudonym,
+			wantWireMode: trackingtypes.TrackingMode_TRACKING_MODE_PSEUDONYMOUS,
+			wantEmail:    testPseudonym,
 		},
 		{
 			name:         "Identified",
 			mode:         tracking.ModeIdentified,
+			mint:         testRecipient,
 			wantWireMode: trackingtypes.TrackingMode_TRACKING_MODE_IDENTIFIED,
 			wantEmail:    testRecipient,
 		},
 		{
 			name:          "Full",
 			mode:          tracking.ModeFull,
+			mint:          testRecipient,
 			wantWireMode:  trackingtypes.TrackingMode_TRACKING_MODE_FULL,
 			wantEmail:     testRecipient,
 			wantIP:        testIP,
@@ -326,36 +354,75 @@ func encodeClaims(t *testing.T, claims map[string]any) string {
 // TestRetainedIsGatedOnMode states in one place the rule both handlers share, over
 // the whole scale rather than only the Modes a token can currently be minted with.
 //
-// The claimed email is non-empty in every case on purpose: it is what a token
-// minted by an older build would carry, and a Mode that does not identify the
-// Recipient must drop it here even so.
+// The line is Pseudonymous, not Identified: from that rung up the event keeps
+// whatever identity its token claims, because an event that dropped its pseudonym
+// would be linkable to nothing and the rung would record nothing at all. Below it
+// the claim is dropped whatever it says, which is why the Modes that keep nothing
+// are given a real address to drop: that is what a token minted by an older build
+// carries, and the Tracker must not let it through even though the mint no longer
+// produces one.
 func TestRetainedIsGatedOnMode(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/o/tok", nil)
 	req.Header.Set("User-Agent", testUserAgent)
 	req.Header.Set("X-Real-Ip", testIP)
 
 	cases := []struct {
-		name string
-		mode tracking.Mode
-		want engagement
+		name    string
+		mode    tracking.Mode
+		claimed string
+		want    engagement
 	}{
-		{name: "Off", mode: tracking.ModeOff, want: engagement{}},
-		{name: "Anonymous", mode: tracking.ModeAnonymous, want: engagement{}},
-		{name: "Pseudonymous", mode: tracking.ModePseudonymous, want: engagement{}},
-		{name: "Identified", mode: tracking.ModeIdentified, want: engagement{email: testRecipient}},
+		{name: "Off", mode: tracking.ModeOff, claimed: testRecipient, want: engagement{}},
+		{name: "Anonymous", mode: tracking.ModeAnonymous, claimed: testRecipient, want: engagement{}},
+		// The sentinel a current token carries under Anonymous is dropped on the
+		// same terms: what it stands for is already said by the Mode.
 		{
-			name: "Full",
-			mode: tracking.ModeFull,
-			want: engagement{email: testRecipient, ip: testIP, userAgent: testUserAgent},
+			name:    "AnonymousWithSentinelIdentity",
+			mode:    tracking.ModeAnonymous,
+			claimed: tracking.AnonymousIdentity(testDomain),
+			want:    engagement{},
+		},
+		{
+			name:    "Pseudonymous",
+			mode:    tracking.ModePseudonymous,
+			claimed: testPseudonym,
+			want:    engagement{email: testPseudonym},
+		},
+		// Keeping the claim cannot invent one. A token minted before the identity
+		// claim was always email-shaped left it empty under the Modes that name
+		// nobody, and such tokens keep arriving for one token lifetime after this
+		// change.
+		{
+			name:    "PseudonymousFromALegacyTokenWithNoIdentity",
+			mode:    tracking.ModePseudonymous,
+			claimed: "",
+			want:    engagement{},
+		},
+		{
+			name:    "Identified",
+			mode:    tracking.ModeIdentified,
+			claimed: testRecipient,
+			want:    engagement{email: testRecipient},
+		},
+		{
+			name:    "Full",
+			mode:    tracking.ModeFull,
+			claimed: testRecipient,
+			want:    engagement{email: testRecipient, ip: testIP, userAgent: testUserAgent},
 		},
 		// An unstated Mode imposes no restriction of its own, so it keeps the
 		// attribution its token was minted to carry — and still never reaches Full.
-		{name: "Unspecified", mode: tracking.ModeUnspecified, want: engagement{email: testRecipient}},
+		{
+			name:    "Unspecified",
+			mode:    tracking.ModeUnspecified,
+			claimed: testRecipient,
+			want:    engagement{email: testRecipient},
+		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.want, retained(req, testRecipient, tc.mode))
+			assert.Equal(t, tc.want, retained(req, tc.claimed, tc.mode))
 		})
 	}
 }

--- a/proto/kannon/mailer/apiv1/mailerapiv1.pb.go
+++ b/proto/kannon/mailer/apiv1/mailerapiv1.pb.go
@@ -424,8 +424,8 @@ type RejectedRecipient struct {
 	//	                           than its Domain's Policy allows; consent may
 	//	                           narrow what is collected, never widen it
 	//	unsupported_tracking_mode  the Recipient stated a Tracking Mode this
-	//	                           build will not act on — the reserved
-	//	                           `pseudonymous`, or a value from a newer schema
+	//	                           build will not act on — a value from a newer
+	//	                           schema
 	//	unsubscribe_url_unresolved this Recipient's fields leave a placeholder in
 	//	                           one_click_unsubscribe.url_template unresolved,
 	//	                           so its unsubscribe endpoint would be advertised

--- a/proto/kannon/tracking/types/tracking.pb.go
+++ b/proto/kannon/tracking/types/tracking.pb.go
@@ -34,8 +34,8 @@ const (
 	TrackingMode_TRACKING_MODE_OFF TrackingMode = 1
 	// Counted in aggregate only; nothing retained that isolates one recipient.
 	TrackingMode_TRACKING_MODE_ANONYMOUS TrackingMode = 2
-	// Linkable within a single batch, carrying no recipient identity.
-	// Reserved: selecting it is rejected as unsupported.
+	// Linkable within a single batch, carrying no recipient identity: events are
+	// attributed to a pseudonym drawn afresh for every batch and stored nowhere.
 	TrackingMode_TRACKING_MODE_PSEUDONYMOUS TrackingMode = 3
 	// Attributed to the recipient.
 	TrackingMode_TRACKING_MODE_IDENTIFIED TrackingMode = 4


### PR DESCRIPTION
Closes #424. Implements the design settled by **ADR 0006**, which is included in this PR (it was written for #424 and had not been committed yet).

`pseudonymous` has been on the scale since Tracking Policies landed, ranked between `anonymous` and `identified`, but reserved — refused at every API boundary — pending the per-Batch identifier decision. That decision is ADR 0006, and it also answers #411.

## The design in one table

The token envelope is untouched. The identity claim is always email-shaped, and the Mode decides which address it is:

| Mode | identity claim |
| --- | --- |
| Identified, Full | the recipient address, as today |
| Pseudonymous | `<rand>@track.<sending-domain>` |
| Anonymous | `anonymous@track.<sending-domain>` — never a stat row |

Because every identity stays email-shaped, **the Stats worker, the `stats` schema and the API surface need no change**: a pseudonymous event flows through the existing per-recipient write path, and the Mode — already on every stat event — is the discriminator. No schema change, no migration.

## What the rung actually promises

- The pseudonym is **128 bits from `crypto/rand`, lowercase hex**, drawn **once per Delivery in the Builder**, so the pixel and every link token of that Delivery carry the same value. That intra-Delivery coherence is the whole content of the rung — drawing one per token would leave every event a singleton and look identical from the outside.
- It is regenerated every Batch, stored nowhere, derived from nothing. Deliberately not an HMAC of the address: a deterministic derivation would let any key holder confirm a guessed pairing, the exact weakness #411 charged against its keyed-hash option.
- `track.<domain>` is a **reserved namespace**, enforced at the one chokepoint every token passes through: `statssec` refuses a pseudonymous mint whose identity is not a sentinel of the Batch's Domain, so a caller passing the real address with a pseudonymous Mode is caught rather than shipped.

## Shape of the change

`Mode` gains `IsolatesRecipient`, one rung below `IdentifiesRecipient`. It answers the three questions that must not drift apart — whether the mint draws a per-Delivery identity, whether the token may be shared across the Batch, and whether the Tracker keeps the claim — because a token that can isolate a Recipient is by construction not the same token for every Recipient.

- `internal/tracking/identity.go` — new: the reserved namespace, the Anonymous sentinel, `NewPseudonym`, and the two questions the mint and the Stats worker ask of an identity.
- `internal/envelope` — one pseudonym per Delivery, shared by both axes; pseudonymous tokens are no longer eligible for the shared-Batch cache.
- `internal/statssec` — the Mode decides the claim; a pseudonymous mint outside the namespace is refused with `ErrIdentityOutsideNamespace`.
- `pkg/tracker` — `retained()` keeps the pseudonym, still drops IP and user agent.
- `pkg/stats` — the Anonymous skip is unchanged; the "names nobody yet is not Anonymous" bug check is now sentinel-aware.
- `internal/trackingpb` — the rejection is gone, and with it `ErrUnsupportedMode`; `unsupported_tracking_mode` survives for wire values from a newer schema.

## Operator-facing

`docs/UPGRADING.md` gains a section: what the rung is for, **that `track.<domain>` must not carry real mailboxes** (no DNS record needed — these are identifiers, never envelope recipients), what the statistics look like, and that pseudonymous costs like identified at the mint rather than like anonymous.

## Verification

Full suite green, `golangci-lint` clean. Every acceptance criterion in #424 is pinned by a test, including an end-to-end one (`TestPseudonymousDeliveryEndToEnd`) that goes from the Mailer API call through the real RSA mint to the delivered body and asserts: no recipient address in any tracking URL, one pseudonym across the pixel and every link, and unlinkability both between two Recipients of a Batch and between two Batches of one Recipient.

Legacy tokens keep verifying: verification never inspects the identity, and the empty-claim path stays for one `tokenExpirePeriod`.

Follow-up: a PR on `app.kannon.email` to stop presenting the Mode as unselectable.