### PR TITLE
fix(smtp): route asynchronous DSN bounces to kannon.stats.bounced

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -218,13 +218,12 @@ Kannon uses NATS JetStream for reliable, decoupled messaging between its modules
 | kannon.sending         | Emails to be sent via SMTP     | Dispatcher           | SMTPSender          |
 | kannon.stats.accepted  | Email accepted for sending     | Validator            | Stats               |
 | kannon.stats.rejected  | Email rejected (invalid, etc.) | Validator            | Stats               |
-| kannon.stats.delivered | Email delivered successfully   | SMTPSender           | Stats               |
-| kannon.stats.bounced   | Email bounced (permanent)      | SMTPSender, SMTP Server | Stats            |
-| kannon.stats.soft-bounce | Email soft-bounced (transient) | SMTP Server        | Stats               |
-| kannon.stats.error     | Transient send error (retried) | SMTPSender           | Stats               |
+| kannon.stats.delivered | Email delivered successfully   | SMTPSender           | Stats, Dispatcher   |
+| kannon.stats.bounced   | Email bounced, synchronously or by a later DSN. Carries `permanent` (5xx vs 4xx) | SMTPSender, SMTP Server | Stats, Dispatcher |
+| kannon.stats.error     | Transient send error (retried) | SMTPSender           | Stats, Dispatcher   |
 | kannon.stats.opened    | Email opened (tracking pixel)  | Tracker              | Stats               |
 | kannon.stats.clicked   | Link clicked in email          | Tracker              | Stats               |
-| kannon.bounce          | Bounce events from SMTP server | SMTP Server          | Dispatcher, Stats   |
+| kannon.bounce          | Stream declared in `x/container`, but nothing publishes or consumes it | — | — |
 
 ### Example NATS JetStream Configuration
 
@@ -249,12 +248,12 @@ streams:
 
 ### Module Interactions with NATS
 
-- **Dispatcher**: Publishes to `kannon.sending`, listens to `kannon.bounce` and delivery/bounce/error events from NATS.
+- **Dispatcher**: Publishes to `kannon.sending`, and consumes `kannon.stats.delivered`, `kannon.stats.bounced` and `kannon.stats.error` to advance a Delivery out of `sending`.
 - **SMTPSender**: Consumes from `kannon.sending`, publishes to `kannon.stats.delivered`, `kannon.stats.bounced`, etc.
 - **Validator**: Publishes to `kannon.stats.accepted` and `kannon.stats.rejected`.
 - **Tracker**: Publishes to `kannon.stats.opened` and `kannon.stats.clicked`.
 - **Stats**: Consumes all `kannon.stats.*` topics.
-- **SMTP Server**: Publishes to `kannon.bounce` and `kannon.stats.bounced`.
+- **SMTP Server**: Publishes asynchronous DSN bounces to `kannon.stats.bounced`, the same subject SMTPSender uses for synchronous ones. Both go through `publisher.PublishStat`, which derives the subject from the payload rather than naming it at the call site.
 
 ### NATS Messaging Diagram
 
@@ -263,17 +262,15 @@ flowchart TD
     subgraph NATS
         SENDING["kannon.sending"]
         STATS["kannon.stats.*"]
-        BOUNCE["kannon.bounce"]
     end
     Dispatcher -- "publish" --> SENDING
     SENDING -- "consume" --> SMTPSender
     SMTPSender -- "publish" --> STATS
     Validator -- "publish" --> STATS
     Tracker -- "publish" --> STATS
-    SMTPServer -- "publish" --> BOUNCE
-    BOUNCE -- "consume" --> Dispatcher
-    BOUNCE -- "consume" --> Stats
+    SMTPServer -- "publish (async DSN bounce)" --> STATS
     STATS -- "consume" --> Stats
+    STATS -- "consume (delivered/bounced/error)" --> Dispatcher
 ```
 
 ## Architecture Diagram

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -100,11 +100,15 @@ The Recipient was refused and no Delivery will be attempted. Terminal — the De
 The remote MX accepted the SMTP handoff (e.g. responded `250 OK`). Does **not** mean the message reached an inbox — only that the next hop accepted responsibility. A subsequent asynchronous DSN can still bounce a Delivered Delivery.
 
 **Bounced**:
-Permanent delivery failure. Two sources:
-- *Synchronous*: the remote MX rejected with a 5xx during transmission (emitted by **SMTPSender**).
+Terminal delivery failure — no further attempt will be made. Two sources, both emitted on `kannon.stats.bounced`:
+- *Synchronous*: the remote MX rejected during transmission (emitted by **SMTPSender**), either with a 5xx or with a 4xx once the retry budget ran out.
 - *Asynchronous*: a DSN was received later (emitted by **SMTPServer**, possibly long after **Delivered**).
 
-Carries `permanent`, `code`, `msg`. The `permanent` flag is true in both cases today; transient failures are not Bounces (see Errored).
+Carries `permanent`, `code`, `msg`. `permanent` qualifies *why* the Delivery is terminal, by SMTP reply class: 5xx means the address itself is dead and worth writing off, 4xx means someone gave up after retrying — us on the synchronous path, the remote MTA on the asynchronous one. Both sources classify it the same way. A transient failure that still has retries left is not a Bounce at all (see Errored).
+
+Terminality is a property of the event, not of the Pool row: by the time an asynchronous DSN arrives the Delivery has usually been Delivered and dropped from the Pool already, so the event lands as a stat with no row left to transition.
+
+_Known gap_: the SMTPServer reads only the DSN's `Diagnostic-Code` and treats every DSN as a failure. An RFC 3464 `Action: delayed` — the remote MTA is still retrying, so no outcome has been reached — is therefore recorded as a Bounce and inflates the bounce rate. Tracked separately from #376.
 
 **Opened**:
 A tracking pixel was retrieved. Engagement event — non-terminal, may fire multiple times per Delivery. Only occurs when the Delivery's Tracking Policy allows opens. Carries the Tracking Mode that governed it, and carries `ip` / `user_agent` only under Full — under Identified it names the Recipient and nothing more, and under Anonymous it names nobody at all and leaves no stat row. The Mode reaches the Tracker as a signed claim in the token, not from a database lookup: the Delivery may already be gone, and a Recipient must not be able to choose how much is retained about them. An event that is *not* Anonymous yet arrives naming nobody is a bug, and is logged as an error rather than quietly discarded.
@@ -125,7 +129,7 @@ stateDiagram-v2
     Created --> Rejected: Validator: address invalid
     [*] --> Rejected: intake: refused before a Delivery exists\n(reported in the send response, not as a stat)
     Validated --> Delivered: SMTPSender: 250 OK
-    Validated --> Bounced: SMTPSender: 5xx (sync)
+    Validated --> Bounced: SMTPSender: 5xx,\nor 4xx with no retries left (sync)
     Validated --> Validated: transient send error\n(retry with backoff)
     Delivered --> Bounced: SMTPServer: DSN received\n(async)
     Rejected --> [*]

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -5,21 +5,26 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
+	netsmtp "net/smtp"
 	"regexp"
 	"testing"
 	"time"
 
 	"connectrpc.com/connect"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/nats-io/nats.go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/kannon-email/kannon/internal/delivery"
 	"github.com/kannon-email/kannon/internal/tests"
 	"github.com/kannon-email/kannon/pkg/api"
 	"github.com/kannon-email/kannon/pkg/dispatcher"
+	kannonsmtp "github.com/kannon-email/kannon/pkg/smtp"
 	"github.com/kannon-email/kannon/pkg/smtpsender"
 	"github.com/kannon-email/kannon/pkg/stats"
 	"github.com/kannon-email/kannon/pkg/tracker"
@@ -92,6 +97,11 @@ func TestE2EEmailSending(t *testing.T) {
 		testPermanentBounce(t, factory, senderMock, infra)
 	})
 
+	t.Run("AsyncSoftBounce", func(t *testing.T) {
+		t.Parallel()
+		testAsyncSoftBounce(t, factory, senderMock, infra)
+	})
+
 	t.Run("TransientThenDeliver", func(t *testing.T) {
 		t.Parallel()
 		testTransientThenDeliver(t, factory, senderMock, infra)
@@ -156,6 +166,7 @@ func runKannon(t *testing.T, infra *TestInfrastructure, senderMock *senderMock) 
 	viper.Set("api.port", infra.apiPort)
 	viper.Set("tracker.port", infra.trackerPort)
 	viper.Set("stats.retention", "8760h")
+	viper.Set("smtp.address", fmt.Sprintf(":%d", infra.smtpPort))
 
 	cnt := container.NewForTest(ctx,
 		container.WithDBURL(infra.dbURL),
@@ -179,6 +190,10 @@ func runKannon(t *testing.T, infra *TestInfrastructure, senderMock *senderMock) 
 	reg.Register(validator.New(cnt))
 	reg.Register(stats.New(cnt))
 	reg.Register(tracker.New(cnt))
+	// The inbound SMTP server: the leg that receives asynchronous DSNs. Unlike
+	// the outbound SMTPSender it needs no test double — a subtest plays the
+	// remote MTA by connecting to it and delivering a real DSN.
+	reg.Register(kannonsmtp.New(cnt))
 
 	// Custom SMTPSender wired against the test sender mock; the package's
 	// New(c) builds a real SMTP sender from the container, which the e2e
@@ -542,6 +557,176 @@ func testPermanentBounce(t *testing.T, clientFactory *clientFactory, senderMock 
 	// senderMock should have observed exactly one attempt — permanent
 	// bounces are not retried.
 	assert.Len(t, senderMock.History(to), 1, "permanent bounce should not be retried")
+}
+
+// dsnTemplate is a delivery status notification in the multipart/report shape
+// of RFC 3464, the format a remote MTA uses to report a delivery it accepted
+// and could not complete.
+const dsnTemplate = `From: MAILER-DAEMON@mx.example.com
+To: %s
+Subject: Undelivered Mail Returned to Sender
+Content-Type: multipart/report; report-type=delivery-status; boundary="B"
+
+--B
+Content-Type: text/plain; charset=us-ascii
+
+This is the mail system at host mx.example.com.
+
+--B
+Content-Type: message/delivery-status
+
+Reporting-MTA: dns; mx.example.com
+Final-Recipient: rfc822; %s
+Action: failed
+Diagnostic-Code: SMTP; %d %s
+
+--B--
+`
+
+// deliverDSN plays the remote MTA: it connects to Kannon's inbound SMTP server
+// and delivers a bounce report addressed to the Envelope's return path, which
+// is the only thing tying the report back to a Batch and a Recipient.
+func deliverDSN(t *testing.T, infra *TestInfrastructure, returnPath, recipient string, code int, reason string) {
+	t.Helper()
+
+	// The registry starts every module concurrently, so the listener may not
+	// be up yet when a parallel subtest gets here. Wait for the port rather
+	// than retrying the SMTP exchange, which would double-report the bounce.
+	require.Eventually(t, func() bool {
+		conn, err := net.DialTimeout("tcp", infra.smtpAddr(), time.Second)
+		if err != nil {
+			return false
+		}
+		conn.Close()
+		return true
+	}, 30*time.Second, 200*time.Millisecond, "inbound SMTP server never accepted connections")
+
+	c, err := netsmtp.Dial(infra.smtpAddr())
+	require.NoError(t, err)
+	defer c.Close()
+
+	require.NoError(t, c.Mail("MAILER-DAEMON@mx.example.com"))
+	require.NoError(t, c.Rcpt(returnPath))
+
+	w, err := c.Data()
+	require.NoError(t, err)
+	_, err = fmt.Fprintf(w, dsnTemplate, returnPath, recipient, code, reason)
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+	require.NoError(t, c.Quit())
+}
+
+// watchBounceSubject subscribes to kannon.stats.bounced and returns a function
+// that waits for the bounce belonging to the given Recipient.
+//
+// Asserting through the stats API is not enough to pin the subject. The Stats
+// worker consumes the kannon.stats.* wildcard and types each row off the
+// payload, never the subject, so it records an asynchronous bounce even when it
+// is published somewhere no consumer subscribes — which is precisely how #376
+// went unnoticed. Watching the subject on the wire is the only assertion that
+// fails when the two bounce paths drift apart again.
+func watchBounceSubject(t *testing.T, infra *TestInfrastructure, email string) func(*testing.T) *statstypes.Stats {
+	t.Helper()
+
+	nc, err := nats.Connect(infra.natsURL)
+	require.NoError(t, err)
+	t.Cleanup(nc.Close)
+
+	got := make(chan *statstypes.Stats, 8)
+	// The subscription needs no explicit teardown: the deferred nc.Close above
+	// drops it with the connection.
+	_, err = nc.Subscribe("kannon.stats.bounced", func(m *nats.Msg) {
+		s := &statstypes.Stats{}
+		if err := proto.Unmarshal(m.Data, s); err != nil {
+			return
+		}
+		if s.Email == email {
+			got <- s
+		}
+	})
+	require.NoError(t, err)
+
+	// Flush so the subscription is registered on the server before the caller
+	// triggers the event it means to observe.
+	require.NoError(t, nc.Flush())
+
+	return func(t *testing.T) *statstypes.Stats {
+		t.Helper()
+		select {
+		case s := <-got:
+			return s
+		case <-time.After(20 * time.Second):
+			t.Fatalf("no bounce for %s arrived on kannon.stats.bounced", email)
+			return nil
+		}
+	}
+}
+
+// testAsyncSoftBounce closes the loop #376 left open: a Delivery is accepted by
+// the relay and reported Delivered, and only later does a DSN come back saying
+// it could not be completed.
+//
+// It is the asynchronous leg end to end — inbound SMTP server, NATS, Stats
+// worker, stats API — and it pins down two things the fix decided. The event
+// must land on kannon.stats.bounced, the same subject as a synchronous bounce
+// (it used to go to kannon.stats.soft-bounce, which nothing consumed). And
+// `permanent` must follow the SMTP reply class, not be asserted unconditionally:
+// a 4xx DSN means the remote MTA gave up after its own retries, which is
+// terminal for us but no evidence the address is dead.
+//
+// Note what does NOT happen: the Delivery is long gone from the Pool by now,
+// dropped when Delivered arrived, so the Dispatcher terms the stat and nothing
+// is rescheduled. The bounce is a record, not a state transition.
+func testAsyncSoftBounce(t *testing.T, clientFactory *clientFactory, senderMock *senderMock, infra *TestInfrastructure) {
+	client := clientFactory.NewClient(t, infra)
+
+	// A plain address: the relay accepts it, so this Delivery reaches
+	// Delivered before the DSN arrives — which is what makes it asynchronous.
+	to := fmt.Sprintf("softbounce.%s@%s", tests.FakeUsername(t), client.domain)
+
+	client.SendEmail(t, &mailerapiv1.SendHTMLReq{
+		Sender:        client.Sender(),
+		Recipients:    []*mailertypes.Recipient{{Email: to}},
+		Subject:       "Async Soft Bounce Test",
+		Html:          "<h1>Hello!</h1>",
+		ScheduledTime: timestamppb.Now(),
+	})
+
+	requireStat(t, client, to, "delivered", 1)
+
+	// The return path the SMTPSender used as envelope-from is where a real
+	// MTA would send its report.
+	sent := senderMock.GetEmail(to)
+	require.NotNil(t, sent, "senderMock should have captured the delivered Envelope")
+	require.Contains(t, sent.From, "bump_", "envelope-from should be a bounce return path")
+
+	// Start watching the subject before provoking the event.
+	awaitOnSubject := watchBounceSubject(t, infra, to)
+
+	deliverDSN(t, infra, sent.From, to, 450, "Mailbox temporarily unavailable")
+
+	// First half: the event travelled on kannon.stats.bounced.
+	onWire := awaitOnSubject(t).Data.GetBounced()
+	require.NotNil(t, onWire, "async bounce should carry typed Bounced data")
+	assert.False(t, onWire.Permanent,
+		"a 4xx DSN is terminal but not permanent: the address is not proven dead")
+	assert.EqualValues(t, 450, onWire.Code)
+	assert.Contains(t, onWire.Msg, "Mailbox temporarily unavailable")
+
+	// Second half: it was persisted and is readable back through the API.
+	matched := requireStat(t, client, to, "bounced", 1)
+	bounced := matched[0].Data.GetBounced()
+	require.NotNil(t, bounced, "persisted bounce should carry typed Bounced data")
+	assert.False(t, bounced.Permanent)
+	assert.EqualValues(t, 450, bounced.Code)
+
+	// The Delivered stat stays: both events are true of this Delivery, in
+	// order. The bounce does not retract or overwrite it.
+	requireStat(t, client, to, "delivered", 1)
+
+	// Nothing was rescheduled off the back of the DSN.
+	assert.Len(t, senderMock.History(to), 1,
+		"an asynchronous bounce must not trigger another send attempt")
 }
 
 func testTransientThenDeliver(t *testing.T, clientFactory *clientFactory, senderMock *senderMock, infra *TestInfrastructure) {

--- a/e2e/infrastructure_test.go
+++ b/e2e/infrastructure_test.go
@@ -20,7 +20,14 @@ type TestInfrastructure struct {
 	natsURL     string
 	apiPort     uint
 	trackerPort uint
+	smtpPort    uint
 	cleanup     []func() error
+}
+
+// smtpAddr is where the bounce-receiving SMTP server listens: the address a
+// remote MTA would deliver a DSN to.
+func (infra *TestInfrastructure) smtpAddr() string {
+	return fmt.Sprintf("localhost:%d", infra.smtpPort)
 }
 
 func (infra *TestInfrastructure) Cleanup() {
@@ -112,10 +119,16 @@ func setupTestInfrastructure(ctx context.Context) (*TestInfrastructure, error) {
 		return infra, fmt.Errorf("could not find available port for tracker: %w", err)
 	}
 
+	smtpPort, err := findAvailablePort()
+	if err != nil {
+		return infra, fmt.Errorf("could not find available port for smtp: %w", err)
+	}
+
 	infra.dbURL = dbURL
 	infra.natsURL = natsURL
 	infra.apiPort = apiPort
 	infra.trackerPort = trackerPort
+	infra.smtpPort = smtpPort
 
 	return infra, nil
 }

--- a/pkg/smtp/smtp.go
+++ b/pkg/smtp/smtp.go
@@ -10,16 +10,19 @@ import (
 	"strconv"
 
 	"github.com/emersion/go-smtp"
+	"github.com/kannon-email/kannon/internal/publisher"
 	"github.com/kannon-email/kannon/internal/utils"
 	st "github.com/kannon-email/kannon/proto/kannon/stats/types"
-	"github.com/nats-io/nats.go"
-	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // The Backend implements SMTP server methods.
+//
+// The bounce feed is held as a publisher.Publisher rather than a *nats.Conn
+// (which satisfies it) so the subject a DSN lands on is observable in a test —
+// see #376, where it silently drifted onto one nobody consumed.
 type Backend struct {
-	nc *nats.Conn
+	nc publisher.Publisher
 }
 
 func (bkd *Backend) NewSession(_ *smtp.Conn) (smtp.Session, error) {
@@ -32,7 +35,7 @@ func (bkd *Backend) NewSession(_ *smtp.Conn) (smtp.Session, error) {
 type Session struct {
 	From string
 	To   string
-	nc   *nats.Conn
+	nc   publisher.Publisher
 }
 
 func (s *Session) AuthPlain(username, password string) error {
@@ -76,7 +79,7 @@ func (s *Session) Data(r io.Reader) error {
 		Data: &st.StatsData{
 			Data: &st.StatsData_Bounced{
 				Bounced: &st.StatsDataBounced{
-					Permanent: true,
+					Permanent: isPermanentCode(code),
 					Code:      uint32(code),
 					Msg:       errMsg,
 				},
@@ -86,19 +89,26 @@ func (s *Session) Data(r io.Reader) error {
 
 	slog.Info(fmt.Sprintf("[🤷 got bounce] %vs - %d - %s", utils.ObfuscateEmail(email), code, errMsg))
 
-	msg, err := proto.Marshal(m)
-	if err != nil {
-		slog.Error("Cannot marshal data", "err", err)
-		return nil
-	}
-
-	err = s.nc.Publish("kannon.stats.soft-bounce", msg)
-	if err != nil {
+	// PublishStat derives the subject from the payload, so an asynchronous
+	// bounce lands on the same kannon.stats.bounced as a synchronous one.
+	// Naming the subject by hand here is what put these events on a topic no
+	// consumer subscribed to (#376).
+	if err := publisher.PublishStat(s.nc, m); err != nil {
 		slog.Error("Cannot publish data", "err", err)
 		return nil
 	}
 
 	return nil
+}
+
+// isPermanentCode classifies a DSN diagnostic code by its SMTP reply class,
+// the same rule the synchronous path applies to a live rejection
+// (internal/smtp.newSMTPErrorFromSTMP). The Delivery is terminal either way —
+// the flag records whether the address itself is worth writing off (5xx) or
+// whether someone merely gave up after retrying (4xx: us on the synchronous
+// path, the remote MTA on this one).
+func isPermanentCode(code int) bool {
+	return code >= 500 && code < 600
 }
 
 func (s *Session) Reset() {}

--- a/pkg/smtp/smtp_test.go
+++ b/pkg/smtp/smtp_test.go
@@ -1,10 +1,14 @@
 package smtp
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
+	st "github.com/kannon-email/kannon/proto/kannon/stats/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 )
 
 func TestDiagnosticCode(t *testing.T) {
@@ -33,4 +37,115 @@ Diagnostic-Code: SMTP; 550 No such recipient
 	code, msg := parseCode(strings.NewReader(msg))
 	assert.Equal(t, 550, code)
 	assert.Equal(t, "SMTP; 550 No such recipient", msg)
+}
+
+// bounceReturnPath encodes test@test.com in batch msg_test01 on domain k.test.com.
+const bounceReturnPath = "bump_dGVzdEB0ZXN0LmNvbQ==+msg_test01@k.test.com"
+
+// dsn renders a delivery status notification carrying the given diagnostic
+// code, in the multipart/report shape a real MTA sends one.
+func dsn(diagnostic string) string {
+	return fmt.Sprintf(`Content-Type: multipart/report; report-type=delivery-status; boundary="B"
+Subject: Undelivered Mail Returned to Sender
+
+--B
+Content-Type: message/delivery-status
+
+Reporting-MTA: smtp; mx.example.com
+Final-Recipient: rfc822; test@test.com
+Action: failed
+%s
+
+--B--`, diagnostic)
+}
+
+type capturingPublisher struct {
+	subjects []string
+	payloads [][]byte
+}
+
+func (p *capturingPublisher) Publish(subj string, data []byte) error {
+	p.subjects = append(p.subjects, subj)
+	p.payloads = append(p.payloads, data)
+	return nil
+}
+
+func (p *capturingPublisher) lastStat(t *testing.T) *st.Stats {
+	t.Helper()
+	require.NotEmpty(t, p.payloads, "nothing was published")
+	m := &st.Stats{}
+	require.NoError(t, proto.Unmarshal(p.payloads[len(p.payloads)-1], m))
+	return m
+}
+
+// An asynchronous DSN must land on the same subject as a synchronous bounce.
+// It used to go to kannon.stats.soft-bounce, which no consumer subscribed to
+// (#376).
+func TestDataPublishesAsyncBounceOnBouncedSubject(t *testing.T) {
+	pub := &capturingPublisher{}
+	s := &Session{To: bounceReturnPath, nc: pub}
+
+	require.NoError(t, s.Data(strings.NewReader(dsn("Diagnostic-Code: SMTP; 550 No such recipient"))))
+
+	require.Equal(t, []string{"kannon.stats.bounced"}, pub.subjects)
+
+	m := pub.lastStat(t)
+	assert.Equal(t, "test@test.com", m.Email)
+	assert.Equal(t, "msg_test01@k.test.com", m.MessageId)
+	assert.Equal(t, "k.test.com", m.Domain)
+
+	bounced := m.Data.GetBounced()
+	require.NotNil(t, bounced, "stat must carry a Bounced payload")
+	assert.Equal(t, uint32(550), bounced.Code)
+	assert.Equal(t, "SMTP; 550 No such recipient", bounced.Msg)
+}
+
+// The permanent flag follows the SMTP reply class instead of being asserted
+// unconditionally: a 4xx DSN means the remote MTA gave up after its own
+// retries, which is terminal for us but no proof the address is dead.
+func TestAsyncBouncePermanentFollowsReplyClass(t *testing.T) {
+	tests := []struct {
+		name       string
+		diagnostic string
+		wantCode   uint32
+		wantPerm   bool
+	}{
+		{"5xx is permanent", "Diagnostic-Code: SMTP; 550 No such recipient", 550, true},
+		{"4xx is not permanent", "Diagnostic-Code: SMTP; 450 Mailbox unavailable", 450, false},
+		{"unparseable body falls back to 550", "X-Nothing-Here: none", 550, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pub := &capturingPublisher{}
+			s := &Session{To: bounceReturnPath, nc: pub}
+
+			require.NoError(t, s.Data(strings.NewReader(dsn(tt.diagnostic))))
+
+			bounced := pub.lastStat(t).Data.GetBounced()
+			require.NotNil(t, bounced)
+			assert.Equal(t, tt.wantCode, bounced.Code)
+			assert.Equal(t, tt.wantPerm, bounced.Permanent)
+		})
+	}
+}
+
+// A message whose recipient is not a bounce return path is not ours to report.
+func TestDataIgnoresNonBounceRecipient(t *testing.T) {
+	pub := &capturingPublisher{}
+	s := &Session{To: "someone@example.com", nc: pub}
+
+	require.NoError(t, s.Data(strings.NewReader(dsn("Diagnostic-Code: SMTP; 550 No such recipient"))))
+
+	assert.Empty(t, pub.subjects, "no stat should be published")
+}
+
+func TestIsPermanentCode(t *testing.T) {
+	assert.True(t, isPermanentCode(500))
+	assert.True(t, isPermanentCode(550))
+	assert.True(t, isPermanentCode(599))
+	assert.False(t, isPermanentCode(499))
+	assert.False(t, isPermanentCode(450))
+	assert.False(t, isPermanentCode(600))
+	assert.False(t, isPermanentCode(0))
 }


### PR DESCRIPTION
Closes #376.

## What was wrong

`pkg/smtp` published incoming DSNs on `kannon.stats.soft-bounce`, a subject nothing subscribes to.

## What it actually cost — less than the issue claims

The issue is filed as a permanent Pool leak. It is not one, and it is worth being precise about why, because the reasoning is what shaped the fix.

The stat was never lost. The Stats worker consumes the `kannon.stats.*` wildcard and derives the type from the payload oneof, not from the subject, so the bounce was persisted as `bounced` and counted in the aggregates all along.

Nor was any Delivery stranded. An asynchronous DSN arrives *after* the relay accepted the message, by which point `kannon.stats.delivered` has already driven `Drop` → `DELETE FROM sending_pool_emails`. There is no row left to strand. Fixing the subject changes no behaviour today: the Dispatcher looks the Delivery up, misses, and terms the stat.

What it cost is the future. `kannon.stats.bounced` is where a suppression list or any bounce handler would attach, and asynchronous DSNs — the hard bounces from real MTAs, the ones that matter most for reputation — were bypassing it silently.

## The fix

Publish through `publisher.PublishStat`, which derives the subject from the payload, rather than naming it at the call site. Correcting the string alone would have left standing the mechanism that let the two bounce paths drift; this removes it. It is what `smtpsender` already does.

`Permanent` was hardcoded `true` while the subject claimed "soft". Neither name was right. A DSN is terminal either way — what varies is whether the address is worth writing off — so it is now classified by SMTP reply class, the same rule `internal/smtp` applies to a live rejection. Note this state already existed and was reachable: `smtpsender` emits `bounced` with `permanent: false` when the retry budget runs out on a 4xx.

`Backend` and `Session` now hold a `publisher.Publisher`, which `*nats.Conn` satisfies, so the subject is observable in a test. It previously was not, which is how this survived.

## Tests

Unit tests in `pkg/smtp` pin the subject and the 5xx/4xx/unparseable classification.

The e2e suite now registers the inbound SMTP server — previously the only module it never ran — and `AsyncSoftBounce` plays the remote MTA: it lets a Delivery reach Delivered, then connects to Kannon's SMTP port and delivers an RFC 3464 report against the Envelope's real return path.

**That test asserts on the NATS subject directly, and it has to.** An earlier draft asserted only through the stats API and passed with #376 fully reintroduced — for the same reason the bug was invisible in production: the API cannot tell you which subject an event travelled on. Both assertions were then verified to fail against a deliberately reverted fix, the subject one with `no bounce arrived on kannon.stats.bounced` and the classification one on `permanent`.

The test also pins the lifecycle claim above: the Delivered stat survives the bounce, and no further send attempt is made.

## Docs

`CONTEXT.md` — **Bounced** reworded to "terminal delivery failure", with `permanent` qualifying why. The old line *"the `permanent` flag is true in both cases today"* was already false before this PR, via `smtpsender`.

`ARCHITECTURE.md` — dropped the `kannon.stats.soft-bounce` row, corrected the consumer column (the Dispatcher was missing from `delivered` / `bounced` / `error`), and marked `kannon.bounce` for what it is: a stream declared in `x/container` that nothing publishes or consumes. The diagram showed it with two consumers that do not exist.

## Follow-ups filed, not included here

- #431 — parse the RFC 3464 `Action:` field, so an `Action: delayed` DSN stops being recorded as a bounce at all. That is the remaining correctness gap and it is larger than #376.
- #432 — the bounce return path is base64-encoded URL-safe and decoded standard. Pre-existing, found while building the e2e round trip.