### PR TITLE
fix: decode bounce return paths URL-safe and retry NATS stream setup

### DIFF
--- a/internal/envelope/message_test.go
+++ b/internal/envelope/message_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/kannon-email/kannon/internal/batch"
+	"github.com/kannon-email/kannon/internal/utils"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -661,4 +662,37 @@ func TestIssue276Link(t *testing.T) {
 	})
 	assert.Nil(t, err)
 	assert.Equal(t, expectedhtml, res)
+}
+
+// TestBuildReturnPathRoundTripsThroughParseBounceReturnPath pins the encoder and
+// the decoder together: buildReturnPath here writes the Recipient with the
+// URL-safe base64 alphabet, and utils.ParseBounceReturnPath must read it back.
+// The two used to disagree on the last two alphabet symbols ('-'/'_' versus
+// '+'/'/'), so any address whose encoding hit one of them produced a return path
+// the bounce handler could not decode and the DSN was silently dropped (#432).
+//
+// Unlike the decoder-side test in internal/utils, this one calls the real
+// encoder, so it fails if either side ever changes alphabet alone.
+func TestBuildReturnPathRoundTripsThroughParseBounceReturnPath(t *testing.T) {
+	messageID := "msg_cl6g7ndft0001018ut5octeun@k.test.com"
+
+	emails := []string{
+		"test@test.com", // plain: both alphabets agree
+		"ab~@test.com",  // encodes to '-' under URL-safe, '+' under standard
+		"aÿ@test.com",   // non-ASCII (SMTPUTF8): '_' under URL-safe, '/' under standard
+	}
+
+	for _, want := range emails {
+		t.Run(want, func(t *testing.T) {
+			returnPath := buildReturnPath(want, messageID)
+
+			email, gotMessageID, domain, found, err := utils.ParseBounceReturnPath(returnPath)
+
+			assert.Nil(t, err)
+			assert.True(t, found)
+			assert.Equal(t, want, email)
+			assert.Equal(t, messageID, gotMessageID)
+			assert.Equal(t, "k.test.com", domain)
+		})
+	}
 }

--- a/internal/utils/message.go
+++ b/internal/utils/message.go
@@ -46,7 +46,11 @@ func ParseBounceReturnPath(returnPath string) (email string, messageID string, d
 	messageID = match[2]
 	found = true
 
-	emailBytes, err := base64.StdEncoding.DecodeString(emailHash)
+	// The email segment is encoded with the URL-safe alphabet by buildReturnPath
+	// (internal/envelope/message.go) — '+' is the field separator in
+	// "bump_<email>+<messageID>", so the standard alphabet, which can itself
+	// emit '+', is not a valid choice for this segment. The decoder must match.
+	emailBytes, err := base64.URLEncoding.DecodeString(emailHash)
 	if err != nil {
 		return "", "", "", false, fmt.Errorf("invalid returnPath: %w", err)
 	}

--- a/internal/utils/message_test.go
+++ b/internal/utils/message_test.go
@@ -1,6 +1,9 @@
 package utils_test
 
 import (
+	"encoding/base64"
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/kannon-email/kannon/internal/utils"
@@ -38,4 +41,66 @@ func TestParseBounceReturnPath(t *testing.T) {
 	assert.Equal(t, "k.test.com", domain)
 	assert.Equal(t, "test@test.com", email)
 	assert.Equal(t, "msg_cl6g7ndft0001018ut5octeun@k.test.com", messageID)
+}
+
+// buildReturnPathForTest replicates buildReturnPath from internal/envelope/message.go,
+// which is unexported and therefore not reachable from here. This copy could in
+// principle drift from the real encoder, so the encoder and decoder are also pinned
+// together by TestBuildReturnPathRoundTripsThroughParseBounceReturnPath in
+// internal/envelope, which calls the real buildReturnPath. What this test adds is
+// the decoder's own contract: it must accept the URL-safe alphabet.
+func buildReturnPathForTest(to, messageID string) string {
+	emailBase64 := base64.URLEncoding.EncodeToString([]byte(to))
+	return fmt.Sprintf("bump_%v+%v", emailBase64, messageID)
+}
+
+// TestParseBounceReturnPathRoundTripsURLSafeAlphabet round-trips buildReturnPath's
+// output through ParseBounceReturnPath for addresses whose base64 encoding is known
+// to hit the two symbols where the URL-safe and standard alphabets diverge ('-'/'_'
+// vs '+'/'/'). Before this fix, ParseBounceReturnPath decoded with the standard
+// alphabet while buildReturnPath encoded with the URL-safe one, so a return path
+// containing '-' or '_' failed to decode and its bounce was silently dropped (#432).
+func TestParseBounceReturnPathRoundTripsURLSafeAlphabet(t *testing.T) {
+	tests := []struct {
+		name string
+		// email is a syntactically valid address chosen so its base64 encoding
+		// lands exactly on a divergent alphabet symbol; see the assertion below,
+		// which checks this rather than assuming it.
+		email      string
+		divergesOn string // the URL-safe-only symbol this fixture's encoding must contain
+	}{
+		{
+			name:       "local part with a trailing '~' forces the '-' symbol",
+			email:      "ab~@test.com",
+			divergesOn: "-",
+		},
+		{
+			name:       "non-ASCII (SMTPUTF8-style) local part forces the '_' symbol",
+			email:      "aÿ@test.com", // 'ÿ', U+00FF
+			divergesOn: "_",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			messageID := "msg_cl6g7ndft0001018ut5octeun@k.test.com"
+			returnPath := buildReturnPathForTest(tc.email, messageID)
+
+			// Confirm the fixture actually exercises the divergent symbol instead
+			// of assuming it: the URL-safe encoding must contain it, and the
+			// standard encoding of the same address must differ because of it.
+			stdEncoded := base64.StdEncoding.EncodeToString([]byte(tc.email))
+			urlEncoded := base64.URLEncoding.EncodeToString([]byte(tc.email))
+			assert.Contains(t, urlEncoded, tc.divergesOn, "fixture must produce the URL-safe symbol under test")
+			assert.NotEqual(t, stdEncoded, urlEncoded, "fixture must make the two alphabets disagree")
+			assert.True(t, strings.Contains(returnPath, tc.divergesOn))
+
+			email, gotMessageID, domain, found, err := utils.ParseBounceReturnPath(returnPath)
+			assert.Nil(t, err)
+			assert.True(t, found)
+			assert.Equal(t, tc.email, email)
+			assert.Equal(t, messageID, gotMessageID)
+			assert.Equal(t, "k.test.com", domain)
+		})
+	}
 }

--- a/pkg/dispatcher/configure_stream_test.go
+++ b/pkg/dispatcher/configure_stream_test.go
@@ -1,0 +1,108 @@
+package dispatcher
+
+// retryConfigureSendingStream replaced an os.Exit(1) on the first JetStream
+// error (#365): in Kubernetes a NATS instance that is briefly slow to come up
+// made the dispatcher crash-loop, amplifying load on NATS. These tests
+// exercise the retry/backoff loop directly against a fake streamCreator, so
+// they run in milliseconds instead of the real multi-second backoff and need
+// no NATS connection at all.
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeStreamCreator is a minimal streamCreator whose CreateOrUpdateStream
+// behaviour is driven by a test-supplied function, so tests can force a
+// given number of failures before success (or permanent failure) without a
+// real JetStream connection.
+type fakeStreamCreator struct {
+	calls int32
+	do    func(calls int32) error
+}
+
+func (f *fakeStreamCreator) CreateOrUpdateStream(_ context.Context, _ jetstream.StreamConfig) (jetstream.Stream, error) {
+	calls := atomic.AddInt32(&f.calls, 1)
+	if err := f.do(calls); err != nil {
+		return nil, err
+	}
+	return nil, nil
+}
+
+func TestRetryConfigureSendingStreamSucceedsOnLaterAttempt(t *testing.T) {
+	ctx := t.Context()
+
+	failUntil := int32(3) // first 2 calls fail, the 3rd succeeds
+	sc := &fakeStreamCreator{
+		do: func(calls int32) error {
+			if calls < failUntil {
+				return errors.New("nats: no responders available for request")
+			}
+			return nil
+		},
+	}
+
+	err := retryConfigureSendingStream(ctx, sc, 5, time.Millisecond)
+
+	require.NoError(t, err)
+	assert.Equal(t, failUntil, atomic.LoadInt32(&sc.calls),
+		"should stop retrying as soon as CreateOrUpdateStream succeeds")
+}
+
+func TestRetryConfigureSendingStreamFailsAfterExhaustingAttempts(t *testing.T) {
+	ctx := t.Context()
+
+	wantErr := errors.New("nats: no responders available for request")
+	sc := &fakeStreamCreator{
+		do: func(int32) error {
+			return wantErr
+		},
+	}
+
+	const attempts = 3
+	err := retryConfigureSendingStream(ctx, sc, attempts, time.Millisecond)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, wantErr)
+	assert.Equal(t, int32(attempts), atomic.LoadInt32(&sc.calls),
+		"should attempt exactly `attempts` times, no more and no less")
+}
+
+func TestRetryConfigureSendingStreamHonoursContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+
+	sc := &fakeStreamCreator{
+		do: func(calls int32) error {
+			if calls == 1 {
+				// Cancel only after the first failed attempt, while the
+				// helper is about to wait between attempts.
+				cancel()
+			}
+			return errors.New("nats: no responders available for request")
+		},
+	}
+
+	// A large attempt count and base delay: if cancellation were not
+	// honoured, this call would block for a long time. The assertion below
+	// on elapsed time is what actually proves the backoff was skipped.
+	const attempts = 10
+	baseDelay := 10 * time.Second
+
+	start := time.Now()
+	err := retryConfigureSendingStream(ctx, sc, attempts, baseDelay)
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Less(t, elapsed, time.Second,
+		"context cancellation should return promptly instead of waiting out the backoff")
+	assert.Equal(t, int32(1), atomic.LoadInt32(&sc.calls),
+		"should not attempt again once the context is cancelled while waiting")
+}

--- a/pkg/dispatcher/dispatcher.go
+++ b/pkg/dispatcher/dispatcher.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"os"
 	"time"
 
 	"golang.org/x/sync/errgroup"
@@ -38,7 +37,9 @@ func run(ctx context.Context, cnt *container.Container) error {
 	eb := envelope.NewBuilder(q, ss)
 
 	js := cnt.NatsJetStream()
-	mustConfigureSendingStream(ctx, js)
+	if err := configureSendingStream(ctx, js); err != nil {
+		return fmt.Errorf("cannot configure sending stream: %w", err)
+	}
 
 	d := disp{
 		ss:      ss,
@@ -71,10 +72,43 @@ func run(ctx context.Context, cnt *container.Container) error {
 	return eg.Wait()
 }
 
-func mustConfigureSendingStream(ctx context.Context, js jetstream.JetStream) {
+// streamCreator is the minimal seam over jetstream.JetStream needed to
+// create/update the sending stream. jetstream.JetStream satisfies it
+// structurally, so production code passes one straight through; tests can
+// supply a fake to exercise the retry/backoff loop without a real NATS
+// connection.
+type streamCreator interface {
+	CreateOrUpdateStream(ctx context.Context, cfg jetstream.StreamConfig) (jetstream.Stream, error)
+}
+
+// configureStreamAttempts and configureStreamBaseDelay bound the retry loop
+// in retryConfigureSendingStream: a handful of attempts with a doubling
+// delay is enough to ride out a NATS instance that is briefly slow to come
+// up (#365) without turning a longer outage into an indefinite hang.
+const (
+	configureStreamAttempts  = 5
+	configureStreamBaseDelay = 1 * time.Second
+)
+
+// configureSendingStream ensures the kannon-sending stream exists.
+//
+// It used to os.Exit(1) on the first JetStream error. In Kubernetes, a NATS
+// pod that is briefly slow to come up made the dispatcher crash-loop, which
+// only amplified the load on NATS. Errors are now returned with retries so
+// the caller decides whether to abort.
+func configureSendingStream(ctx context.Context, js jetstream.JetStream) error {
+	return retryConfigureSendingStream(ctx, js, configureStreamAttempts, configureStreamBaseDelay)
+}
+
+// retryConfigureSendingStream retries sc.CreateOrUpdateStream up to attempts
+// times, waiting baseDelay*2^i between attempt i and i+1. It honours ctx
+// cancellation while waiting instead of sleeping blindly, so a shutdown
+// during startup returns promptly rather than burning the rest of the
+// backoff.
+func retryConfigureSendingStream(ctx context.Context, sc streamCreator, attempts int, baseDelay time.Duration) error {
 	name := "kannon-sending"
 	confs := jetstream.StreamConfig{
-		Name:        "kannon-sending",
+		Name:        name,
 		Description: "Email Sending Pool for Kannon",
 		Replicas:    1,
 		Subjects:    []string{"kannon.sending"},
@@ -84,10 +118,28 @@ func mustConfigureSendingStream(ctx context.Context, js jetstream.JetStream) {
 		Storage:     jetstream.FileStorage,
 		Discard:     jetstream.DiscardOld,
 	}
-	_, err := js.CreateOrUpdateStream(ctx, confs)
-	if err != nil {
-		slog.Error("cannot create js stream", "err", err)
-		os.Exit(1)
+
+	var lastErr error
+	for attempt := range attempts {
+		_, err := sc.CreateOrUpdateStream(ctx, confs)
+		if err == nil {
+			slog.Info(fmt.Sprintf("created js stream: %v", name))
+			return nil
+		}
+		lastErr = err
+
+		if attempt == attempts-1 {
+			break
+		}
+
+		delay := baseDelay * time.Duration(1<<attempt)
+		slog.Warn("cannot create js stream, retrying", "err", err, "attempt", attempt+1, "delay", delay)
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(delay):
+		}
 	}
-	slog.Info(fmt.Sprintf("created js stream: %v", name))
+
+	return fmt.Errorf("cannot create js stream after %d attempts: %w", attempts, lastErr)
 }


### PR DESCRIPTION
Two independent reliability fixes, each in its own commit.

## `fix(utils)`: bounce return path alphabet — Fixes #432

`buildReturnPath` encodes the Recipient with `base64.URLEncoding`; `ParseBounceReturnPath` decoded it with `base64.StdEncoding`. The alphabets differ on their last two symbols (`-`/`_` vs `+`/`/`), so an address whose encoding hits one of them produced a return path the decoder rejected.

`Session.Data` in `pkg/smtp` treats that decode error as "not our bounce", so the DSN was accepted at the SMTP level and then dropped — no stat, only a warning in the log. The encoding is deterministic, so affected Recipients lost **every** bounce, consistently.

URL-safe is the correct alphabet here: `+` is the field separator in `bump_<email>+<messageID>`, so the standard alphabet is not a valid choice for that segment. The decoder was the wrong side.

**Strict, not tolerant.** `internal/envelope` is the only producer of these return paths (`pkg/smtpsender`'s test fixtures already build them URL-safe), so accepting both alphabets would only mask a future regression of this same kind rather than protect a genuine second producer.

Covered from both sides:
- `internal/utils` — the decoder's own contract, with fixtures that *assert* they hit the divergent symbols instead of assuming it.
- `internal/envelope` — a round trip through the **real** `buildReturnPath`, which fails if either side ever changes alphabet alone.

Reproduced before the fix: decoding the URL-safe output of these fixtures with `StdEncoding` fails with `illegal base64 data at input byte 3`.

## `fix(dispatcher)`: retry NATS stream configuration — Fixes #365

`mustConfigureSendingStream` logged and `os.Exit(1)`-ed on the first JetStream error. In Kubernetes a briefly-slow NATS therefore crash-looped the dispatcher pod, amplifying the load on NATS and making the transient failure worse.

`configureSendingStream` now retries `CreateOrUpdateStream` 5 times with a doubling delay (~15s total) and returns an error. Waiting selects on `ctx.Done()`, so a shutdown during startup returns promptly instead of burning the rest of the backoff. The error propagates through the existing errgroup chain to `cmd/root.go`, which already aborts on a service error — so the entrypoint decides, not the library.

Acceptance criteria from the issue:
- [x] No `Fatal` in `pkg/dispatcher` — the only `os.Exit` in production code is gone (the ones left are in a `TestMain`, the idiomatic test-binary pattern)
- [x] Tolerates a few seconds of NATS unavailability at startup
- [x] Context cancellation honoured during the wait

Tested through a minimal `streamCreator` seam that `jetstream.JetStream` satisfies structurally: success on a later attempt, exhaustion, and cancellation — with a 1ms injected delay, so no real sleeping.

## Verification

- `go build ./...` clean
- `go test ./internal/utils/... ./internal/envelope/... ./pkg/dispatcher/... -race` green (retry tests also at `-count=3`)
- `golangci-lint run` on the touched packages: 0 issues
- `gofmt` clean

## Note for the reviewer

PRs here are squash-merged, so **only this PR title lands on `main`** and release-please will produce a single changelog entry — the dispatcher fix won't get its own line. If you'd rather have both in the changelog, this should be split into two PRs; happy to do that.