### PR TITLE
fix(delivery): bound the retry path with a time-based Retry Budget

### DIFF
--- a/.proto/kannon/stats/types/stats.proto
+++ b/.proto/kannon/stats/types/stats.proto
@@ -48,7 +48,12 @@ message StatsDataRejected {
 
 message StatsDataDelivered {}
 
-message StatsDataFailed {}
+// Failed is a Delivery whose retry budget ran out without a single attempt
+// ever being answered, so there is no reply to classify: deliberately no
+// `code`, only a `reason`, like Rejected.
+message StatsDataFailed {
+  string reason = 1;
+}
 
 message StatsDataBounced {
   bool permanent = 1;

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -28,6 +28,12 @@ _Avoid_: treating `template_type` as a source-format axis (HTML/MJML/etc.); that
 One Recipient's slot in a Batch. Persistent record carrying lifecycle state, retry count, scheduled time, and per-recipient personalisation fields. The unit Validator and Dispatcher operate on.
 _Avoid_: SendingPoolEmail, PoolEmail, Email (when meaning the row, not the address)
 
+**Retry Budget**:
+How long Kannon keeps trying to get a Delivery out, counted from the moment its Batch asked for it to be sent. A Delivery is retried for as long as the next retry would still fall inside the window, and always gets at least one attempt however late it is offered one.
+
+The allowance is a span of time rather than a number of attempts, so it is indifferent to *what* consumed the attempts — a remote MX answering transiently, an Envelope that could not be built or handed on, a send whose outcome never came back. Every Delivery gets the same span, and Kannon's own faults cannot eat into a sender's chances of delivery. Running out is what makes a Delivery terminal without an answer: **Bounced** if the attempt that ran out the clock was answered, **Failed** if none ever was.
+_Avoid_: Retry Count, Max Retries, Attempts — the attempt tally exists, but it shapes the backoff curve rather than deciding when to stop
+
 **Envelope**:
 A built, DKIM-signed, transmission-ready message for one Delivery. Transient — exists in flight on the `kannon.sending` NATS topic, handed from Dispatcher to the Sender worker. Immutable once built.
 _Avoid_: EmailToSend, OutboundMail
@@ -106,9 +112,19 @@ Terminal delivery failure — no further attempt will be made. Two sources, both
 
 Carries `permanent`, `code`, `msg`. `permanent` qualifies *why* the Delivery is terminal, by SMTP reply class: 5xx means the address itself is dead and worth writing off, 4xx means someone gave up after retrying — us on the synchronous path, the remote MTA on the asynchronous one. Both sources classify it the same way. A transient failure that still has retries left is not a Bounce at all (see Errored).
 
+A Bounce always carries a reply code, because a Bounce is a remote mail system having spoken. A Delivery that ends without one ever having spoken is **Failed**, not Bounced.
+
 Terminality is a property of the event, not of the Pool row: by the time an asynchronous DSN arrives the Delivery has usually been Delivered and dropped from the Pool already, so the event lands as a stat with no row left to transition.
 
 _Known gap_: the SMTPServer reads only the DSN's `Diagnostic-Code` and treats every DSN as a failure. An RFC 3464 `Action: delayed` — the remote MTA is still retrying, so no outcome has been reached — is therefore recorded as a Bounce and inflates the bounce rate. Tracked separately from #376.
+
+**Failed**:
+Terminal failure in which no attempt at this Delivery ever produced an outcome. Carries a `reason` and — unlike **Bounced** — no reply code, because there is none to carry: no remote mail system ever spoke. Emitted by the **Dispatcher** when a Delivery exhausts its retry budget without a single attempt having been answered, whether because no Envelope could be built for it (its Batch's Template is gone, its Domain's DKIM key is unusable) or because none of its Envelopes could be handed on.
+
+Failed states what Kannon knows, which is less than what happened: an Envelope may have been transmitted and its outcome lost on the way back, and such a Delivery is Failed too. Kannon claims only that it never learned of an outcome — never that the recipient did not receive the mail.
+
+Distinct from **Rejected**, which is a judgement Kannon passed on the Recipient *before* attempting anything. Failed is the absence of an answer *after* attempting, repeatedly.
+_Avoid_: Errored (that is the transient retry signal), Dropped, Abandoned, Expired
 
 **Opened**:
 A tracking pixel was retrieved. Engagement event — non-terminal, may fire multiple times per Delivery. Only occurs when the Delivery's Tracking Policy allows opens. Carries the Tracking Mode that governed it, and carries `ip` / `user_agent` only under Full — under Identified it names the Recipient and nothing more, and under Anonymous it names nobody at all and leaves no stat row. The Mode reaches the Tracker as a signed claim in the token, not from a database lookup: the Delivery may already be gone, and a Recipient must not be able to choose how much is retained about them. An event that is *not* Anonymous yet arrives naming nobody is a bug, and is logged as an error rather than quietly discarded.
@@ -131,9 +147,11 @@ stateDiagram-v2
     Validated --> Delivered: SMTPSender: 250 OK
     Validated --> Bounced: SMTPSender: 5xx,\nor 4xx with no retries left (sync)
     Validated --> Validated: transient send error\n(retry with backoff)
+    Validated --> Failed: Dispatcher: retry budget spent\nwith no attempt ever answered
     Delivered --> Bounced: SMTPServer: DSN received\n(async)
     Rejected --> [*]
     Bounced --> [*]
+    Failed --> [*]
     Delivered --> [*]
 
     note right of Delivered
@@ -157,6 +175,12 @@ Notes:
 **Pool**:
 The internal work-in-progress board for in-flight Deliveries (PostgreSQL table `sending_pool_emails`). Rows are **deleted** on terminal outcomes — successful or failed — rather than flagged. Pool state values are implementation detail and intentionally NOT part of the shared language; see `docs/REFACTORING.md` §1 and `internal/db/pool.go`.
 _Avoid_: Queue, SendingPool (when discussed as a domain concept — it isn't one)
+
+**Reclaim**:
+Handing a Delivery back to the Pool because the **claim** a worker held on it outlived the work. A worker takes a claim by moving the row into one of the two in-flight Pool statuses — the kind of claim is a `delivery.InFlight` — and a Delivery is **stranded** when nothing is coming to move it out again: the worker died holding the claim, or the outcome of the work never came back. Nobody else can move it, because the only exits from an in-flight status belong to the worker that took the claim. So each claiming worker reclaims its own status on a timer, past a threshold of its own — the Dispatcher what it claimed for dispatch, the Validator what it claimed for validation (ADR 0004, ADR 0007).
+
+A reclaim recovers and never terminates. It asserts nothing about what happened to the Delivery in the meantime, because it cannot know, so it emits no outcome and the sender is told nothing: only the **Retry Budget** ends a Delivery.
+_Avoid_: Reaper / Reaping, Sweep / Sweeper, Requeue, Janitor, Unstick. *Stranded* names the condition a reclaim recovers from and *claim* the thing it takes back — neither is a name for the recovery itself.
 
 ## Relationships
 

--- a/db/migrations/20260803094036_add_sending_pool_emails_claimed_at.sql
+++ b/db/migrations/20260803094036_add_sending_pool_emails_claimed_at.sql
@@ -1,0 +1,22 @@
+-- migrate:up
+-- claimed_at records when a worker claimed a Delivery into an in-flight status.
+-- It is the honest answer to "how long has this row been in flight": the claim
+-- does not touch scheduled_time, so under a backlog that column can be hours in
+-- the past on a row claimed a second ago (ADR 0007).
+ALTER TABLE sending_pool_emails ADD COLUMN claimed_at timestamp NULL;
+
+-- Rows already in flight when this migration runs were claimed by a binary that
+-- did not write the column. NOW() gives each of them one full threshold as grace
+-- before the owning worker reclaims it, instead of leaving them NULL and
+-- therefore stranded forever.
+UPDATE sending_pool_emails SET claimed_at = NOW()
+  WHERE status IN ('sending', 'validating');
+
+CREATE INDEX sending_pool_emails_status_claimed_at_idx
+  ON sending_pool_emails (status, claimed_at)
+  WHERE status IN ('sending', 'validating');
+
+-- migrate:down
+DROP INDEX sending_pool_emails_status_claimed_at_idx;
+
+ALTER TABLE sending_pool_emails DROP COLUMN claimed_at;

--- a/db/schema.go
+++ b/db/schema.go
@@ -2,7 +2,35 @@ package dbschema
 
 import (
 	_ "embed"
+
+	"github.com/amacneil/dbmate/v2/pkg/dbutil"
 )
 
 //go:embed schema.sql
-var Schema string
+var rawSchema string
+
+// Schema is db/schema.sql, ready to execute over a plain SQL connection.
+//
+// The file is written verbatim by `dbmate dump`, and pg_dump 15.14+/16.10+/17.6+
+// wraps its output in `\restrict` / `\unrestrict` psql meta-commands (the
+// CVE-2025-8714 mitigation). dbmate keeps them in the dump deliberately — with a
+// fixed key, so the file stays byte-stable across dumps — and strips them again
+// inside `dbmate load`. Kannon never loads the file through dbmate: the
+// integration suites provision Postgres by executing this string over pgx
+// (internal/tests.TestPostgresInit), which speaks SQL and not psql, and a
+// meta-command reaching it fails the whole suite with `syntax error at or near
+// "\"`. So the same strip dbmate applies on load is applied here, through
+// dbmate's own implementation rather than a second copy of it.
+var Schema = executableSchema(rawSchema)
+
+func executableSchema(raw string) string {
+	stripped, err := dbutil.StripPsqlMetaCommands([]byte(raw))
+	if err != nil {
+		// Only reachable if scanning the embedded dump fails. Hand back the dump
+		// as it stands rather than panicking in package init: this package is
+		// imported by the binary for Migrate, which does not touch Schema, and
+		// whoever executes it will fail loudly on the meta-command itself.
+		return raw
+	}
+	return string(stripped)
+}

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,3 +1,5 @@
+\restrict dbmate
+
 -- Dumped from database version 17.6 (Homebrew)
 -- Dumped by pg_dump version 17.6 (Homebrew)
 
@@ -235,7 +237,8 @@ CREATE TABLE public.sending_pool_emails (
     status character varying(100) DEFAULT 'initializing'::character varying NOT NULL,
     created_at timestamp without time zone DEFAULT now() NOT NULL,
     domain character varying NOT NULL,
-    tracking jsonb DEFAULT '{"links": "identified", "opens": "identified"}'::jsonb NOT NULL
+    tracking jsonb DEFAULT '{"links": "identified", "opens": "identified"}'::jsonb NOT NULL,
+    claimed_at timestamp without time zone
 );
 
 
@@ -606,6 +609,13 @@ CREATE INDEX messages_message_id_idx ON public.messages USING btree (message_id)
 
 
 --
+-- Name: sending_pool_emails_status_claimed_at_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX sending_pool_emails_status_claimed_at_idx ON public.sending_pool_emails USING btree (status, claimed_at) WHERE ((status)::text = ANY ((ARRAY['sending'::character varying, 'validating'::character varying])::text[]));
+
+
+--
 -- Name: sending_pool_emails_status_scheduled_time_idx; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -712,6 +722,8 @@ ALTER TABLE ONLY public.sending_pool_emails
 -- PostgreSQL database dump complete
 --
 
+\unrestrict dbmate
+
 
 --
 -- Dbmate schema migrations
@@ -734,4 +746,5 @@ INSERT INTO public.schema_migrations (version) VALUES
     ('20260214120002'),
     ('20260509102644'),
     ('20260726084414'),
-    ('20260727071416');
+    ('20260727071416'),
+    ('20260803094036');

--- a/db/schema_test.go
+++ b/db/schema_test.go
@@ -1,0 +1,24 @@
+package dbschema
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestSchemaCarriesNoPsqlMetaCommands guards the whole integration suite. Every
+// package that provisions Postgres executes Schema over pgx, so a `\restrict`
+// line surviving into it does not fail one test — it fails every suite in the
+// repo at once, with `syntax error at or near "\"`, and the cause is nowhere
+// near the tests that break.
+func TestSchemaCarriesNoPsqlMetaCommands(t *testing.T) {
+	for i, line := range strings.Split(Schema, "\n") {
+		assert.False(t, strings.HasPrefix(strings.TrimSpace(line), `\`),
+			"line %d is a psql meta-command and cannot be executed over a SQL connection: %q", i+1, line)
+	}
+
+	// And the strip took nothing else with it.
+	assert.Contains(t, Schema, "CREATE TABLE public.sending_pool_emails")
+	assert.Contains(t, Schema, "claimed_at timestamp without time zone")
+}

--- a/docs/adr/0007-how-a-delivery-stops-being-tried.md
+++ b/docs/adr/0007-how-a-delivery-stops-being-tried.md
@@ -1,0 +1,196 @@
+# ADR 0007: How a Delivery stops being tried, and what it becomes
+
+## Status
+
+Accepted (2026-08-03).
+
+## Context
+
+Three faults in the retry path were reported together as #378: a retry cap that
+nothing could reach, a `permanent` flag suspected of lying, and Pool rows
+stranded in an in-flight status with nothing to recover them. Two of the three
+turned out not to be what the report said, and the third turned out to be larger.
+
+**The `permanent` flag is correct as it stands.** #433 rewrote what it means
+(`CONTEXT.md`, *Bounced*) so that it follows the SMTP reply class on both the
+synchronous and the asynchronous path — which is what the code already did. The
+report was written against the previous wording, and the fix it proposed would
+now be a regression against a spec that is one day old.
+
+**The cap existed too**, as `maxRetry = 10` inside `internal/envelope`, read once
+to set the Envelope's `ShouldRetry` flag. It bounds the only loop it can see: a
+Delivery that reaches SMTP and keeps being answered transiently. It cannot bound
+the loop #403 opened when it stopped stranding claimed Deliveries on dispatch
+failure — a Delivery whose Envelope can never be *built* is now rescheduled
+forever, because no Envelope means no `ShouldRetry` and so nothing that can ever
+bounce. This is reachable without any crash: `GetSendingData` joins Batch,
+Template and Domain, there is no foreign key from `messages.template_id`, and so
+deleting a Template orphans every pending Delivery of every Batch that
+referenced it. Such a Delivery is retried with a doubling backoff until its next
+attempt is years away, and the sender is never told — its last stat is
+`accepted`, permanently.
+
+**The stranded row is the half of ADR 0004 that was never built.** That ADR
+accepted the strand in as many words — "a rare stranded Delivery instead of a
+systematic duplicate" — on the understanding that something would eventually
+recover it. Nothing does.
+
+Three questions therefore had to be answered together, because each one's answer
+constrains the others: what does a Delivery become when Kannon gives up on it,
+what does giving up *measure*, and what may a recovery of a stranded row claim?
+
+## Decision
+
+### A Delivery no answer ever came back for is Failed, not Bounced
+
+The discriminator between the two terminal failures is epistemic — it is about
+what reached us, not about what happened. **A Bounce always carries a reply
+code**, because a Bounce is a remote mail system having spoken; 5xx or 4xx,
+synchronous or from a later DSN, there is always a real code and `permanent`
+always classifies it. **Failed is the absence of any reply at all**, and so
+`StatsDataFailed` deliberately has no `code` field to fill in — only a `reason`,
+like Rejected.
+
+Neither of the two existing outcomes could take the case honestly. Rejected is a
+judgement Kannon passes on the Recipient *before* attempting anything; Failed is
+the absence of an answer *after* attempting, repeatedly. And forcing it into
+Bounced would mean inventing `permanent` and `code` values for an event where no
+reply class exists — re-opening the exact ambiguity #433 had just closed.
+
+The wire slot already exists: `StatsDataFailed` has occupied field 3 of the
+`StatsData` oneof since the proto was written, unemitted and unmapped. Reviving
+it costs a `reason` field on a message nobody has ever sent, so nothing is
+wire-breaking. Persistence and hourly aggregation come for free — the Stats
+worker consumes the `kannon.stats.*` wildcard and `stats.type` is a varchar, not
+an enum — so the new outcome needs no migration.
+
+### The Retry Budget is a span of time, not a count of attempts
+
+A Delivery is retried for as long as the next retry would still fall inside a
+window measured from the moment its Batch asked for it to be sent, and always
+gets at least one attempt however late it is offered one. `RetryWindow` defaults
+to **24 hours**.
+
+Two reasons, and the second is the one that matters.
+
+The window makes the give-up decision fall on the **reschedule**, not on the
+next claim. Both paths that hand a Delivery back to the Pool — the Dispatcher's
+own dispatch failure and the error-stat consumer — run through `Reschedule`, so
+one predicate on the entity governs every retry in the system. Under a count,
+the give-up lands at the *claim after* the last one: a Delivery rescheduled to
+`original + 34h` stays alive for a day and a half before anything notices it is
+over, and the sender learns of the outcome long after Kannon decided it.
+
+A span is also indifferent to *what* consumed the attempts. This matters now
+that the attempt tally is bumped by three unrelated events — a transient SMTP
+answer, a dispatch-side failure, and a reclaim of a stranded row — so under a
+count an outage of Kannon's own would spend a sender's chances of delivery. A
+span cannot:
+every Delivery gets the same 24 hours whoever burned the attempts. The tally
+survives, but only to shape the backoff curve.
+
+24 hours is not a new behaviour. Under `DefaultBackoff` the tenth retry is
+scheduled at `original + 2m·2⁹` = 17.1h and the eleventh would fall at
+`2m·2¹⁰` = 34.1h, so a 24-hour window admits exactly the retries `maxRetry = 10`
+admitted and refuses exactly the one it refused. It also coincides with the
+`MaxAge` of the `kannon-sending` stream, past which an Envelope cannot survive
+anyway.
+
+The window is a wiring point threaded through the Container, alongside the
+`BackoffPolicy` it is inseparable from, and **not** a viper key — ADR 0001's
+reasoning applies verbatim, and #378's request for an operator knob is declined
+for now. A raw count exposed to operators can re-create the very bug being fixed
+here (a cap of 60 against a doubling curve is a Delivery retried for centuries);
+a window cannot, but no operator has asked for either, and #366 remains its home
+if one ever does.
+
+### A reclaim recovers a stranded Delivery; it never terminates one
+
+A row that has sat in an in-flight status past its threshold is handed back to
+the Pool with its attempt counter bumped. The reclaim emits no outcome and makes
+no claim about what happened, because it genuinely does not know: the Envelope
+was published, the SMTP transaction may have completed in full, and the mail may
+be in the recipient's inbox. Only the Retry Budget terminates a Delivery — one
+place in the whole system decides that it is over.
+
+Recovering rather than closing the books accepts a real risk of a duplicate
+email. The send guard cannot suppress it: the guard is keyed on the stream
+sequence of the message being delivered, and a recovered Delivery is published
+afresh under a new sequence, which is the same thing that makes a legitimate
+retry send again. That risk is accepted, and it is the same judgement ADR 0004
+made twice — the guard *fails open* precisely because "a duplicate is a smaller
+failure than a batch that never leaves". Kannon is a transactional sender whose
+core traffic is password resets and receipts; for that traffic a missing email is
+far worse than a second copy. What ADR 0004 rejected was a *systematic*
+duplicate; a reclaim on an hours-long threshold produces a rare one, which was
+not on the table then.
+
+The threshold is measured from a new `claimed_at` column rather than from
+`scheduled_time`. `PrepareForSend` does not touch `scheduled_time`, so under a
+backlog — exactly when a reclaim matters — that column can be hours in the past on
+a row claimed one second ago, and a reclaim reading it would reset live sends and
+duplicate them in bulk. An honest column also answers "how long has this been in
+flight" for whoever is looking at the table, which is the blindness the reclaim
+exists to end.
+
+One mechanism covers every in-flight status, with a per-status threshold, but it
+is invoked by the worker that owns that status — the Dispatcher reclaims
+`sending`, the Validator reclaims `validating`. A reclaim run from outside both
+would have to write to a status it does not own, which is the arrangement
+ADR 0004 declined to create when it kept the SMTPSender out of the Pool. The
+thresholds differ by two orders of magnitude, because so does the plausible time
+in flight: `sending` uses
+**1 hour**, taken from `sendGuardTTL`, which is already defined as long enough to
+outlast every redelivery window plus the replacement of a dead worker — the
+codebase's existing answer to "how long can an Envelope still be alive". A
+`validating` row is stuck the moment it is a few minutes old, since the
+Validator's whole cycle is bounded at ten seconds, and uses **5 minutes**.
+
+## Consequences
+
+- A new customer-visible outcome. `Failed` appears in stats and in the stats API
+  for a Delivery that previously produced no terminal event at all.
+- A `Failed` Delivery may in fact have been delivered. Kannon claims only that it
+  never learned of an outcome, and `CONTEXT.md` says so where the term is
+  defined. Any bounce-rate or deliverability figure built on top must not read it
+  as evidence the recipient did not receive the mail.
+- `ExponentialBackoff` needs no maximum. The window makes the `math.Pow` overflow
+  at ~63 attempts unreachable by construction, so the fix stays one mechanism
+  rather than two.
+- One dbmate migration: `claimed_at` plus a partial index for the reclaim
+  predicate.
+- A recovered Delivery can be delivered twice. This is a deliberate widening of
+  the trade ADR 0004 took, in the same direction.
+- Deleting a Template still orphans the pending Deliveries of every Batch that
+  referenced it. The Retry Budget now closes those Deliveries out as Failed
+  within 24 hours instead of leaking them forever, but the missing foreign key is
+  an upstream cause and is tracked separately.
+
+## Rejected alternatives
+
+- **Fixing the `permanent` flag as #378 asked.** It is not broken; the report
+  predates #433's re-specification, and the change would break the e2e
+  assertions that pin the current meaning.
+- **Terminating an unbuildable Delivery on the first failure**, via a typed
+  "cannot build" error. A missing Template row is indistinguishable from one that
+  is about to be recreated — `template_id` is a caller-chosen string, so
+  recreating it makes the join resolve again — and from replica lag, or from
+  pointing at the wrong database. Retrying is right; only the bound was missing.
+- **A separate budget for internal failures**, so that Kannon's own faults
+  cannot spend a sender's delivery chances. Superseded by measuring the budget in
+  time, which achieves the same end with no second counter, no second threshold
+  to tune, and no migration. Under a count it would have bought a distinction the
+  architecture already draws for free: whoever exhausts the budget is the one
+  holding the evidence, and emits the outcome it can prove.
+- **Recovering a stranded row event-driven instead of on a timer**, off the
+  JetStream advisory for a consumer exceeding `MaxDeliver`. It does not cover the
+  case ADR 0004 created, which is the main one: the worker that loses the send
+  claim *acknowledges* the message, so the delivery succeeds as far as the server
+  is concerned and no advisory fires. Nor does it cover expiry by `MaxAge`. A
+  timer is needed regardless, and one mechanism is better than two.
+- **Reaping on `scheduled_time` instead of a new column**, as #378 proposed. It
+  reads as "claimed long ago" only when there is no backlog, and resets live
+  sends when there is.
+- **A reclaim that terminates the row it finds.** It would have to assert that a
+  Delivery was not transmitted when it may well have been, and it would put the
+  give-up decision in a second place.

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -112,6 +112,11 @@ func TestE2EEmailSending(t *testing.T) {
 		testDispatchFailureRecovery(t, factory, senderMock, infra)
 	})
 
+	t.Run("RetryBudgetExhausted", func(t *testing.T) {
+		t.Parallel()
+		testRetryBudgetExhausted(t, factory, infra)
+	})
+
 	t.Run("Opened", func(t *testing.T) {
 		t.Parallel()
 		testOpened(t, factory, senderMock, infra)
@@ -177,6 +182,17 @@ func runKannon(t *testing.T, infra *TestInfrastructure, senderMock *senderMock) 
 			Base: 50 * time.Millisecond,
 			Min:  50 * time.Millisecond,
 		}),
+		// The Retry Budget has to be scaled by the same factor as the backoff
+		// base, or a collapsed curve races through the whole budget and
+		// terminates every Delivery in the suite. Production is 24h against
+		// 2m·2ⁿ; this curve is 50ms·2ⁿ, i.e. 2400× faster, and 24h/2400 = 36s.
+		//
+		// That derivation keeps the boundary exactly where production has it:
+		// 50ms·2⁹ = 25.6s is inside the window and 50ms·2¹⁰ = 51.2s is outside
+		// it, so ten retries are admitted and the eleventh refused — identical
+		// to the maxRetry = 10 constant this replaced. No subtest that relies on
+		// being retried, DispatchFailureRecovery included, changes behaviour.
+		container.WithRetryWindow(36*time.Second),
 	)
 	t.Cleanup(func() {
 		if err := cnt.CloseWithTimeout(30 * time.Second); err != nil {
@@ -839,6 +855,89 @@ func testDispatchFailureRecovery(t *testing.T, clientFactory *clientFactory, sen
 		require.NoError(tt, db.QueryRow(t.Context(),
 			`SELECT count(*) FROM sending_pool_emails WHERE message_id = $1`, msgID).Scan(&n))
 		require.Zero(tt, n, "delivered Deliveries must be cleaned from the pool")
+	}, 30*time.Second, 500*time.Millisecond, "pool must drain for the batch")
+}
+
+// testRetryBudgetExhausted closes the loop testDispatchFailureRecovery opens.
+// That test heals the Batch's Template and the Delivery goes out; this one never
+// heals it, which before #378 meant the Delivery was rescheduled with a doubling
+// backoff until its next attempt was years away — the sender's last stat being
+// `accepted`, permanently. Now the Retry Budget ends it: a Failed stat the sender
+// can read, and the Pool row gone (ADR 0007).
+//
+// The Template is broken with the same reversible SQL surgery the neighbouring
+// test uses, and the Delivery is then jumped past its budget with a second piece
+// of surgery: send_attempts_cnt is set to 10, which under this container's 36s
+// window is the very first retry the budget refuses (50ms·2¹⁰ = 51.2s). Reaching
+// that boundary honestly costs 50ms·2⁹ ≈ 26s of wall clock, too slow and
+// too flaky for a subtest running alongside seventeen others; the surgery moves
+// the Delivery to the boundary and leaves the real Dispatcher to decide what
+// happens there, which is the part under test. Where the boundary itself sits is
+// pinned away from here and for free: TestCanRetry/EquivalentToTheRetryCapItReplaced
+// in internal/delivery pins that the tenth retry is admitted and the eleventh
+// refused, and pkg/dispatcher/retry_budget_test.go walks a Delivery across it one
+// dispatch cycle at a time.
+//
+// ADR 0001 rejected "test-only DB mutation of sending_pool_emails.scheduled_time"
+// on two grounds, and only one of them reaches this test. Its load-bearing
+// objection was that such a mutation bypasses the production path *under test* —
+// there, the reschedule loop itself — and nothing under test here is bypassed:
+// the real Dispatcher still claims this Delivery, still tries to build its
+// Envelope, and still makes the termination decision, which is the behaviour #378
+// added. The reschedule loop this jump skips is covered where it is cheap to
+// cover honestly, in pkg/dispatcher/retry_budget_test.go: rescheduled at 0 and 1
+// attempts, terminated at 2, no surgery. The other objection does apply and is
+// accepted — writing send_attempts_cnt couples this test to a column name that is
+// internal to the Pool.
+func testRetryBudgetExhausted(t *testing.T, clientFactory *clientFactory, infra *TestInfrastructure) {
+	client := clientFactory.NewClient(t, infra)
+
+	db, err := pgxpool.New(t.Context(), infra.dbURL)
+	require.NoError(t, err)
+	t.Cleanup(db.Close)
+
+	to := fmt.Sprintf("spent.%s@%s", tests.FakeUsername(t), client.domain)
+
+	// Scheduled slightly in the future, as in testDispatchFailureRecovery: the
+	// gap is the window for both operations below, before the Dispatcher can
+	// claim the Delivery. The Validator ignores scheduled_time, so validation
+	// still happens now.
+	msgID := client.SendEmail(t, &mailerapiv1.SendHTMLReq{
+		Sender:        client.Sender(),
+		Recipients:    []*mailertypes.Recipient{{Email: to}},
+		Subject:       "Retry Budget Exhausted Test",
+		Html:          "<h1>Hello!</h1>",
+		ScheduledTime: timestamppb.New(time.Now().Add(3 * time.Second)),
+	})
+
+	var templateID string
+	require.NoError(t, db.QueryRow(t.Context(),
+		`SELECT template_id FROM messages WHERE message_id = $1`, msgID).Scan(&templateID))
+	_, err = db.Exec(t.Context(),
+		`UPDATE templates SET template_id = $1 WHERE template_id = $2`, templateID+".broken", templateID)
+	require.NoError(t, err)
+
+	_, err = db.Exec(t.Context(),
+		`UPDATE sending_pool_emails SET send_attempts_cnt = 10 WHERE message_id = $1 AND email = $2`,
+		msgID, to)
+	require.NoError(t, err)
+
+	// Half one: the sender is told, and told something it can act on.
+	matched := requireStat(t, client, to, "failed", 1)
+	require.NotNil(t, matched[0].Data)
+	failed := matched[0].Data.GetFailed()
+	require.NotNil(t, failed, "failed stat should carry typed Failed data")
+	assert.Contains(t, failed.Reason, "retry budget",
+		"a Failed stat states what ran out; unlike Bounced it carries no reply code")
+	assert.NotContains(t, failed.Reason, to, "the reason is customer-visible and must name no address")
+
+	// Half two: the Delivery is terminal, so it leaves the Pool — it is not
+	// waiting for a retry that will never be allowed.
+	require.EventuallyWithT(t, func(tt *assert.CollectT) {
+		var n int
+		require.NoError(tt, db.QueryRow(t.Context(),
+			`SELECT count(*) FROM sending_pool_emails WHERE message_id = $1`, msgID).Scan(&n))
+		require.Zero(tt, n, "a Delivery whose Retry Budget is spent must be dropped from the pool")
 	}, 30*time.Second, 500*time.Millisecond, "pool must drain for the batch")
 }
 

--- a/internal/db/conv.go
+++ b/internal/db/conv.go
@@ -12,3 +12,13 @@ func PgTimestampFromTime(t time.Time) pgtype.Timestamp {
 		Valid: true,
 	}
 }
+
+// PgIntervalFromDuration converts a Go duration into a Postgres interval, so a
+// threshold expressed in Go can be applied against NOW() inside the database
+// rather than against a timestamp computed in the process's own clock.
+func PgIntervalFromDuration(d time.Duration) pgtype.Interval {
+	return pgtype.Interval{
+		Microseconds: d.Microseconds(),
+		Valid:        true,
+	}
+}

--- a/internal/db/delivery_repo.go
+++ b/internal/db/delivery_repo.go
@@ -3,6 +3,8 @@ package sqlc
 import (
 	"context"
 	"errors"
+	"fmt"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -12,17 +14,24 @@ import (
 )
 
 type deliveryRepository struct {
-	db      *pgxpool.Pool
-	backoff delivery.BackoffPolicy
+	db          *pgxpool.Pool
+	backoff     delivery.BackoffPolicy
+	retryWindow time.Duration
 }
 
 // NewDeliveryRepository creates a new PostgreSQL-backed Delivery repository.
-// It writes to and reads from the sending_pool_emails table. The backoff
-// policy is applied to every Delivery rehydrated from a row, so the
-// repository's reschedule path uses the canonical curve threaded through the
-// Container (see x/container.Container.BackoffPolicy).
-func NewDeliveryRepository(db *pgxpool.Pool, backoff delivery.BackoffPolicy) delivery.Repository {
-	return &deliveryRepository{db: db, backoff: backoff}
+// It writes to and reads from the sending_pool_emails table. The backoff policy
+// and the Retry Budget window are applied to every Delivery rehydrated from a
+// row, so the repository's reschedule path uses the canonical curve and the
+// canonical budget threaded through the Container (see
+// x/container.Container.BackoffPolicy and .RetryWindow).
+//
+// Both are positional and required rather than functional options: a silent
+// fallback would leave a test container's Deliveries on the production curve or
+// the production budget, which surfaces as a multi-minute wait or a Delivery
+// that never gives up instead of as a compile error (ADR 0001).
+func NewDeliveryRepository(db *pgxpool.Pool, backoff delivery.BackoffPolicy, retryWindow time.Duration) delivery.Repository {
+	return &deliveryRepository{db: db, backoff: backoff, retryWindow: retryWindow}
 }
 
 func (r *deliveryRepository) Schedule(ctx context.Context, ds ...*delivery.Delivery) error {
@@ -114,6 +123,59 @@ func (r *deliveryRepository) Clean(ctx context.Context, batchID batch.ID, email 
 	})
 }
 
+// reclaimTarget is the storage-level meaning of a delivery.InFlight: the status
+// a claim of that kind holds a row in, the status it was taken from and must go
+// back to, and whether handing it back spends a send attempt.
+type reclaimTarget struct {
+	from         SendingPoolStatus
+	to           SendingPoolStatus
+	bumpAttempts bool
+}
+
+// reclaimTargets is the single place the two in-flight statuses are paired with
+// their pre-claim status and their attempt-counter policy, so the two cannot
+// drift apart.
+var reclaimTargets = map[delivery.InFlight]reclaimTarget{
+	// A dispatch reclaim bumps the attempt counter: it is what makes a
+	// condition that strands systematically converge on termination through
+	// the Retry Budget instead of looping for ever.
+	delivery.InFlightForDispatch: {
+		from:         SendingPoolStatusSending,
+		to:           SendingPoolStatusScheduled,
+		bumpAttempts: true,
+	},
+	// A validation reclaim does not. It is not a send attempt, and bumping it
+	// would silently advance the backoff curve of a Delivery that has never
+	// been near an MX. A row that strands there has no per-row cause either —
+	// the Validator passes an address or Drops it as Rejected — so the cause is
+	// always infrastructural and always transient, and looping is correct.
+	delivery.InFlightForValidation: {
+		from:         SendingPoolStatusValidating,
+		to:           SendingPoolStatusToValidate,
+		bumpAttempts: false,
+	},
+}
+
+func (r *deliveryRepository) ReclaimStranded(ctx context.Context, f delivery.InFlight, olderThan time.Duration, max int) ([]*delivery.Delivery, error) {
+	target, ok := reclaimTargets[f]
+	if !ok {
+		return nil, fmt.Errorf("cannot reclaim: unknown in-flight claim %d", uint8(f))
+	}
+
+	q := New(r.db)
+	rows, err := q.ReclaimStranded(ctx, ReclaimStrandedParams{
+		FromStatus:   target.from,
+		ToStatus:     target.to,
+		BumpAttempts: target.bumpAttempts,
+		StrandedFor:  PgIntervalFromDuration(olderThan),
+		Max:          int32(max),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return r.rowsToDeliveries(rows), nil
+}
+
 func (r *deliveryRepository) rowsToDeliveries(rows []SendingPoolEmail) []*delivery.Delivery {
 	out := make([]*delivery.Delivery, len(rows))
 	for i, row := range rows {
@@ -132,6 +194,7 @@ func (r *deliveryRepository) rowToDelivery(row SendingPoolEmail) *delivery.Deliv
 		ScheduledTime:         row.ScheduledTime.Time,
 		OriginalScheduledTime: row.OriginalScheduledTime.Time,
 		Backoff:               r.backoff,
+		RetryWindow:           r.retryWindow,
 		Tracking:              row.Tracking,
 	})
 }

--- a/internal/db/delivery_repo_bench_test.go
+++ b/internal/db/delivery_repo_bench_test.go
@@ -30,7 +30,7 @@ func buildDeliveries(b *testing.B, batchID batch.ID, domain string, n, iter int)
 }
 
 func BenchmarkScheduleMany(b *testing.B) {
-	repo := NewDeliveryRepository(db, delivery.DefaultBackoff)
+	repo := NewDeliveryRepository(db, delivery.DefaultBackoff, delivery.DefaultRetryWindow)
 	ctx := b.Context()
 
 	for _, n := range []int{10, 100, 1000, 10_000} {

--- a/internal/db/delivery_repo_test.go
+++ b/internal/db/delivery_repo_test.go
@@ -14,6 +14,6 @@ func (deliveryTestHelper) CreateBatch(t *testing.T) (batch.ID, string) {
 }
 
 func TestDeliveryRepository(t *testing.T) {
-	repo := NewDeliveryRepository(db, delivery.DefaultBackoff)
+	repo := NewDeliveryRepository(db, delivery.DefaultBackoff, delivery.DefaultRetryWindow)
 	delivery.RunRepoSpec(t, repo, deliveryTestHelper{})
 }

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -62,17 +62,6 @@ type AggregatedStat struct {
 	Count     int64
 }
 
-type AggregatedStatsCutoff struct {
-	Ts pgtype.Timestamp
-}
-
-type AggregatedStatsHourly struct {
-	Domain    string
-	Timestamp pgtype.Timestamp
-	Type      string
-	Count     int64
-}
-
 type ApiKey struct {
 	ID            string
 	Name          string

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -62,6 +62,17 @@ type AggregatedStat struct {
 	Count     int64
 }
 
+type AggregatedStatsCutoff struct {
+	Ts pgtype.Timestamp
+}
+
+type AggregatedStatsHourly struct {
+	Domain    string
+	Timestamp pgtype.Timestamp
+	Type      string
+	Count     int64
+}
+
 type ApiKey struct {
 	ID            string
 	Name          string
@@ -107,6 +118,7 @@ type SendingPoolEmail struct {
 	CreatedAt             pgtype.Timestamp
 	Domain                string
 	Tracking              tracking.Policy
+	ClaimedAt             pgtype.Timestamp
 }
 
 type Stat struct {

--- a/internal/db/pool.sql
+++ b/internal/db/pool.sql
@@ -1,6 +1,6 @@
 -- name: PrepareForSend :many
 UPDATE sending_pool_emails AS sp
-    SET status = 'sending'
+    SET status = 'sending', claimed_at = NOW()
     FROM (
             SELECT id FROM sending_pool_emails
             WHERE scheduled_time <= NOW() AND status = 'scheduled'
@@ -12,12 +12,37 @@ UPDATE sending_pool_emails AS sp
 
 -- name: PrepareForValidate :many
 UPDATE sending_pool_emails AS sp
-    SET status = 'validating'
+    SET status = 'validating', claimed_at = NOW()
     FROM (
             SELECT id FROM sending_pool_emails
             WHERE status = 'to_validate'
             FOR UPDATE SKIP LOCKED
             LIMIT $1
+        ) AS t
+    WHERE sp.id = t.id
+    RETURNING sp.*;
+
+-- ReclaimStranded hands rows that have sat in an in-flight status past a
+-- threshold back to the status they were claimed from, and clears the claim.
+-- One query serves every in-flight status so the two cannot drift; the caller
+-- supplies the status pair and whether the recovery counts as a send attempt,
+-- and delivery.InFlight is what keeps those three from being paired wrongly.
+--
+-- The threshold is measured from claimed_at, never from scheduled_time: the
+-- claim does not touch scheduled_time, so under a backlog that column is hours
+-- in the past on a row claimed a second ago (ADR 0007).
+--
+-- name: ReclaimStranded :many
+UPDATE sending_pool_emails AS sp
+    SET status = @to_status,
+        claimed_at = NULL,
+        send_attempts_cnt = sp.send_attempts_cnt + CASE WHEN @bump_attempts::bool THEN 1 ELSE 0 END
+    FROM (
+            SELECT s.id FROM sending_pool_emails AS s
+            WHERE s.status = @from_status
+              AND s.claimed_at < NOW() - @stranded_for::interval
+            FOR UPDATE SKIP LOCKED
+            LIMIT @max
         ) AS t
     WHERE sp.id = t.id
     RETURNING sp.*;

--- a/internal/db/pool.sql.go
+++ b/internal/db/pool.sql.go
@@ -105,7 +105,7 @@ func (q *Queries) GetMessage(ctx context.Context, messageID string) (Message, er
 }
 
 const getPool = `-- name: GetPool :one
-SELECT id, scheduled_time, original_scheduled_time, send_attempts_cnt, email, message_id, fields, status, created_at, domain, tracking FROM  sending_pool_emails 
+SELECT id, scheduled_time, original_scheduled_time, send_attempts_cnt, email, message_id, fields, status, created_at, domain, tracking, claimed_at FROM  sending_pool_emails 
 WHERE email = $1 AND message_id = $2
 `
 
@@ -129,6 +129,7 @@ func (q *Queries) GetPool(ctx context.Context, arg GetPoolParams) (SendingPoolEm
 		&i.CreatedAt,
 		&i.Domain,
 		&i.Tracking,
+		&i.ClaimedAt,
 	)
 	return i, err
 }
@@ -183,7 +184,7 @@ func (q *Queries) GetSendingData(ctx context.Context, messageID string) (GetSend
 }
 
 const getSendingPoolsEmails = `-- name: GetSendingPoolsEmails :many
-SELECT id, scheduled_time, original_scheduled_time, send_attempts_cnt, email, message_id, fields, status, created_at, domain, tracking FROM sending_pool_emails WHERE message_id = $1 ORDER BY id LIMIT $2 OFFSET $3
+SELECT id, scheduled_time, original_scheduled_time, send_attempts_cnt, email, message_id, fields, status, created_at, domain, tracking, claimed_at FROM sending_pool_emails WHERE message_id = $1 ORDER BY id LIMIT $2 OFFSET $3
 `
 
 type GetSendingPoolsEmailsParams struct {
@@ -213,6 +214,7 @@ func (q *Queries) GetSendingPoolsEmails(ctx context.Context, arg GetSendingPools
 			&i.CreatedAt,
 			&i.Domain,
 			&i.Tracking,
+			&i.ClaimedAt,
 		); err != nil {
 			return nil, err
 		}
@@ -226,7 +228,7 @@ func (q *Queries) GetSendingPoolsEmails(ctx context.Context, arg GetSendingPools
 
 const prepareForSend = `-- name: PrepareForSend :many
 UPDATE sending_pool_emails AS sp
-    SET status = 'sending'
+    SET status = 'sending', claimed_at = NOW()
     FROM (
             SELECT id FROM sending_pool_emails
             WHERE scheduled_time <= NOW() AND status = 'scheduled'
@@ -234,7 +236,7 @@ UPDATE sending_pool_emails AS sp
             LIMIT $1
         ) AS t
     WHERE sp.id = t.id
-    RETURNING sp.id, sp.scheduled_time, sp.original_scheduled_time, sp.send_attempts_cnt, sp.email, sp.message_id, sp.fields, sp.status, sp.created_at, sp.domain, sp.tracking
+    RETURNING sp.id, sp.scheduled_time, sp.original_scheduled_time, sp.send_attempts_cnt, sp.email, sp.message_id, sp.fields, sp.status, sp.created_at, sp.domain, sp.tracking, sp.claimed_at
 `
 
 func (q *Queries) PrepareForSend(ctx context.Context, limit int32) ([]SendingPoolEmail, error) {
@@ -258,6 +260,7 @@ func (q *Queries) PrepareForSend(ctx context.Context, limit int32) ([]SendingPoo
 			&i.CreatedAt,
 			&i.Domain,
 			&i.Tracking,
+			&i.ClaimedAt,
 		); err != nil {
 			return nil, err
 		}
@@ -271,7 +274,7 @@ func (q *Queries) PrepareForSend(ctx context.Context, limit int32) ([]SendingPoo
 
 const prepareForValidate = `-- name: PrepareForValidate :many
 UPDATE sending_pool_emails AS sp
-    SET status = 'validating'
+    SET status = 'validating', claimed_at = NOW()
     FROM (
             SELECT id FROM sending_pool_emails
             WHERE status = 'to_validate'
@@ -279,7 +282,7 @@ UPDATE sending_pool_emails AS sp
             LIMIT $1
         ) AS t
     WHERE sp.id = t.id
-    RETURNING sp.id, sp.scheduled_time, sp.original_scheduled_time, sp.send_attempts_cnt, sp.email, sp.message_id, sp.fields, sp.status, sp.created_at, sp.domain, sp.tracking
+    RETURNING sp.id, sp.scheduled_time, sp.original_scheduled_time, sp.send_attempts_cnt, sp.email, sp.message_id, sp.fields, sp.status, sp.created_at, sp.domain, sp.tracking, sp.claimed_at
 `
 
 func (q *Queries) PrepareForValidate(ctx context.Context, limit int32) ([]SendingPoolEmail, error) {
@@ -303,6 +306,79 @@ func (q *Queries) PrepareForValidate(ctx context.Context, limit int32) ([]Sendin
 			&i.CreatedAt,
 			&i.Domain,
 			&i.Tracking,
+			&i.ClaimedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const reclaimStranded = `-- name: ReclaimStranded :many
+UPDATE sending_pool_emails AS sp
+    SET status = $1,
+        claimed_at = NULL,
+        send_attempts_cnt = sp.send_attempts_cnt + CASE WHEN $2::bool THEN 1 ELSE 0 END
+    FROM (
+            SELECT s.id FROM sending_pool_emails AS s
+            WHERE s.status = $3
+              AND s.claimed_at < NOW() - $4::interval
+            FOR UPDATE SKIP LOCKED
+            LIMIT $5
+        ) AS t
+    WHERE sp.id = t.id
+    RETURNING sp.id, sp.scheduled_time, sp.original_scheduled_time, sp.send_attempts_cnt, sp.email, sp.message_id, sp.fields, sp.status, sp.created_at, sp.domain, sp.tracking, sp.claimed_at
+`
+
+type ReclaimStrandedParams struct {
+	ToStatus     SendingPoolStatus
+	BumpAttempts bool
+	FromStatus   SendingPoolStatus
+	StrandedFor  pgtype.Interval
+	Max          int32
+}
+
+// ReclaimStranded hands rows that have sat in an in-flight status past a
+// threshold back to the status they were claimed from, and clears the claim.
+// One query serves every in-flight status so the two cannot drift; the caller
+// supplies the status pair and whether the recovery counts as a send attempt,
+// and delivery.InFlight is what keeps those three from being paired wrongly.
+//
+// The threshold is measured from claimed_at, never from scheduled_time: the
+// claim does not touch scheduled_time, so under a backlog that column is hours
+// in the past on a row claimed a second ago (ADR 0007).
+func (q *Queries) ReclaimStranded(ctx context.Context, arg ReclaimStrandedParams) ([]SendingPoolEmail, error) {
+	rows, err := q.db.Query(ctx, reclaimStranded,
+		arg.ToStatus,
+		arg.BumpAttempts,
+		arg.FromStatus,
+		arg.StrandedFor,
+		arg.Max,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []SendingPoolEmail
+	for rows.Next() {
+		var i SendingPoolEmail
+		if err := rows.Scan(
+			&i.ID,
+			&i.ScheduledTime,
+			&i.OriginalScheduledTime,
+			&i.SendAttemptsCnt,
+			&i.Email,
+			&i.MessageID,
+			&i.Fields,
+			&i.Status,
+			&i.CreatedAt,
+			&i.Domain,
+			&i.Tracking,
+			&i.ClaimedAt,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/db/pool_claimer_test.go
+++ b/internal/db/pool_claimer_test.go
@@ -23,7 +23,7 @@ func (h claimerTestHelper) Schedule(t *testing.T, ds ...*delivery.Delivery) {
 }
 
 func TestPoolClaimer(t *testing.T) {
-	deliveries := NewDeliveryRepository(db, delivery.DefaultBackoff)
+	deliveries := NewDeliveryRepository(db, delivery.DefaultBackoff, delivery.DefaultRetryWindow)
 	c := pool.NewClaimer(deliveries)
 	pool.RunClaimerSpec(t, c, claimerTestHelper{deliveries: deliveries})
 }

--- a/internal/db/statistics.go
+++ b/internal/db/statistics.go
@@ -12,5 +12,6 @@ const (
 	StatsTypeClicked   StatsType = "clicked"
 	StatsTypeBounce    StatsType = "bounced"
 	StatsTypeError     StatsType = "error"
+	StatsTypeFailed    StatsType = "failed"
 	StatsTypeUnknown   StatsType = "unknown"
 )

--- a/internal/delivery/delivery.go
+++ b/internal/delivery/delivery.go
@@ -16,6 +16,13 @@ var (
 	ErrDeliveryNotFound = errors.New("delivery not found")
 )
 
+// DefaultRetryWindow is the Retry Budget a Delivery is given when its caller
+// states none: 24 hours from the moment its Batch asked for it to be sent
+// (CONTEXT.md, *Retry Budget*). It reproduces the reach of the retry cap it
+// replaced and coincides with the MaxAge of the kannon-sending stream, past
+// which an Envelope cannot survive anyway (ADR 0007).
+const DefaultRetryWindow = 24 * time.Hour
+
 // Delivery is the per-recipient transmission unit of a Batch.
 type Delivery struct {
 	batchID               batch.ID
@@ -26,6 +33,7 @@ type Delivery struct {
 	scheduledTime         time.Time
 	originalScheduledTime time.Time
 	backoff               BackoffPolicy
+	retryWindow           time.Duration
 	tracking              tracking.Policy
 }
 
@@ -37,6 +45,9 @@ type NewParams struct {
 	Domain        string
 	ScheduledTime time.Time
 	Backoff       BackoffPolicy
+	// RetryWindow is this Delivery's Retry Budget. Zero substitutes
+	// DefaultRetryWindow, on the same terms as Backoff.
+	RetryWindow time.Duration
 	// Tracking is the effective Tracking Policy for this Delivery, already
 	// resolved by the caller at intake (ADR 0003).
 	Tracking tracking.Policy
@@ -63,6 +74,7 @@ func New(p NewParams) (*Delivery, error) {
 		scheduledTime:         p.ScheduledTime,
 		originalScheduledTime: p.ScheduledTime,
 		backoff:               policyOrDefault(p.Backoff),
+		retryWindow:           windowOrDefault(p.RetryWindow),
 		tracking:              p.Tracking.Normalized(),
 	}, nil
 }
@@ -77,6 +89,7 @@ type LoadParams struct {
 	ScheduledTime         time.Time
 	OriginalScheduledTime time.Time
 	Backoff               BackoffPolicy
+	RetryWindow           time.Duration
 	Tracking              tracking.Policy
 }
 
@@ -91,6 +104,7 @@ func Load(p LoadParams) *Delivery {
 		scheduledTime:         p.ScheduledTime,
 		originalScheduledTime: p.OriginalScheduledTime,
 		backoff:               policyOrDefault(p.Backoff),
+		retryWindow:           windowOrDefault(p.RetryWindow),
 		tracking:              p.Tracking,
 	}
 }
@@ -120,9 +134,38 @@ func (d *Delivery) NextRetryAt() time.Time {
 	return d.originalScheduledTime.Add(d.backoff.Delay(d.sendAttempts))
 }
 
+// CanRetry reports whether this Delivery may be attempted again: the next
+// retry must still fall inside the Retry Budget window.
+//
+// This is the one predicate that stops a Delivery being tried, consulted by
+// every path that hands one back to the Pool (ADR 0007). It replaces the
+// maxRetry = 10 constant that used to live in internal/envelope, and admits
+// exactly the same retries: under DefaultBackoff the tenth retry falls at
+// 2m·2⁹ = 17h04m, inside the 24h window, and the eleventh at 2m·2¹⁰ = 34h08m,
+// outside it.
+//
+// It takes no clock. Both instants derive from originalScheduledTime, so the
+// predicate reduces to backoff.Delay(sendAttempts) < retryWindow — deterministic
+// in tests, and indifferent to how late the Delivery is being handled. That is
+// the non-obvious virtue of measuring the budget from the Batch's own scheduled
+// time: a Dispatcher that was down for three days does not mass-terminate the
+// Batch it finds waiting on resumption, and a Delivery always gets at least one
+// attempt however late it is offered one — by construction, not by a special
+// case for the first attempt.
+func (d *Delivery) CanRetry() bool {
+	return d.NextRetryAt().Before(d.originalScheduledTime.Add(d.retryWindow))
+}
+
 func policyOrDefault(p BackoffPolicy) BackoffPolicy {
 	if p == nil {
 		return DefaultBackoff
 	}
 	return p
+}
+
+func windowOrDefault(w time.Duration) time.Duration {
+	if w <= 0 {
+		return DefaultRetryWindow
+	}
+	return w
 }

--- a/internal/delivery/delivery_test.go
+++ b/internal/delivery/delivery_test.go
@@ -69,6 +69,82 @@ func TestNew(t *testing.T) {
 	})
 }
 
+func TestCanRetry(t *testing.T) {
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	load := func(attempts int, window time.Duration) *Delivery {
+		return Load(LoadParams{
+			BatchID:               batch.NewID("example.com"),
+			Email:                 "to@example.com",
+			Domain:                "example.com",
+			SendAttempts:          attempts,
+			ScheduledTime:         base,
+			OriginalScheduledTime: base,
+			Backoff:               DefaultBackoff,
+			RetryWindow:           window,
+		})
+	}
+
+	// The equivalence with the retry cap this replaced. maxRetry = 10 inside
+	// internal/envelope admitted attempts 0..9 and refused the 10th; under
+	// DefaultBackoff the tenth retry falls at 2m·2⁹ = 17h04m and the eleventh at
+	// 2m·2¹⁰ = 34h08m, so a 24h window admits exactly the same retries.
+	t.Run("EquivalentToTheRetryCapItReplaced", func(t *testing.T) {
+		assert.Equal(t, 17*time.Hour+4*time.Minute, DefaultBackoff.Delay(9))
+		assert.Equal(t, 34*time.Hour+8*time.Minute, DefaultBackoff.Delay(10))
+
+		assert.True(t, load(9, DefaultRetryWindow).CanRetry(),
+			"the tenth retry falls at 17h04m, inside the 24h window")
+		assert.False(t, load(10, DefaultRetryWindow).CanRetry(),
+			"the eleventh retry falls at 34h08m, outside the 24h window")
+	})
+
+	t.Run("WindowDefaultsWhenZero", func(t *testing.T) {
+		// A caller that states no window gets DefaultRetryWindow, so a missing
+		// wire-up degrades to the production budget rather than to a Delivery
+		// nothing will ever retry.
+		assert.True(t, load(9, 0).CanRetry())
+		assert.False(t, load(10, 0).CanRetry())
+
+		// And a stated window is honoured: the same Delivery that has run out
+		// under 24h still has room under 48h.
+		assert.True(t, load(10, 48*time.Hour).CanRetry())
+	})
+
+	t.Run("FirstAttemptSurvivesArbitraryLateness", func(t *testing.T) {
+		// The design's own claim: both instants CanRetry compares derive from
+		// originalScheduledTime, so lateness cannot spend the budget. A
+		// Dispatcher that was down for a week does not mass-terminate the Batch
+		// it finds waiting on resumption — the guarantee holds by construction
+		// rather than by a special case for the first attempt.
+		late := Load(LoadParams{
+			BatchID:               batch.NewID("example.com"),
+			Email:                 "to@example.com",
+			Domain:                "example.com",
+			ScheduledTime:         time.Now().UTC().Add(-7 * 24 * time.Hour),
+			OriginalScheduledTime: time.Now().UTC().Add(-7 * 24 * time.Hour),
+			Backoff:               DefaultBackoff,
+			RetryWindow:           DefaultRetryWindow,
+		})
+		assert.True(t, late.CanRetry(), "a Delivery offered its first attempt a week late still gets one")
+	})
+
+	t.Run("NewCarriesTheWindow", func(t *testing.T) {
+		d, err := New(NewParams{
+			BatchID:       batch.NewID("example.com"),
+			Email:         "to@example.com",
+			Domain:        "example.com",
+			ScheduledTime: base,
+			Backoff:       DefaultBackoff,
+			RetryWindow:   time.Nanosecond,
+		})
+		require.NoError(t, err)
+		// A Delivery created at intake carries the same budget as one rehydrated
+		// from its row, so the two cannot disagree about when it is over.
+		assert.False(t, d.CanRetry())
+	})
+}
+
 func TestNextRetryAt(t *testing.T) {
 	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 

--- a/internal/delivery/repo.go
+++ b/internal/delivery/repo.go
@@ -2,9 +2,39 @@ package delivery
 
 import (
 	"context"
+	"time"
 
 	"github.com/kannon-email/kannon/internal/batch"
 )
+
+// InFlight names the operation a worker has claimed a Delivery for. There are
+// exactly two, one per claiming worker, and the value alone determines both
+// where a claim of that kind was taken from and whether handing the Delivery
+// back counts as a spent send attempt — so a caller cannot pair the wrong
+// status with the wrong bump.
+type InFlight uint8
+
+const (
+	// InFlightForDispatch is a Delivery the Dispatcher has claimed for
+	// transmission (see Repository.PrepareForSend).
+	InFlightForDispatch InFlight = iota + 1
+
+	// InFlightForValidation is a Delivery the Validator has claimed for
+	// address validation (see Repository.PrepareForValidate).
+	InFlightForValidation
+)
+
+// String names the claim for logs.
+func (f InFlight) String() string {
+	switch f {
+	case InFlightForDispatch:
+		return "dispatch"
+	case InFlightForValidation:
+		return "validation"
+	default:
+		return "unknown"
+	}
+}
 
 // Repository persists Delivery entities (per-recipient sending pool rows).
 type Repository interface {
@@ -33,4 +63,17 @@ type Repository interface {
 
 	// Clean removes a terminated Delivery.
 	Clean(ctx context.Context, batchID batch.ID, email string) error
+
+	// ReclaimStranded hands back to the pool up to max Deliveries that have
+	// been claimed for f since longer ago than olderThan, and returns them as
+	// they now stand — pre-claim state, no claim held, attempt counter bumped
+	// if a claim of that kind spends one.
+	//
+	// olderThan is measured from the moment of the claim, never from the
+	// scheduled time: a claim does not move the scheduled time, so under a
+	// backlog a Delivery claimed one second ago looks hours overdue.
+	//
+	// It recovers; it never terminates. Only the Retry Budget ends a Delivery
+	// (ADR 0007).
+	ReclaimStranded(ctx context.Context, f InFlight, olderThan time.Duration, max int) ([]*Delivery, error)
 }

--- a/internal/envelope/builder.go
+++ b/internal/envelope/builder.go
@@ -15,8 +15,6 @@ import (
 	"github.com/kannon-email/kannon/internal/utils"
 )
 
-const maxRetry = 10
-
 // SendingData is the per-Batch lookup the Builder needs to render an
 // outgoing Envelope: template HTML + Domain DKIM keys + Batch metadata.
 // It is populated by a SendingDataSource at the storage boundary.
@@ -120,12 +118,16 @@ func (b *defaultBuilder) Build(ctx context.Context, d *delivery.Delivery) (*Enve
 	}
 
 	return New(Params{
-		EmailID:     buildEmailID(d.Email(), data.MessageID),
-		From:        data.SenderEmail,
-		To:          d.Email(),
-		ReturnPath:  returnPath,
-		Body:        signedMsg,
-		ShouldRetry: d.SendAttempts() < maxRetry,
+		EmailID:    buildEmailID(d.Email(), data.MessageID),
+		From:       data.SenderEmail,
+		To:         d.Email(),
+		ReturnPath: returnPath,
+		Body:       signedMsg,
+		// The Envelope carries the Delivery's own answer to "may this be tried
+		// again", so the SMTPSender does not have to hold a second opinion: the
+		// decision to stop belongs to the Delivery and is a span of time, not a
+		// count of attempts (ADR 0007).
+		ShouldRetry: d.CanRetry(),
 	}), nil
 }
 

--- a/internal/envelope/builder_test.go
+++ b/internal/envelope/builder_test.go
@@ -524,7 +524,13 @@ func decodeQuotedPrintable(b []byte) (string, error) {
 	return string(out), nil
 }
 
-func TestBuilderShouldRetryFalseAfterMaxAttempts(t *testing.T) {
+// TestBuilderShouldRetryFollowsTheRetryBudget pins that the Envelope's
+// ShouldRetry flag is the Delivery's own Retry Budget predicate and nothing else
+// (ADR 0007). The Builder used to hold a maxRetry = 10 constant of its own; the
+// window admits exactly the same retries, so the boundary is unchanged — under
+// DefaultBackoff the tenth retry falls inside the 24h budget at 17h04m and the
+// eleventh outside it at 34h08m.
+func TestBuilderShouldRetryFollowsTheRetryBudget(t *testing.T) {
 	priv := newDKIMKeys(t)
 	src := stubSource{data: envelope.SendingData{
 		HTML:           "<html><body>x</body></html>",
@@ -536,16 +542,23 @@ func TestBuilderShouldRetryFalseAfterMaxAttempts(t *testing.T) {
 	}}
 	b := envelope.NewBuilderWith(src, stubTokens{})
 
-	d := delivery.Load(delivery.LoadParams{
-		BatchID:      batch.ID("msg-1@test.com"),
-		Email:        "rcpt@example.com",
-		Domain:       "test.com",
-		SendAttempts: 10,
-		Backoff:      delivery.DefaultBackoff,
-	})
-	env, err := b.Build(t.Context(), d)
-	assert.Nil(t, err)
-	assert.False(t, env.ShouldRetry())
+	build := func(t *testing.T, attempts int) *envelope.Envelope {
+		t.Helper()
+		d := delivery.Load(delivery.LoadParams{
+			BatchID:      batch.ID("msg-1@test.com"),
+			Email:        "rcpt@example.com",
+			Domain:       "test.com",
+			SendAttempts: attempts,
+			Backoff:      delivery.DefaultBackoff,
+			RetryWindow:  delivery.DefaultRetryWindow,
+		})
+		env, err := b.Build(t.Context(), d)
+		require.NoError(t, err)
+		return env
+	}
+
+	assert.True(t, build(t, 9).ShouldRetry(), "the tenth retry is still inside the budget")
+	assert.False(t, build(t, 10).ShouldRetry(), "the eleventh retry falls outside the budget")
 }
 
 func TestEnvelopeToProto(t *testing.T) {

--- a/internal/envelope/envelope_integration_test.go
+++ b/internal/envelope/envelope_integration_test.go
@@ -52,9 +52,9 @@ func TestMain(m *testing.M) {
 	q = sqlc.New(db)
 
 	eb = envelope.NewBuilder(q, statssec.NewStatsService(q))
-	ma = mailapi.NewMailerAPIV1(db, delivery.DefaultBackoff)
+	ma = mailapi.NewMailerAPIV1(db, delivery.DefaultBackoff, delivery.DefaultRetryWindow)
 	adminAPI = adminapi.CreateAdminAPIService(db)
-	claimer = pool.NewClaimer(sqlc.NewDeliveryRepository(db, delivery.DefaultBackoff))
+	claimer = pool.NewClaimer(sqlc.NewDeliveryRepository(db, delivery.DefaultBackoff, delivery.DefaultRetryWindow))
 
 	code := m.Run()
 

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -6,6 +6,7 @@ package pool
 
 import (
 	"context"
+	"time"
 
 	"github.com/kannon-email/kannon/internal/batch"
 	"github.com/kannon-email/kannon/internal/delivery"
@@ -39,6 +40,17 @@ type Claimer interface {
 	// Lookup loads a Delivery by its (BatchID, Email) key. Used by
 	// stats-driven consumers that only have the storage key on hand.
 	Lookup(ctx context.Context, batchID batch.ID, email string) (*delivery.Delivery, error)
+
+	// ReclaimStranded hands back to the pool up to max Deliveries that have
+	// been in flight for f since longer ago than olderThan — a worker died
+	// holding the claim, or the outcome of the work never came back — and
+	// returns them as they now stand, for the caller to log and count.
+	//
+	// Called by the worker that owns the claim: the Dispatcher reclaims what it
+	// claimed for dispatch, the Validator what it claimed for validation. It
+	// recovers and makes no claim about what happened to the Delivery in the
+	// meantime; only the Retry Budget terminates one (ADR 0007).
+	ReclaimStranded(ctx context.Context, f delivery.InFlight, olderThan time.Duration, max int) ([]*delivery.Delivery, error)
 }
 
 type claimer struct {
@@ -72,4 +84,8 @@ func (c *claimer) Drop(ctx context.Context, d *delivery.Delivery) error {
 
 func (c *claimer) Lookup(ctx context.Context, batchID batch.ID, email string) (*delivery.Delivery, error) {
 	return c.deliveries.Get(ctx, batchID, email)
+}
+
+func (c *claimer) ReclaimStranded(ctx context.Context, f delivery.InFlight, olderThan time.Duration, max int) ([]*delivery.Delivery, error) {
+	return c.deliveries.ReclaimStranded(ctx, f, olderThan, max)
 }

--- a/internal/pool/reclaim.go
+++ b/internal/pool/reclaim.go
@@ -1,0 +1,108 @@
+package pool
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/kannon-email/kannon/internal/delivery"
+	"github.com/kannon-email/kannon/internal/utils"
+)
+
+// Reclaiming the Deliveries stranded in an in-flight status (CONTEXT.md,
+// *Reclaim*; ADR 0007).
+//
+// The mechanism is shared here; the decision to run it is not. Each claiming
+// worker builds a Reclaimer for the one status it owns and reclaims that status
+// itself — the Dispatcher what it claimed for dispatch, the Validator what it
+// claimed for validation — because a reclaim run from outside both workers would
+// write to a status it does not own, which is the arrangement ADR 0004 §"Why not
+// the Pool" declined to create when it kept the SMTPSender out of the Pool.
+// Everything that differs between the two travels as an argument, or lives with
+// the worker that can explain it.
+
+// ReclaimInterval is how often a worker reclaims its own in-flight status. Every
+// threshold is minutes or hours, so there is nothing to gain from looking more
+// often.
+const ReclaimInterval = 5 * time.Minute
+
+const (
+	// reclaimPageSize bounds one cycle, so a mass strand is drained over
+	// several of them instead of materialising the whole backlog — and one log
+	// line per row — in a single pass.
+	reclaimPageSize = 1000
+
+	// reclaimTimeout budgets the single statement a cycle issues.
+	reclaimTimeout = 30 * time.Second
+)
+
+// Reclaimer recovers the Deliveries stranded in one in-flight status, on behalf
+// of the worker that owns it.
+//
+// It is deliberately incapable of covering more than the one status it was built
+// for: the threshold and the in-flight value are fixed at construction, by the
+// worker, so nothing here can reclaim a status its caller does not own.
+type Reclaimer struct {
+	claimer   Claimer
+	log       *slog.Logger
+	inFlight  delivery.InFlight
+	olderThan time.Duration
+}
+
+// NewReclaimer binds the shared mechanism to one worker's status and threshold.
+// Whether handing a row back also spends a send attempt follows from f alone
+// (internal/db, reclaimTargets), so a caller cannot pair the wrong status with
+// the wrong bump.
+func NewReclaimer(c Claimer, log *slog.Logger, f delivery.InFlight, olderThan time.Duration) Reclaimer {
+	return Reclaimer{claimer: c, log: log, inFlight: f, olderThan: olderThan}
+}
+
+// Cycle hands every Delivery that has held a claim of this kind for longer than
+// the threshold back to the Pool, and reports what it took back.
+//
+// It recovers; it never terminates and emits no outcome, because it genuinely
+// does not know what happened: the work may have completed in full — for a
+// dispatch claim, the Envelope was published, the SMTP transaction may have run
+// to the end, and the mail may be in the recipient's inbox. Handing the Delivery
+// back therefore risks a duplicate, and that is the same trade ADR 0004 took
+// twice, since for password resets and receipts a missing email is worse than a
+// second copy. Only the Retry Budget ends a Delivery (ADR 0007).
+func (r Reclaimer) Cycle(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, reclaimTimeout)
+	defer cancel()
+
+	reclaimed, err := r.claimer.ReclaimStranded(ctx, r.inFlight, r.olderThan, reclaimPageSize)
+	if err != nil {
+		return fmt.Errorf("cannot reclaim deliveries stranded in %s: %w", r.inFlight, err)
+	}
+	if len(reclaimed) == 0 {
+		return nil
+	}
+
+	// The condition this recovers from is invisible from outside the database,
+	// which is half of why it went unnoticed for so long: every reclaim is
+	// logged individually, and the cycle carries the count.
+	log := r.log.With("in_flight", r.inFlight.String(), "threshold", r.olderThan)
+	for _, dlv := range reclaimed {
+		log.Warn("[reclaimed stranded delivery]",
+			"email", utils.ObfuscateEmail(dlv.Email()),
+			"batch_id", dlv.BatchID().String(),
+			"send_attempts", dlv.SendAttempts())
+	}
+	log.Warn("reclaimed stranded deliveries", "count", len(reclaimed))
+
+	return nil
+}
+
+// Loop is Cycle as a runner loop body. It logs the error rather than returning
+// it: runner.Run stops at the first error and every runnable in the process
+// shares one errgroup (x/container.Registry.Run), so a Postgres blip inside a
+// best-effort recovery would take the whole of Kannon down with it. The next
+// cycle is ReclaimInterval away.
+func (r Reclaimer) Loop(ctx context.Context) error {
+	if err := r.Cycle(ctx); err != nil {
+		r.log.Error("reclaim cycle failed, stranded claims stay until the next one", "err", err)
+	}
+	return nil
+}

--- a/internal/stats/service_test.go
+++ b/internal/stats/service_test.go
@@ -239,6 +239,11 @@ func TestDetermineType(t *testing.T) {
 		{"clicked", &types.StatsData{Data: &types.StatsData_Clicked{}}, stats.TypeClicked},
 		{"bounced", &types.StatsData{Data: &types.StatsData_Bounced{}}, stats.TypeBounce},
 		{"error", &types.StatsData{Data: &types.StatsData_Error{}}, stats.TypeError},
+		// Failed is the absence of any reply at all — a Delivery whose retry
+		// budget ran out without a single attempt ever being answered
+		// (CONTEXT.md, Failed / ADR 0007). Before this case existed it fell
+		// through to TypeUnknown like any unmapped variant.
+		{"failed", &types.StatsData{Data: &types.StatsData_Failed{}}, stats.TypeFailed},
 	}
 
 	for _, tt := range tests {

--- a/internal/stats/stat.go
+++ b/internal/stats/stat.go
@@ -17,6 +17,7 @@ const (
 	TypeClicked   Type = "clicked"
 	TypeBounce    Type = "bounced"
 	TypeError     Type = "error"
+	TypeFailed    Type = "failed"
 	TypeUnknown   Type = "unknown"
 )
 
@@ -76,6 +77,8 @@ func DetermineType(d *types.StatsData) Type {
 		return TypeOpened
 	case *types.StatsData_Error:
 		return TypeError
+	case *types.StatsData_Failed:
+		return TypeFailed
 	default:
 		return TypeUnknown
 	}
@@ -94,6 +97,7 @@ var DisplayName = map[Type]string{
 	TypeClicked:   "Clicked",
 	TypeDelivered: "Delivered",
 	TypeError:     "Send Error",
+	TypeFailed:    "Failed",
 	TypeOpened:    "Opened",
 	TypeUnknown:   "Unknown",
 }

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -57,7 +57,7 @@ func run(ctx context.Context, config Config, cnt *container.Container) error {
 	statsService := stats.NewService(statsRepo, stats.WithAggregatedStatsRepository(aggregatedRepo))
 
 	adminAPIService := adminapi.CreateAdminAPIService(db)
-	mailAPIService := mailapi.NewMailerAPIV1(db, cnt.BackoffPolicy())
+	mailAPIService := mailapi.NewMailerAPIV1(db, cnt.BackoffPolicy(), cnt.RetryWindow())
 	statsAPIService := statsv1.NewStatsAPIService(statsService)
 	statsV2APIService := statsv2.NewStatsAPIService(statsService)
 	hzAPIService := hzapi.CreateHZAPIService(cnt)

--- a/pkg/api/mailapi/base_test.go
+++ b/pkg/api/mailapi/base_test.go
@@ -36,7 +36,7 @@ func TestMain(m *testing.M) {
 	}
 
 	q = sqlc.New(db)
-	ts = mailapi.NewMailerAPIV1(db, delivery.DefaultBackoff)
+	ts = mailapi.NewMailerAPIV1(db, delivery.DefaultBackoff, delivery.DefaultRetryWindow)
 	adminAPI = adminapi.CreateAdminAPIService(db)
 
 	code := m.Run()

--- a/pkg/api/mailapi/mailer.go
+++ b/pkg/api/mailapi/mailer.go
@@ -36,6 +36,10 @@ type mailAPIService struct {
 	batches    batch.Repository
 	deliveries delivery.Repository
 	backoff    delivery.BackoffPolicy
+	// retryWindow is the Retry Budget stamped on every Delivery created at
+	// intake. It travels with backoff so a fresh Delivery cannot carry a
+	// different budget from the same Delivery once rehydrated from its row.
+	retryWindow time.Duration
 }
 
 func (s mailAPIService) SendHTML(ctx context.Context, req *connect.Request[pb.SendHTMLReq]) (*connect.Response[pb.SendRes], error) {
@@ -258,6 +262,7 @@ func (s mailAPIService) scheduleBatch(ctx context.Context, domain *domains.Domai
 			Domain:        b.Domain(),
 			ScheduledTime: scheduled,
 			Backoff:       s.backoff,
+			RetryWindow:   s.retryWindow,
 			Tracking:      policy,
 		})
 		if err != nil {
@@ -509,20 +514,21 @@ func validateHeaders(h *mailertypes.Headers) (batch.Headers, error) {
 	return batch.Headers{To: h.To, Cc: h.Cc}, nil
 }
 
-func NewMailerAPIV1(db *pgxpool.Pool, backoff delivery.BackoffPolicy) mailerv1connect.MailerHandler {
+func NewMailerAPIV1(db *pgxpool.Pool, backoff delivery.BackoffPolicy, retryWindow time.Duration) mailerv1connect.MailerHandler {
 	domainsCli := sqlc.NewDomainsRepository(db)
 	apiKeysRepo := sqlc.NewAPIKeysRepository(db)
 	apiKeysService := apikeys.NewService(apiKeysRepo)
 	batchRepo := sqlc.NewBatchRepository(db)
-	deliveryRepo := sqlc.NewDeliveryRepository(db, backoff)
+	deliveryRepo := sqlc.NewDeliveryRepository(db, backoff, retryWindow)
 	templatesRepo := sqlc.NewTemplatesRepository(db)
 
 	return &mailAPIService{
-		domains:    domainsCli,
-		apiKeys:    apiKeysService,
-		batches:    batchRepo,
-		deliveries: deliveryRepo,
-		templates:  templatesRepo,
-		backoff:    backoff,
+		domains:     domainsCli,
+		apiKeys:     apiKeysService,
+		batches:     batchRepo,
+		deliveries:  deliveryRepo,
+		templates:   templatesRepo,
+		backoff:     backoff,
+		retryWindow: retryWindow,
 	}
 }

--- a/pkg/dispatcher/disp.go
+++ b/pkg/dispatcher/disp.go
@@ -17,6 +17,7 @@ import (
 	statstypes "github.com/kannon-email/kannon/proto/kannon/stats/types"
 	"github.com/nats-io/nats.go/jetstream"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 type disp struct {
@@ -38,6 +39,21 @@ func (d *disp) log() *slog.Logger {
 const (
 	claimTimeout       = 10 * time.Second
 	perDeliveryTimeout = 5 * time.Second
+)
+
+// The reason carried by the Failed stat of a Delivery whose Retry Budget ran
+// out. It states what ran out and on which leg, and nothing else: this string is
+// customer-visible through the stats API, so it may never carry a raw error
+// string, an email address, or anything about the database.
+const (
+	// reasonBudgetSpentDispatching: no Envelope for this Delivery could be built
+	// or handed on before the budget ran out — its Batch's Template is gone, its
+	// Domain's DKIM key is unusable, or NATS would not take the Envelope.
+	reasonBudgetSpentDispatching = "retry budget exhausted while dispatching"
+
+	// reasonBudgetSpentSending: the budget ran out with a transmission attempt
+	// outstanding.
+	reasonBudgetSpentSending = "retry budget exhausted while sending"
 )
 
 func (d *disp) DispatchCycle(ctx context.Context) error {
@@ -63,11 +79,12 @@ func (d *disp) claimForDispatch(ctx context.Context) ([]*delivery.Delivery, erro
 }
 
 // dispatchOne builds and publishes the Envelope for one claimed Delivery.
-// On any failure the Delivery is handed back to the pool (Reschedule):
-// the claim already flipped it to 'sending', and the only other exits from
+// On any failure the Delivery goes back through the retry chokepoint: the
+// claim already flipped it to 'sending', and the only other exits from
 // that status are stats-feedback driven — which can never arrive for an
 // Envelope that was never published. Dropping the row on the floor here
-// loses it silently and permanently (#400).
+// loses it silently and permanently (#400), so it is either handed back to
+// the pool or ended as Failed, never neither.
 func (d *disp) dispatchOne(ctx context.Context, dlv *delivery.Delivery) {
 	log := d.log().With(
 		"email", utils.ObfuscateEmail(dlv.Email()),
@@ -95,16 +112,85 @@ func (d *disp) dispatchOne(ctx context.Context, dlv *delivery.Delivery) {
 	log.Info("[✅ accepted]")
 }
 
-// reschedule returns a claimed-but-failed Delivery to the pool with the
-// usual retry backoff. It runs on a context detached from cancellation:
-// the failure being handled is often the cycle context dying, and the
-// recovery write must not share that fate.
+// reschedule is dispatchOne's side of the chokepoint. It logs what retryOrFail
+// reports instead of returning it, because a dispatch cycle handles each
+// Delivery's failure in-loop and must carry on with the rest of the claimed page
+// (#400) — whereas the error-stat consumer needs the error to drive Nak/Ack.
 func (d *disp) reschedule(ctx context.Context, dlv *delivery.Delivery, log *slog.Logger) {
+	if err := d.retryOrFail(ctx, dlv, reasonBudgetSpentDispatching); err != nil {
+		log.With("err", err).Error("Cannot hand delivery back to the pool after dispatch failure")
+	}
+}
+
+// retryOrFail hands a Delivery back to the Pool for another attempt, or ends it
+// as Failed when its Retry Budget has no room for one.
+//
+// This is the single chokepoint for both paths that return a Delivery to the
+// Pool — the Dispatcher's own dispatch failure and the error-stat consumer — so
+// the give-up decision cannot drift between them. One predicate on the entity
+// governs every retry in the system (ADR 0007).
+//
+// It runs on a context detached from cancellation: the failure being handled is
+// often the cycle context dying, and neither the recovery write nor the terminal
+// one may share that fate.
+//
+// A reader will trip on Failed being emitted here rather than Bounced, since
+// CONTEXT.md (*Retry Budget*) says an exhausted Delivery is Bounced when the
+// attempt that ran out the clock was answered and Failed when none ever was —
+// and the error-stat leg has an SMTP reply in hand. The two agree, because a
+// Delivery whose ShouldRetry is already false never reaches this leg: the
+// SMTPSender bounces it itself (handleSendError). The only way a spent budget
+// arrives here is that the attempt tally advanced through an *unanswered*
+// internal event — a dispatch failure, or a reclaim of a stranded row — after the
+// Envelope was built, and it is that event, not the answered one, that ran out
+// the clock.
+func (d *disp) retryOrFail(ctx context.Context, dlv *delivery.Delivery, reason string) error {
 	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), claimTimeout)
 	defer cancel()
-	if err := d.claimer.Reschedule(ctx, dlv); err != nil {
-		log.With("err", err).Error("Cannot reschedule delivery after dispatch failure")
+
+	if dlv.CanRetry() {
+		return d.claimer.Reschedule(ctx, dlv)
 	}
+	return d.fail(ctx, dlv, reason)
+}
+
+// fail ends a Delivery whose Retry Budget is spent: the sender is told, and the
+// row leaves the Pool.
+//
+// The stat is published before the row is dropped. If the publish fails the row
+// stays in an in-flight status and the next reclaim brings it back for this same
+// verdict, at worst emitting the outcome twice — stats accumulate per Delivery
+// and the latest one wins, so a duplicate is harmless. The other order trades
+// that for the bug being fixed here: a Delivery that vanishes with `accepted` as
+// its last word.
+func (d *disp) fail(ctx context.Context, dlv *delivery.Delivery, reason string) error {
+	stat := &statstypes.Stats{
+		MessageId: dlv.BatchID().String(),
+		Domain:    dlv.Domain(),
+		Email:     dlv.Email(),
+		Timestamp: timestamppb.Now(),
+		Data: &statstypes.StatsData{
+			Data: &statstypes.StatsData_Failed{
+				Failed: &statstypes.StatsDataFailed{Reason: reason},
+			},
+		},
+	}
+	// PublishStat derives kannon.stats.failed from the payload, so the subject
+	// cannot disagree with the outcome it carries.
+	if err := publisher.PublishStat(d.pub, stat); err != nil {
+		return fmt.Errorf("cannot publish failed stat: %w", err)
+	}
+
+	if err := d.claimer.Drop(ctx, dlv); err != nil {
+		return fmt.Errorf("cannot drop delivery with a spent retry budget: %w", err)
+	}
+
+	d.log().Warn("[❌ failed] retry budget exhausted",
+		"email", utils.ObfuscateEmail(dlv.Email()),
+		"batch_id", dlv.BatchID().String(),
+		"send_attempts", dlv.SendAttempts(),
+		"reason", reason)
+	return nil
 }
 
 func (d *disp) handleErrors(ctx context.Context) error {
@@ -123,8 +209,8 @@ func (d *disp) parseErrorsFunc(ctx context.Context, m *statstypes.Stats) error {
 	if err != nil {
 		return fmt.Errorf("cannot lookup delivery: %w", err)
 	}
-	if err := d.claimer.Reschedule(ctx, dlv); err != nil {
-		return fmt.Errorf("cannot set delivered: %w", err)
+	if err := d.retryOrFail(ctx, dlv, reasonBudgetSpentSending); err != nil {
+		return fmt.Errorf("cannot hand delivery back to the pool after a send error: %w", err)
 	}
 	return nil
 }

--- a/pkg/dispatcher/dispatch_cycle_incident_test.go
+++ b/pkg/dispatcher/dispatch_cycle_incident_test.go
@@ -5,7 +5,7 @@ package dispatcher
 // In production a single multi-recipient Batch saw a large tail of its
 // Deliveries fail inside eb.Build with err="context deadline exceeded",
 // all within a few milliseconds, and remain stranded in status='sending'
-// forever (no reaper, no retry): the per-cycle context budget was SHARED
+// forever (no reclaim, no retry): the per-cycle context budget was SHARED
 // across the whole claimed page, and a claimed-but-failed Delivery had no
 // recovery path at all.
 //
@@ -159,7 +159,12 @@ func TestDispatchCycle_BudgetDeathMidPage_NoDeliveryLost(t *testing.T) {
 	// Deliveries become due again within test time (the e2e suite does the
 	// same via container.WithBackoff).
 	backoff := delivery.ExponentialBackoff{Base: 10 * time.Millisecond, Min: 10 * time.Millisecond}
-	repo := sqlc.NewDeliveryRepository(testDB, backoff)
+	// The production Retry Budget against a collapsed curve is effectively
+	// unreachable (10ms·2ⁿ passes 24h only around the 23rd attempt), which is
+	// what this test wants: it asserts that every rescheduled victim is
+	// eventually published, so nothing here may be terminated. The budget's own
+	// boundary is exercised in retry_budget_test.go.
+	repo := sqlc.NewDeliveryRepository(testDB, backoff, delivery.DefaultRetryWindow)
 	claimer := pool.NewClaimer(repo)
 
 	ds := make([]*delivery.Delivery, total)

--- a/pkg/dispatcher/dispatcher.go
+++ b/pkg/dispatcher/dispatcher.go
@@ -33,7 +33,7 @@ func run(ctx context.Context, cnt *container.Container) error {
 	q := cnt.Queries()
 
 	ss := statssec.NewStatsService(q)
-	claimer := pool.NewClaimer(sqlc.NewDeliveryRepository(cnt.DB(), cnt.BackoffPolicy()))
+	claimer := pool.NewClaimer(sqlc.NewDeliveryRepository(cnt.DB(), cnt.BackoffPolicy(), cnt.RetryWindow()))
 	eb := envelope.NewBuilder(q, ss)
 
 	js := cnt.NatsJetStream()
@@ -67,6 +67,10 @@ func run(ctx context.Context, cnt *container.Container) error {
 
 	eg.Go(func() error {
 		return runner.Run(ctx, d.DispatchCycle, runner.WaitLoop(1*time.Second))
+	})
+
+	eg.Go(func() error {
+		return runner.Run(ctx, d.reclaimLoop, runner.WaitLoop(pool.ReclaimInterval))
 	})
 
 	return eg.Wait()

--- a/pkg/dispatcher/reclaim.go
+++ b/pkg/dispatcher/reclaim.go
@@ -1,0 +1,49 @@
+package dispatcher
+
+import (
+	"context"
+	"time"
+
+	"github.com/kannon-email/kannon/internal/delivery"
+	"github.com/kannon-email/kannon/internal/pool"
+)
+
+// The Dispatcher's reclaim of the Deliveries stranded in 'sending' (CONTEXT.md,
+// *Reclaim*).
+//
+// pool.Reclaimer is the mechanism; what belongs here is the decision to run it
+// and the two things only the Dispatcher can explain — how long a claim of
+// 'sending' may live, and why taking one back spends a send attempt. The
+// Dispatcher reclaims that status itself because it owns every transition of it;
+// the rule that keeps a reclaim inside the worker that owns the status is spelled
+// out on pool.Reclaimer (ADR 0004 §"Why not the Pool").
+
+// sendingStrandThreshold is how long a Delivery may sit claimed for dispatch
+// before the Dispatcher takes it back. It is sendGuardTTL
+// (pkg/smtpsender/guard.go), already reasoned there as long enough to outlast
+// every redelivery window plus the replacement of a dead worker — the codebase's
+// existing answer to "how long can an Envelope still be alive". Past it,
+// whatever was going to happen to it has happened.
+const sendingStrandThreshold = 1 * time.Hour
+
+// reclaimer binds the shared mechanism to the one status the Dispatcher owns.
+//
+// A reclaim from 'sending' bumps the attempt counter (internal/db,
+// reclaimTargets): the Envelope was published, so an attempt was genuinely
+// spent, and the bump is what makes a condition that strands systematically
+// converge on termination through the Retry Budget instead of looping for ever.
+func (d *disp) reclaimer() pool.Reclaimer {
+	return pool.NewReclaimer(d.claimer, d.log(), delivery.InFlightForDispatch, sendingStrandThreshold)
+}
+
+// ReclaimCycle hands every Delivery that has been claimed for dispatch for
+// longer than sendingStrandThreshold back to the Pool, with its attempt counter
+// bumped, and reports what it took back.
+func (d *disp) ReclaimCycle(ctx context.Context) error {
+	return d.reclaimer().Cycle(ctx)
+}
+
+// reclaimLoop is the loop body wired into the dispatcher's run loop.
+func (d *disp) reclaimLoop(ctx context.Context) error {
+	return d.reclaimer().Loop(ctx)
+}

--- a/pkg/dispatcher/reclaim_test.go
+++ b/pkg/dispatcher/reclaim_test.go
@@ -1,0 +1,196 @@
+package dispatcher
+
+// Reclaiming Deliveries stranded in 'sending' — the half of ADR 0004 that was
+// never built (#378, ADR 0007).
+//
+// These tests drive the REAL ReclaimCycle + REAL pool.Claimer + REAL Postgres
+// (dockertest, via the TestMain in dispatch_cycle_incident_test.go). They own
+// their fixture rows and delete them again, because the pool is shared with
+// every other test in this package.
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kannon-email/kannon/internal/batch"
+	sqlc "github.com/kannon-email/kannon/internal/db"
+	"github.com/kannon-email/kannon/internal/delivery"
+	"github.com/kannon-email/kannon/internal/pool"
+)
+
+// TestReclaimCycle_SendingStrandedPastThreshold_ReturnsToPoolWithAttemptBumped
+// pins the recovery itself. Before this existed, a Delivery whose claim was
+// lost — the worker died mid-send, or the outcome stat never reached the
+// Dispatcher (ADR 0004's accepted "rare stranded Delivery") — sat in 'sending'
+// forever: the only exits from that status are stats-driven, and no stat was
+// ever coming. Nothing retried it and the sender was never told.
+//
+// The attempt counter must be bumped: it is what makes a condition that
+// strands systematically converge on termination through the Retry Budget
+// instead of looping for ever.
+func TestReclaimCycle_SendingStrandedPastThreshold_ReturnsToPoolWithAttemptBumped(t *testing.T) {
+	ctx := t.Context()
+	batchID, domain := seedReclaimBatch(t)
+
+	repo := sqlc.NewDeliveryRepository(testDB, delivery.DefaultBackoff, delivery.DefaultRetryWindow)
+	claimer := pool.NewClaimer(repo)
+	d := &disp{claimer: claimer}
+
+	email := "stranded@" + domain
+	claimForDispatch(t, repo, claimer, batchID, domain, email)
+
+	// The claim is older than sendingStrandThreshold: whatever was going to
+	// happen to this Envelope has happened by now.
+	backdateClaim(t, batchID, email, sendingStrandThreshold+time.Minute)
+
+	require.NoError(t, d.ReclaimCycle(ctx))
+
+	got := poolRow(t, batchID, email)
+	assert.Equal(t, sqlc.SendingPoolStatusScheduled, got.Status,
+		"a Delivery stranded in 'sending' past the threshold must be handed back to the pool")
+	assert.EqualValues(t, 1, got.SendAttemptsCnt,
+		"a reclaim from 'sending' counts as a spent attempt, so the Retry Budget can eventually end the loop")
+	assert.False(t, got.ClaimedAt.Valid,
+		"a Delivery that is no longer in flight must not claim to be: claimed_at is cleared")
+}
+
+// TestReclaimCycle_FreshlyClaimedUnderBacklog_IsUntouched is the assertion this
+// whole part exists for. #378 proposed reclaiming on
+// `status='sending' AND scheduled_time < NOW() - INTERVAL '15 minutes'`, but
+// PrepareForSend never touches scheduled_time: under a backlog — exactly the
+// condition in which a reclaim earns its keep — that column is hours in the past
+// on a row claimed one second ago. Such a predicate resets live sends, and
+// because the send guard is keyed on the stream sequence of the message being
+// delivered (ADR 0004), every one of them is published afresh and delivered a
+// second time. The threshold must be measured from claimed_at and nothing else.
+func TestReclaimCycle_FreshlyClaimedUnderBacklog_IsUntouched(t *testing.T) {
+	ctx := t.Context()
+	batchID, domain := seedReclaimBatch(t)
+
+	repo := sqlc.NewDeliveryRepository(testDB, delivery.DefaultBackoff, delivery.DefaultRetryWindow)
+	claimer := pool.NewClaimer(repo)
+	d := &disp{claimer: claimer}
+
+	email := "inflight@" + domain
+	claimForDispatch(t, repo, claimer, batchID, domain, email)
+
+	// A backlog: this Delivery was due six hours ago and is being sent right
+	// now. Both facts are true at once, and only the second one matters.
+	backdateSchedule(t, batchID, email, 6*time.Hour)
+	backdateClaim(t, batchID, email, 1*time.Second)
+
+	require.NoError(t, d.ReclaimCycle(ctx))
+
+	got := poolRow(t, batchID, email)
+	assert.Equal(t, sqlc.SendingPoolStatusSending, got.Status,
+		"a Delivery claimed one second ago is in flight, however long ago it was scheduled")
+	assert.EqualValues(t, 0, got.SendAttemptsCnt,
+		"a live send must not have its attempt counter bumped under it")
+	assert.True(t, got.ClaimedAt.Valid, "a live claim must be left alone")
+}
+
+// seedReclaimBatch seeds the Batch row that sending_pool_emails' foreign key
+// needs, plus the Domain that owns it, and removes both afterwards.
+func seedReclaimBatch(t *testing.T) (batch.ID, string) {
+	t.Helper()
+	ctx := t.Context()
+	q := sqlc.New(testDB)
+
+	domain := fmt.Sprintf("reclaim-%d.test", time.Now().UnixNano())
+	_, err := q.CreateDomain(ctx, sqlc.CreateDomainParams{
+		Domain:         domain,
+		DkimPrivateKey: "test-private",
+		DkimPublicKey:  "test-public",
+	})
+	require.NoError(t, err)
+
+	b, err := batch.New(batch.NewParams{
+		Domain:      domain,
+		Subject:     "reclaim",
+		Sender:      batch.Sender{Email: "noreply@" + domain, Alias: "Reclaim"},
+		TemplateID:  "tpl_reclaim@" + domain,
+		Attachments: batch.Attachments{},
+	})
+	require.NoError(t, err)
+	require.NoError(t, sqlc.NewBatchRepository(testDB).Create(ctx, b))
+
+	// context.Background(), not t.Context(): the test's context is cancelled
+	// before Cleanup runs, and a fixture row left behind here would show up in
+	// the pool-wide counts other tests in this package assert on.
+	t.Cleanup(func() {
+		cleanupCtx := context.Background()
+		//nolint:errcheck // best-effort test cleanup
+		testDB.Exec(cleanupCtx, "DELETE FROM sending_pool_emails WHERE domain = $1", domain)
+		//nolint:errcheck // best-effort test cleanup
+		testDB.Exec(cleanupCtx, "DELETE FROM messages WHERE domain = $1", domain)
+		//nolint:errcheck // best-effort test cleanup
+		testDB.Exec(cleanupCtx, "DELETE FROM domains WHERE domain = $1", domain)
+	})
+
+	return b.ID(), domain
+}
+
+// claimForDispatch takes one Delivery all the way through the real claim path
+// — scheduled, validated, then claimed into 'sending' — so the row under test
+// carries exactly the state a live dispatch leaves behind.
+func claimForDispatch(t *testing.T, repo delivery.Repository, claimer pool.Claimer, batchID batch.ID, domain, email string) {
+	t.Helper()
+	ctx := t.Context()
+
+	dlv, err := delivery.New(delivery.NewParams{
+		BatchID:       batchID,
+		Email:         email,
+		Fields:        map[string]string{"name": "X"},
+		Domain:        domain,
+		ScheduledTime: time.Now().UTC().Add(-time.Minute),
+		Backoff:       delivery.DefaultBackoff,
+	})
+	require.NoError(t, err)
+	require.NoError(t, repo.Schedule(ctx, dlv))
+	require.NoError(t, claimer.MarkValidated(ctx, dlv))
+
+	_, err = claimer.ClaimForDispatch(ctx, 100)
+	require.NoError(t, err)
+	require.Equal(t, sqlc.SendingPoolStatusSending, poolRow(t, batchID, email).Status,
+		"fixture precondition: the delivery must be claimed for dispatch")
+}
+
+// backdateClaim rewrites claimed_at to `age` ago, standing in for a claim
+// taken that long before now.
+func backdateClaim(t *testing.T, batchID batch.ID, email string, age time.Duration) {
+	t.Helper()
+	_, err := testDB.Exec(t.Context(),
+		`UPDATE sending_pool_emails
+		    SET claimed_at = NOW() - make_interval(secs => $1)
+		  WHERE message_id = $2 AND email = $3`,
+		age.Seconds(), batchID.String(), email)
+	require.NoError(t, err)
+}
+
+// backdateSchedule rewrites scheduled_time to `age` ago, standing in for the
+// backlog the claim path never clears.
+func backdateSchedule(t *testing.T, batchID batch.ID, email string, age time.Duration) {
+	t.Helper()
+	_, err := testDB.Exec(t.Context(),
+		`UPDATE sending_pool_emails
+		    SET scheduled_time = NOW() - make_interval(secs => $1),
+		        original_scheduled_time = NOW() - make_interval(secs => $1)
+		  WHERE message_id = $2 AND email = $3`,
+		age.Seconds(), batchID.String(), email)
+	require.NoError(t, err)
+}
+
+func poolRow(t *testing.T, batchID batch.ID, email string) sqlc.SendingPoolEmail {
+	t.Helper()
+	row, err := sqlc.New(testDB).GetPool(t.Context(), sqlc.GetPoolParams{
+		Email:     email,
+		MessageID: batchID.String(),
+	})
+	require.NoError(t, err)
+	return row
+}

--- a/pkg/dispatcher/retry_budget_test.go
+++ b/pkg/dispatcher/retry_budget_test.go
@@ -1,0 +1,211 @@
+package dispatcher
+
+// The Retry Budget as the Dispatcher sees it (#378, ADR 0007).
+//
+// #403 stopped stranding a claimed Delivery whose Envelope could not be built,
+// and in doing so opened a loop nothing could close: no Envelope means no
+// ShouldRetry flag, so such a Delivery can never bounce, and it was rescheduled
+// with a doubling backoff until its next attempt was years away — the sender's
+// last stat being `accepted`, permanently. This test drives the REAL
+// DispatchCycle + REAL Builder + REAL pool.Claimer + REAL Postgres (dockertest,
+// via the TestMain in dispatch_cycle_incident_test.go) through exactly that
+// condition and asserts the loop now ends: the Delivery is dropped from the Pool
+// and the sender is told, as Failed.
+//
+// The build failure needs no injection seam. seedReclaimBatch's Batch names a
+// Template that was never created, which is the production cause verbatim:
+// GetSendingData joins Batch × Template × Domain and there is no foreign key
+// from messages.template_id, so deleting a Template orphans every pending
+// Delivery of every Batch that referenced it.
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/kannon-email/kannon/internal/batch"
+	sqlc "github.com/kannon-email/kannon/internal/db"
+	"github.com/kannon-email/kannon/internal/delivery"
+	"github.com/kannon-email/kannon/internal/envelope"
+	"github.com/kannon-email/kannon/internal/pool"
+	"github.com/kannon-email/kannon/internal/statssec"
+	statstypes "github.com/kannon-email/kannon/proto/kannon/stats/types"
+)
+
+// publishedMsg is one NATS publish, kept undecoded. recordingPublisher in
+// dispatch_cycle_incident_test.go reads every payload as an EmailToSend, which a
+// stats payload is not; these tests need to tell the two subjects apart.
+type publishedMsg struct {
+	subject string
+	data    []byte
+}
+
+type subjectPublisher struct {
+	sent []publishedMsg
+}
+
+func (p *subjectPublisher) Publish(subject string, data []byte) error {
+	p.sent = append(p.sent, publishedMsg{subject: subject, data: data})
+	return nil
+}
+
+// statsOn decodes every payload published on one subject.
+func (p *subjectPublisher) statsOn(t *testing.T, subject string) []*statstypes.Stats {
+	t.Helper()
+	var out []*statstypes.Stats
+	for _, m := range p.sent {
+		if m.subject != subject {
+			continue
+		}
+		s := &statstypes.Stats{}
+		require.NoError(t, proto.Unmarshal(m.data, s))
+		out = append(out, s)
+	}
+	return out
+}
+
+// TestDispatchCycle_RetryBudgetSpent_FailsInsteadOfReschedulingForever pins both
+// halves of the termination: the Pool row is dropped, and a Failed stat carrying
+// a short non-sensitive reason is published for the sender to read.
+//
+// The budget is shrunk in step with the backoff curve, the way the e2e suite
+// does it. Against 100ms·2ⁿ a 250ms window admits the retry at 0 attempts
+// (100ms) and at 1 (200ms) and refuses the one at 2 (400ms) — so the Delivery is
+// handed back twice and terminated on the third cycle. Nothing waits: a
+// reschedule rolls scheduled_time to originalScheduledTime + delay, and the
+// fixture's original scheduled time is a minute in the past, so each retry is
+// already due.
+func TestDispatchCycle_RetryBudgetSpent_FailsInsteadOfReschedulingForever(t *testing.T) {
+	ctx := t.Context()
+	batchID, domain := seedReclaimBatch(t)
+	email := "spent@" + domain
+
+	const retryWindow = 250 * time.Millisecond
+	backoff := delivery.ExponentialBackoff{Base: 100 * time.Millisecond, Min: 100 * time.Millisecond}
+	require.Less(t, backoff.Delay(1), retryWindow, "fixture arithmetic: the second retry is inside the window")
+	require.Greater(t, backoff.Delay(2), retryWindow, "fixture arithmetic: the third retry is outside it")
+
+	repo := sqlc.NewDeliveryRepository(testDB, backoff, retryWindow)
+	claimer := pool.NewClaimer(repo)
+	q := sqlc.New(testDB)
+	pub := &subjectPublisher{}
+	d := &disp{
+		claimer: claimer,
+		eb:      envelope.NewBuilder(q, statssec.NewStatsService(q)),
+		pub:     pub,
+	}
+
+	scheduleValidated(t, repo, claimer, batchID, domain, email)
+
+	// Cycles 1 and 2 — the budget still has room, so the unbuildable Delivery is
+	// handed back to the Pool with its attempt counter bumped, exactly as before.
+	for attempt := 1; attempt <= 2; attempt++ {
+		require.NoError(t, d.DispatchCycle(ctx))
+
+		got := poolRow(t, batchID, email)
+		assert.Equal(t, sqlc.SendingPoolStatusScheduled, got.Status,
+			"a Delivery with budget left must be handed back to the pool")
+		assert.EqualValues(t, attempt, got.SendAttemptsCnt)
+		assert.Empty(t, pub.statsOn(t, "kannon.stats.failed"),
+			"a Delivery with budget left must not be reported as Failed")
+	}
+
+	// Cycle 3 — the next retry would fall outside the window. This is where the
+	// loop used to be endless.
+	require.NoError(t, d.DispatchCycle(ctx))
+
+	assert.False(t, poolRowExists(t, batchID, email),
+		"a Delivery whose Retry Budget is spent must be dropped from the pool, not rescheduled")
+
+	failed := pub.statsOn(t, "kannon.stats.failed")
+	require.Len(t, failed, 1, "exactly one terminal outcome must be published")
+	assert.Equal(t, batchID.String(), failed[0].MessageId)
+	assert.Equal(t, domain, failed[0].Domain)
+	assert.Equal(t, email, failed[0].Email)
+	require.NotNil(t, failed[0].Timestamp)
+
+	data := failed[0].Data.GetFailed()
+	require.NotNil(t, data, "the stat must carry typed Failed data")
+	assert.Equal(t, reasonBudgetSpentDispatching, data.Reason)
+
+	// The reason is customer-visible through the stats API, so it may state what
+	// ran out and on which leg and nothing else — no raw error, no address, no
+	// database detail.
+	assert.NotContains(t, data.Reason, email)
+	assert.NotContains(t, data.Reason, domain)
+
+	assert.Empty(t, pub.statsOn(t, "kannon.sending"),
+		"no Envelope was ever built, so none may have been published")
+}
+
+// TestParseErrors_RetryBudgetSpent_FailsTheDelivery pins the second path into
+// the same chokepoint. An error stat is the transient send signal, and the
+// Delivery it names is normally rescheduled; when the budget has no room left it
+// must be terminated instead, and the returned error must stay nil so the
+// consumer acks the stat rather than redelivering it for ever.
+func TestParseErrors_RetryBudgetSpent_FailsTheDelivery(t *testing.T) {
+	ctx := t.Context()
+	batchID, domain := seedReclaimBatch(t)
+	email := "spent-on-send@" + domain
+
+	// A window narrower than the very first retry: this Delivery has no room
+	// left whatever its attempt count.
+	repo := sqlc.NewDeliveryRepository(testDB, delivery.DefaultBackoff, time.Nanosecond)
+	claimer := pool.NewClaimer(repo)
+	pub := &subjectPublisher{}
+	d := &disp{claimer: claimer, pub: pub}
+
+	claimForDispatch(t, repo, claimer, batchID, domain, email)
+
+	require.NoError(t, d.parseErrorsFunc(ctx, &statstypes.Stats{
+		MessageId: batchID.String(),
+		Domain:    domain,
+		Email:     email,
+		Data: &statstypes.StatsData{
+			Data: &statstypes.StatsData_Error{
+				Error: &statstypes.StatsDataError{Code: 421, Msg: "connection reset"},
+			},
+		},
+	}))
+
+	assert.False(t, poolRowExists(t, batchID, email),
+		"a Delivery whose Retry Budget is spent must be dropped, not rescheduled")
+
+	failed := pub.statsOn(t, "kannon.stats.failed")
+	require.Len(t, failed, 1)
+	assert.Equal(t, reasonBudgetSpentSending, failed[0].Data.GetFailed().Reason)
+	assert.NotContains(t, failed[0].Data.GetFailed().Reason, "connection reset",
+		"the reason must not carry the raw error it was handed")
+}
+
+// scheduleValidated puts one Delivery in the Pool ready for the Dispatcher to
+// claim itself — scheduled in the past, and validated. Unlike claimForDispatch
+// it stops short of the claim, because these tests exercise the real
+// DispatchCycle, which claims.
+func scheduleValidated(t *testing.T, repo delivery.Repository, claimer pool.Claimer, batchID batch.ID, domain, email string) {
+	t.Helper()
+	ctx := t.Context()
+
+	dlv, err := delivery.New(delivery.NewParams{
+		BatchID:       batchID,
+		Email:         email,
+		Fields:        map[string]string{"name": "X"},
+		Domain:        domain,
+		ScheduledTime: time.Now().UTC().Add(-time.Minute),
+	})
+	require.NoError(t, err)
+	require.NoError(t, repo.Schedule(ctx, dlv))
+	require.NoError(t, claimer.MarkValidated(ctx, dlv))
+}
+
+func poolRowExists(t *testing.T, batchID batch.ID, email string) bool {
+	t.Helper()
+	var n int
+	require.NoError(t, testDB.QueryRow(t.Context(),
+		`SELECT count(*) FROM sending_pool_emails WHERE message_id = $1 AND email = $2`,
+		batchID.String(), email).Scan(&n))
+	return n > 0
+}

--- a/pkg/smtpsender/smtpsender.go
+++ b/pkg/smtpsender/smtpsender.go
@@ -227,6 +227,16 @@ func (s *smtpSender) handleSendError(sendErr smtp.SenderError, data *msgtypes.Em
 		Timestamp: timestamppb.Now(),
 	}
 	if !data.ShouldRetry || sendErr.IsPermanent() {
+		// Permanent below still reads sendErr.IsPermanent(), not the reason
+		// this branch was taken: a 4xx that lands here because ShouldRetry
+		// is already false is terminal for us, but it is not evidence the
+		// address is dead, and Bounced.Permanent tracks the SMTP reply
+		// class, never the retry decision. #378 read this as the wrong flag
+		// at retry exhaustion; #433 re-specified `permanent` to follow the
+		// reply class on both the synchronous and asynchronous path
+		// (CONTEXT.md, Bounced), which is exactly what this line already
+		// did. "Fixing" it would regress the async 4xx assertions in
+		// e2e/e2e_test.go.
 		msg.Data = &statstypes.StatsData{
 			Data: &statstypes.StatsData_Bounced{
 				Bounced: &statstypes.StatsDataBounced{

--- a/pkg/smtpsender/smtpsender_test.go
+++ b/pkg/smtpsender/smtpsender_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kannon-email/kannon/internal/tests"
 	"github.com/kannon-email/kannon/internal/utils"
 	msgtypes "github.com/kannon-email/kannon/proto/kannon/mailer/types"
+	statstypes "github.com/kannon-email/kannon/proto/kannon/stats/types"
 	"github.com/nats-io/nats.go/jetstream"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -124,6 +125,105 @@ func TestShortAckDeadlineRedeliversButDoesNotResend(t *testing.T) {
 	assert.Equal(t, []string{"kannon.stats.delivered"}, pub.subjects())
 }
 
+// TestHandleSendErrorClassifiesByReplyClassNotByRetryDecision is the
+// synchronous mirror of the asynchronous DSN assertion in
+// e2e/e2e_test.go:testAsyncSoftBounce (~line 711): Bounced.Permanent must
+// track the SMTP reply class, never the reason handleSendError took the
+// Bounced branch in the first place.
+//
+// #378 read the line `Permanent: sendErr.IsPermanent()` at retry exhaustion
+// as the wrong flag — "it should be true, we gave up". #433 re-specified
+// `permanent` to follow the reply class on both the synchronous and the
+// asynchronous path (CONTEXT.md, Bounced), which is exactly what the code
+// already did: a transient (4xx) reply stays non-permanent even once
+// ShouldRetry is false, and a permanent (5xx) reply is permanent regardless
+// of ShouldRetry. This test pins that mapping down so it cannot be "fixed"
+// into a regression again.
+func TestHandleSendErrorClassifiesByReplyClassNotByRetryDecision(t *testing.T) {
+	tests := []struct {
+		name          string
+		shouldRetry   bool
+		sendErr       *fakeSenderError
+		wantSubject   string
+		wantPermanent bool
+	}{
+		{
+			name:          "retries exhausted, transient (4xx) reply publishes Bounced with permanent=false",
+			shouldRetry:   false,
+			sendErr:       &fakeSenderError{msg: "451 try again later", permanent: false, code: 451},
+			wantSubject:   "kannon.stats.bounced",
+			wantPermanent: false,
+		},
+		{
+			name:          "retries exhausted, permanent (5xx) reply publishes Bounced with permanent=true",
+			shouldRetry:   false,
+			sendErr:       &fakeSenderError{msg: "550 no such user", permanent: true, code: 550},
+			wantSubject:   "kannon.stats.bounced",
+			wantPermanent: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pub := &recordingPublisher{}
+			s := &smtpSender{publisher: pub}
+
+			data := envelope("bounce@example.com")
+			data.ShouldRetry = tt.shouldRetry
+
+			require.NoError(t, s.handleSendError(tt.sendErr, data))
+
+			require.Equal(t, []string{tt.wantSubject}, pub.subjects())
+			published := pub.stats(t)
+			require.Len(t, published, 1)
+
+			bounced := published[0].Data.GetBounced()
+			require.NotNil(t, bounced, "expected a typed Bounced payload")
+			assert.Equal(t, tt.wantPermanent, bounced.Permanent)
+			assert.EqualValues(t, tt.sendErr.code, bounced.Code)
+			assert.Equal(t, tt.sendErr.msg, bounced.Msg)
+		})
+	}
+}
+
+// TestHandleSendErrorWithRetriesRemainingPublishesError contrasts the
+// exhausted-retries cases above: a transient reply with retries still
+// available must publish the internal Error retry signal, not a Bounced
+// outcome — Bounced is reserved for a Delivery that is actually terminal.
+func TestHandleSendErrorWithRetriesRemainingPublishesError(t *testing.T) {
+	pub := &recordingPublisher{}
+	s := &smtpSender{publisher: pub}
+
+	sendErr := &fakeSenderError{msg: "451 try again later", permanent: false, code: 451}
+	data := envelope("retry@example.com")
+	data.ShouldRetry = true
+
+	require.NoError(t, s.handleSendError(sendErr, data))
+
+	require.Equal(t, []string{"kannon.stats.error"}, pub.subjects())
+	published := pub.stats(t)
+	require.Len(t, published, 1)
+
+	errData := published[0].Data.GetError()
+	require.NotNil(t, errData, "expected a typed Error payload")
+	assert.EqualValues(t, sendErr.code, errData.Code)
+	assert.Equal(t, sendErr.msg, errData.Msg)
+	assert.Nil(t, published[0].Data.GetBounced(), "a retryable transient failure must not be reported as Bounced")
+}
+
+// fakeSenderError is a local stand-in for smtp.SenderError: the concrete
+// smtpError type in internal/smtp is unexported, so a test outside that
+// package cannot construct one directly.
+type fakeSenderError struct {
+	msg       string
+	permanent bool
+	code      uint32
+}
+
+func (e *fakeSenderError) Error() string     { return e.msg }
+func (e *fakeSenderError) IsPermanent() bool { return e.permanent }
+func (e *fakeSenderError) Code() uint32      { return e.code }
+
 func mustSendingStream(ctx context.Context, t *testing.T, js jetstream.JetStream) {
 	t.Helper()
 	_, err := js.CreateOrUpdateStream(ctx, jetstream.StreamConfig{
@@ -208,12 +308,14 @@ func (s *blockingSender) Send(from, to string, body []byte) smtp.SenderError {
 type recordingPublisher struct {
 	mu   sync.Mutex
 	subj []string
+	data [][]byte
 }
 
-func (p *recordingPublisher) Publish(subj string, _ []byte) error {
+func (p *recordingPublisher) Publish(subj string, data []byte) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.subj = append(p.subj, subj)
+	p.data = append(p.data, data)
 	return nil
 }
 
@@ -221,6 +323,22 @@ func (p *recordingPublisher) subjects() []string {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	return append([]string(nil), p.subj...)
+}
+
+// stats unmarshals every payload published so far, in publish order, so a
+// test can assert on the typed StatsData a subject carried rather than only
+// on the subject it was published to.
+func (p *recordingPublisher) stats(t *testing.T) []*statstypes.Stats {
+	t.Helper()
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	out := make([]*statstypes.Stats, len(p.data))
+	for i, d := range p.data {
+		s := &statstypes.Stats{}
+		require.NoError(t, proto.Unmarshal(d, s))
+		out[i] = s
+	}
+	return out
 }
 
 // countingGuard counts how many deliveries reached the guard, which is how a

--- a/pkg/validator/reclaim.go
+++ b/pkg/validator/reclaim.go
@@ -1,0 +1,51 @@
+package validator
+
+import (
+	"context"
+	"time"
+
+	"github.com/kannon-email/kannon/internal/delivery"
+	"github.com/kannon-email/kannon/internal/pool"
+)
+
+// The Validator's reclaim of the Deliveries stranded in 'validating' (CONTEXT.md,
+// *Reclaim*).
+//
+// pool.Reclaimer is the mechanism; what belongs here is the decision to run it
+// and the two things only the Validator can explain — how long a claim of
+// 'validating' may live, and why taking one back must not spend a send attempt.
+// The Validator reclaims that status itself for the same reason the Dispatcher
+// reclaims its own: nothing else writes 'validating'. The rule is spelled out on
+// pool.Reclaimer (ADR 0004 §"Why not the Pool", ADR 0007).
+
+// validatingStrandThreshold is how long a Delivery may sit claimed for
+// validation before the Validator takes it back. The whole validation cycle is
+// bounded at ten seconds, so a row a few minutes old is stuck — two orders of
+// magnitude below the dispatch threshold, because so is the plausible time in
+// flight.
+const validatingStrandThreshold = 5 * time.Minute
+
+// reclaimer binds the shared mechanism to the one status the Validator owns.
+//
+// A reclaim from 'validating' leaves the attempt counter alone (internal/db,
+// reclaimTargets): it is not a send attempt, and bumping it would silently
+// advance the backoff curve of a Delivery that has never been near an MX. A row
+// that permanently strands here has no per-row cause — the Validator either
+// passes an address or Drops it as Rejected — so the cause is always
+// infrastructural, always transient, and looping is the correct behaviour
+// (ADR 0007).
+func (v *Validator) reclaimer() pool.Reclaimer {
+	return pool.NewReclaimer(v.claimer, v.log(), delivery.InFlightForValidation, validatingStrandThreshold)
+}
+
+// ReclaimCycle hands every Delivery that has been claimed for validation for
+// longer than validatingStrandThreshold back to the Pool, and reports what it
+// took back.
+func (v *Validator) ReclaimCycle(ctx context.Context) error {
+	return v.reclaimer().Cycle(ctx)
+}
+
+// reclaimLoop is the loop body wired into the validator's run loop.
+func (v *Validator) reclaimLoop(ctx context.Context) error {
+	return v.reclaimer().Loop(ctx)
+}

--- a/pkg/validator/reclaim_test.go
+++ b/pkg/validator/reclaim_test.go
@@ -1,0 +1,147 @@
+package validator_test
+
+// Reclaiming Deliveries stranded in 'validating' (#378, ADR 0007).
+//
+// Drives the REAL Validator.ReclaimCycle + REAL pool.Claimer + REAL Postgres
+// (dockertest, via the TestMain in validator_test.go). The fixture rows are
+// deleted again: the pool is shared with every other test in this package.
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kannon-email/kannon/internal/batch"
+	sqlc "github.com/kannon-email/kannon/internal/db"
+	"github.com/kannon-email/kannon/internal/delivery"
+	"github.com/kannon-email/kannon/internal/pool"
+)
+
+// strandedValidatingFor is comfortably past the Validator's threshold. The
+// whole validation cycle is bounded at ten seconds, so a row this old is stuck
+// by definition.
+const strandedValidatingFor = 10 * time.Minute
+
+// TestReclaimCycle_ValidatingStrandedPastThreshold_ReturnsToPoolWithoutAttemptBump
+// pins both halves of the Validator's reclaim.
+//
+// The recovery: a Delivery claimed into 'validating' by a worker that then died
+// has no other way out — nothing else writes that status — so it never reaches
+// the Dispatcher at all.
+//
+// And the bump that must NOT happen: a reclaim from 'validating' is not a send
+// attempt. Bumping the counter would silently advance the backoff curve for a
+// Delivery that has never been near an MX. A permanently stranding 'validating'
+// row also has no per-row cause — the Validator either passes an address or
+// Drops it as Rejected — so the condition is always infrastructural and always
+// transient, and looping there is the correct behaviour.
+func TestReclaimCycle_ValidatingStrandedPastThreshold_ReturnsToPoolWithoutAttemptBump(t *testing.T) {
+	ctx := t.Context()
+	batchID, domain := seedReclaimBatch(t)
+
+	repo := sqlc.NewDeliveryRepository(db, delivery.DefaultBackoff, delivery.DefaultRetryWindow)
+	claimer := pool.NewClaimer(repo)
+
+	email := "stranded@" + domain
+	claimForValidation(t, repo, claimer, batchID, domain, email)
+	backdateClaim(t, batchID, email, strandedValidatingFor)
+
+	require.NoError(t, vt.ReclaimCycle(ctx))
+
+	got := poolRow(t, batchID, email)
+	assert.Equal(t, sqlc.SendingPoolStatusToValidate, got.Status,
+		"a Delivery stranded in 'validating' past the threshold must be handed back to the pool")
+	assert.EqualValues(t, 0, got.SendAttemptsCnt,
+		"a validating reclaim is not a send attempt and must not advance the backoff curve")
+	assert.False(t, got.ClaimedAt.Valid,
+		"a Delivery that is no longer in flight must not claim to be: claimed_at is cleared")
+}
+
+// seedReclaimBatch seeds the Batch row that sending_pool_emails' foreign key
+// needs, plus the Domain that owns it, and removes both afterwards.
+func seedReclaimBatch(t *testing.T) (batch.ID, string) {
+	t.Helper()
+	ctx := t.Context()
+
+	domain := fmt.Sprintf("reclaim-%d.test", time.Now().UnixNano())
+	_, err := q.CreateDomain(ctx, sqlc.CreateDomainParams{
+		Domain:         domain,
+		DkimPrivateKey: "test-private",
+		DkimPublicKey:  "test-public",
+	})
+	require.NoError(t, err)
+
+	b, err := batch.New(batch.NewParams{
+		Domain:      domain,
+		Subject:     "reclaim",
+		Sender:      batch.Sender{Email: "noreply@" + domain, Alias: "Reclaim"},
+		TemplateID:  "tpl_reclaim@" + domain,
+		Attachments: batch.Attachments{},
+	})
+	require.NoError(t, err)
+	require.NoError(t, sqlc.NewBatchRepository(db).Create(ctx, b))
+
+	// context.Background(), not t.Context(): the test's context is cancelled
+	// before Cleanup runs, and a fixture row left behind here is picked up by
+	// the next Validator cycle of another test in this package.
+	t.Cleanup(func() {
+		cleanupCtx := context.Background()
+		//nolint:errcheck // best-effort test cleanup
+		db.Exec(cleanupCtx, "DELETE FROM sending_pool_emails WHERE domain = $1", domain)
+		//nolint:errcheck // best-effort test cleanup
+		db.Exec(cleanupCtx, "DELETE FROM messages WHERE domain = $1", domain)
+		//nolint:errcheck // best-effort test cleanup
+		db.Exec(cleanupCtx, "DELETE FROM domains WHERE domain = $1", domain)
+	})
+
+	return b.ID(), domain
+}
+
+// claimForValidation takes one Delivery through the real claim path, so the row
+// under test carries exactly the state a live validation leaves behind.
+func claimForValidation(t *testing.T, repo delivery.Repository, claimer pool.Claimer, batchID batch.ID, domain, email string) {
+	t.Helper()
+	ctx := t.Context()
+
+	dlv, err := delivery.New(delivery.NewParams{
+		BatchID:       batchID,
+		Email:         email,
+		Fields:        map[string]string{"name": "X"},
+		Domain:        domain,
+		ScheduledTime: time.Now().UTC().Add(-time.Minute),
+		Backoff:       delivery.DefaultBackoff,
+	})
+	require.NoError(t, err)
+	require.NoError(t, repo.Schedule(ctx, dlv))
+
+	_, err = claimer.ClaimForValidation(ctx, 100)
+	require.NoError(t, err)
+	require.Equal(t, sqlc.SendingPoolStatusValidating, poolRow(t, batchID, email).Status,
+		"fixture precondition: the delivery must be claimed for validation")
+}
+
+// backdateClaim rewrites claimed_at to `age` ago, standing in for a claim taken
+// that long before now.
+func backdateClaim(t *testing.T, batchID batch.ID, email string, age time.Duration) {
+	t.Helper()
+	_, err := db.Exec(t.Context(),
+		`UPDATE sending_pool_emails
+		    SET claimed_at = NOW() - make_interval(secs => $1)
+		  WHERE message_id = $2 AND email = $3`,
+		age.Seconds(), batchID.String(), email)
+	require.NoError(t, err)
+}
+
+func poolRow(t *testing.T, batchID batch.ID, email string) sqlc.SendingPoolEmail {
+	t.Helper()
+	row, err := q.GetPool(t.Context(), sqlc.GetPoolParams{
+		Email:     email,
+		MessageID: batchID.String(),
+	})
+	require.NoError(t, err)
+	return row
+}

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -16,6 +16,7 @@ import (
 	"github.com/kannon-email/kannon/internal/runner"
 	"github.com/kannon-email/kannon/proto/kannon/stats/types"
 	"github.com/kannon-email/kannon/x/container"
+	"golang.org/x/sync/errgroup"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -41,7 +42,7 @@ func New(cnt *container.Container) container.Runnable {
 	return container.Runnable{
 		Name: "validator",
 		Run: func(ctx context.Context) error {
-			claimer := pool.NewClaimer(sqlc.NewDeliveryRepository(cnt.DB(), cnt.BackoffPolicy()))
+			claimer := pool.NewClaimer(sqlc.NewDeliveryRepository(cnt.DB(), cnt.BackoffPolicy(), cnt.RetryWindow()))
 
 			v := Validator{
 				claimer: claimer,
@@ -50,7 +51,17 @@ func New(cnt *container.Container) container.Runnable {
 
 			v.log().Info("🚀 Starting validator")
 
-			return runner.Run(ctx, v.Cycle, runner.WaitLoop(1*time.Second))
+			eg, ctx := errgroup.WithContext(ctx)
+
+			eg.Go(func() error {
+				return runner.Run(ctx, v.Cycle, runner.WaitLoop(1*time.Second))
+			})
+
+			eg.Go(func() error {
+				return runner.Run(ctx, v.reclaimLoop, runner.WaitLoop(pool.ReclaimInterval))
+			})
+
+			return eg.Wait()
 		},
 	}
 }

--- a/pkg/validator/validator_test.go
+++ b/pkg/validator/validator_test.go
@@ -45,10 +45,10 @@ func TestMain(m *testing.M) {
 	}
 
 	q = sqlc.New(db)
-	claimer := pool.NewClaimer(sqlc.NewDeliveryRepository(db, delivery.DefaultBackoff))
+	claimer := pool.NewClaimer(sqlc.NewDeliveryRepository(db, delivery.DefaultBackoff, delivery.DefaultRetryWindow))
 	vt = validator.NewValidator(claimer, &mp)
 
-	ts = mailapi.NewMailerAPIV1(db, delivery.DefaultBackoff)
+	ts = mailapi.NewMailerAPIV1(db, delivery.DefaultBackoff, delivery.DefaultRetryWindow)
 	adminAPI = adminapi.CreateAdminAPIService(db)
 
 	code := m.Run()

--- a/proto/kannon/stats/types/stats.pb.go
+++ b/proto/kannon/stats/types/stats.pb.go
@@ -474,8 +474,12 @@ func (*StatsDataDelivered) Descriptor() ([]byte, []int) {
 	return file_kannon_stats_types_stats_proto_rawDescGZIP(), []int{5}
 }
 
+// Failed is a Delivery whose retry budget ran out without a single attempt
+// ever being answered, so there is no reply to classify: deliberately no
+// `code`, only a `reason`, like Rejected.
 type StatsDataFailed struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
+	Reason        string                 `protobuf:"bytes,1,opt,name=reason,proto3" json:"reason,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -508,6 +512,13 @@ func (x *StatsDataFailed) ProtoReflect() protoreflect.Message {
 // Deprecated: Use StatsDataFailed.ProtoReflect.Descriptor instead.
 func (*StatsDataFailed) Descriptor() ([]byte, []int) {
 	return file_kannon_stats_types_stats_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *StatsDataFailed) GetReason() string {
+	if x != nil {
+		return x.Reason
+	}
+	return ""
 }
 
 type StatsDataBounced struct {
@@ -765,8 +776,9 @@ const file_kannon_stats_types_stats_proto_rawDesc = "" +
 	"\x11StatsDataAccepted\"+\n" +
 	"\x11StatsDataRejected\x12\x16\n" +
 	"\x06reason\x18\x01 \x01(\tR\x06reason\"\x14\n" +
-	"\x12StatsDataDelivered\"\x11\n" +
-	"\x0fStatsDataFailed\"V\n" +
+	"\x12StatsDataDelivered\")\n" +
+	"\x0fStatsDataFailed\x12\x16\n" +
+	"\x06reason\x18\x01 \x01(\tR\x06reason\"V\n" +
 	"\x10StatsDataBounced\x12\x1c\n" +
 	"\tpermanent\x18\x01 \x01(\bR\tpermanent\x12\x12\n" +
 	"\x04code\x18\x02 \x01(\rR\x04code\x12\x10\n" +

--- a/sqlc.yaml
+++ b/sqlc.yaml
@@ -13,6 +13,7 @@ sql:
         emit_exact_table_names: false
         emit_empty_slices: false
         emit_json_tags: false
+        omit_unused_structs: true
         overrides:
           - column: "sending_pool_emails.fields"
             go_type:

--- a/x/container/container.go
+++ b/x/container/container.go
@@ -32,6 +32,7 @@ type Container struct {
 	senderHostname  string
 	demoSender      bool
 	backoff         delivery.BackoffPolicy
+	retryWindow     time.Duration
 
 	// singleton instances
 	db                 *singleton[*pgxpool.Pool]
@@ -69,6 +70,7 @@ func New(ctx context.Context) *Container {
 		senderHostname:     sc.Hostname,
 		demoSender:         sc.DemoSender,
 		backoff:            delivery.DefaultBackoff,
+		retryWindow:        delivery.DefaultRetryWindow,
 		db:                 &singleton[*pgxpool.Pool]{},
 		nats:               &singleton[*nats.Conn]{},
 		embeddedNatsServer: &singleton[*server.Server]{},
@@ -96,6 +98,14 @@ func WithBackoff(p delivery.BackoffPolicy) TestOption {
 	return func(c *Container) { c.backoff = p }
 }
 
+// WithRetryWindow overrides the Retry Budget. Tests shrink it in step with
+// WithBackoff — the window has to be scaled by the same factor as the backoff
+// base, or a collapsed curve would race through the whole budget in
+// milliseconds and terminate every Delivery in the suite.
+func WithRetryWindow(w time.Duration) TestOption {
+	return func(c *Container) { c.retryWindow = w }
+}
+
 // NewForTest builds a Container without reading viper, applying the supplied
 // options. Tests use this to wire a synthetic container without inventing
 // per-package backdoors.
@@ -103,6 +113,7 @@ func NewForTest(ctx context.Context, opts ...TestOption) *Container {
 	c := &Container{
 		ctx:                ctx,
 		backoff:            delivery.DefaultBackoff,
+		retryWindow:        delivery.DefaultRetryWindow,
 		db:                 &singleton[*pgxpool.Pool]{},
 		nats:               &singleton[*nats.Conn]{},
 		embeddedNatsServer: &singleton[*server.Server]{},
@@ -296,6 +307,18 @@ func (c *Container) NatsJetStream() jetstream.JetStream {
 // Production uses delivery.DefaultBackoff; tests may override via WithBackoff.
 func (c *Container) BackoffPolicy() delivery.BackoffPolicy {
 	return c.backoff
+}
+
+// RetryWindow returns the canonical Retry Budget for this Container: how long
+// Kannon keeps trying to get a Delivery out, counted from the moment its Batch
+// asked for it to be sent. Production uses delivery.DefaultRetryWindow; tests
+// may override via WithRetryWindow.
+//
+// It travels with BackoffPolicy because the two are inseparable — the window
+// bounds the very curve the policy draws — and, like it, is a wiring point
+// rather than a viper key (ADR 0007, ADR 0001 §"No viper key").
+func (c *Container) RetryWindow() time.Duration {
+	return c.retryWindow
 }
 
 func (c *Container) Sender() smtp.Sender {


### PR DESCRIPTION
**What this PR does / why we need it**:

Implements the three parts of #378 as respecified there, with [ADR 0007](../blob/fix/378-bound-the-retry-path/docs/adr/0007-how-a-delivery-stops-being-tried.md) as the accepted design and the **Retry Budget**, **Failed** and **Reclaim** entries in `CONTEXT.md` as the vocabulary.

**A Delivery no answer ever came back for is `Failed`** — not Bounced, not Rejected. A Bounce always carries a reply code, because a Bounce is a remote mail system having spoken, so `StatsDataFailed` deliberately carries a `reason` and no `code`. The wire slot has existed unemitted since the proto was written, so nothing is wire-breaking and there is no migration for it: the Stats worker consumes the `kannon.stats.*` wildcard and `stats.type` is a varchar.

**The Retry Budget replaces `envelope.maxRetry = 10` with a span of time**, defaulting to 24h from the moment the Batch asked for the Delivery to be sent. One predicate on the entity, `Delivery.CanRetry`, now governs every retry, and both paths that hand a Delivery back to the Pool meet at one chokepoint that either reschedules or ends it as Failed. A span is indifferent to *what* consumed the attempts, so an outage of Kannon's own cannot spend a sender's chances of delivery. Under `DefaultBackoff` a 24h window admits exactly the retries the constant admitted — 17h04m inside, 34h08m outside — which is pinned by test rather than asserted in a comment. `ExponentialBackoff` still needs no maximum: the window makes the overflow unreachable by construction.

**`Reclaim` builds the half of ADR 0004 that was never built.** A `claimed_at` column plus a partial index let each claiming worker recover its own stranded rows — the Dispatcher past one hour, cited to `sendGuardTTL`; the Validator past five minutes. The threshold is measured from the claim and **never** from `scheduled_time`: the claim does not move that column, so under a backlog it is hours in the past on a row claimed one second ago, and reading it would reset live sends and duplicate them in bulk. That is the single most important assertion in the suite. A dispatch reclaim spends a send attempt, which is what makes a systematically stranding condition converge on termination through the Retry Budget; a validation reclaim does not, being no send attempt at all. A reclaim recovers and never terminates.

**The `permanent` flag was not broken.** #433 respecified it to follow the SMTP reply class on both the synchronous and asynchronous paths, which is what the code already did, so the fix #378 originally proposed would now be a regression against the e2e assertions. The line that reads like a bug now says why it is not, and a unit test pins it on the synchronous leg.

### Two incidental commits, kept separate

Since this is squash-merged, flagging them so they are not a surprise in the diff:

- `fix(db): strip psql meta-commands from the embedded schema dump` — modern `pg_dump` wraps its output in `\restrict` / `\unrestrict`, which dbmate keeps in the dump deliberately and strips on load. Kannon executes the embedded dump over pgx, so a meta-command reaching it fails **every** integration suite at once. Forced by this PR's migration; without it `db/schema.sql` would need hand-editing after every `dbmate dump`.
- `chore(db): stop generating models for transaction-scoped temp tables` — latent drift from `20260727071416`, whose `CREATE TEMP TABLE`s sqlc catalogued as real tables. Surfaced on this PR's regeneration.

### Verification

`go build`, `go vet`, `gofmt`, `go test ./... -short`, `go test ./e2e -race` (19 subtests) and `make lint` including the `deadcode` gate all pass.

### Notes for the reviewer

- The new e2e subtest's termination boundary falls at ~25.6s while `DispatchFailureRecovery` measures 10.3–11.2s: ~2.3× margin. The suite passed repeatedly, but that is where to look first if CI ever goes flaky here.
- «expose a count per status» is implemented as structured logs, since the repo has no first-party metrics dependency.
- `ReclaimStranded` has no entry in `repospec.go`: #378 explicitly specified the delivered integration-test style. Raised in review and consciously declined.
- The **out of scope** item — the missing foreign key on `messages.template_id`, which is the upstream cause — is deliberately untouched and wants its own issue.

**Which issue(s) this PR fixes**
Fixes #378