### PR TITLE
fix(config): let the file outrank the environment, and refuse a malformed reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ services:
 - `env://NAME` is required: a process whose variable is not set refuses to boot, naming both the key and the variable.
 - `env://NAME:-default` falls back, and treats a variable set to the empty string as unset — POSIX `${NAME:-default}`.
 - The reference must be the whole value: `https://env://HOST/v1` is left alone, and a literal is escaped as `\env://NAME`.
+- A misspelled reference is refused rather than taken literally: `env:/NAME`, `ENV://NAME`, `env://my-name` and `env://NAME:default` (the default is introduced by `:-`) all stop the boot with a message, instead of handing the code the text you wrote.
 
 That is what makes a single file describe a whole installation: every Deployment mounts the same ConfigMap and differs only in the variables it sets. See [`k8s/deployment.yaml`](k8s/deployment.yaml) and [`examples/docker-compose/kannon.yaml`](examples/docker-compose/kannon.yaml).
 
@@ -262,7 +263,9 @@ Both still work, both are deprecated, and neither has to be dropped in one go �
 | `K_DATABASE_URL=…` in the environment   | `database_url: env://K_DATABASE_URL` in the file           |
 | `K_API_ADMIN_TOKEN=…`                   | `api.admin_token: env://K_API_ADMIN_TOKEN`                 |
 
-The variable does not have to be renamed: the file can go on referring to whatever the deployment already sets. What changes is that the reference is written down, so which settings come from the environment is visible in one place — and it works for **every** key, where the `K_` prefix only ever reached the four top-level ones plus `K_API_ADMIN_TOKEN`. `K_API_PORT`, `K_SENDER_HOSTNAME` and `K_TRACKER_PORT` were silently ignored; Kannon now warns at startup about every `K_` variable it finds.
+The variable does not have to be renamed: the file can go on referring to whatever the deployment already sets. What changes is that the reference is written down, so which settings come from the environment is visible in one place — and it works for **every** key, where the `K_` prefix only ever reached the four top-level ones plus `K_API_ADMIN_TOKEN`. `K_API_PORT`, `K_SENDER_HOSTNAME` and `K_TRACKER_PORT` were silently ignored; Kannon warns at startup about every `K_` variable it finds and does not read.
+
+The file wins. A `K_` variable is a fallback for a key the file says nothing about, so once a key is written down — as a value or as a reference — a variable left behind in a manifest cannot override it, and the startup warning stops naming it.
 
 > **Deprecated aliases:** `run-verifier` continues to work as an alias for `run-validator`, `run-bounce` for `run-tracker`, and the `bump:` YAML section (plus the `K_BUMP_PORT` env var) for `tracker:`. They will be removed in a future major version.
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -30,3 +30,25 @@ func readConfig() (config.RootConfig, error) {
 
 	return cfg, nil
 }
+
+// readConfigAndServices is readConfig plus the section saying which components this
+// process is, for the commands that start components.
+//
+// The two live in one function because their order matters and is the cmd layer's
+// to get wrong: config.Read is what promotes the deprecated spellings, and two of
+// them — --run-bounce and --run-verifier — are keys config.LoadServices then reads.
+// Read the services first and those aliases are promoted too late, the registry
+// comes up empty, and the process exits as if it had been asked to run nothing.
+func readConfigAndServices() (config.RootConfig, config.Services, error) {
+	cfg, err := readConfig()
+	if err != nil {
+		return config.RootConfig{}, config.Services{}, err
+	}
+
+	services, err := config.LoadServices()
+	if err != nil {
+		return config.RootConfig{}, config.Services{}, err
+	}
+
+	return cfg, services, nil
+}

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -1,0 +1,44 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+// Regression: --run-bounce / --run-verifier are promoted onto their canonical names
+// by config.Read, and config.LoadServices is what reads those names. Asserted
+// through the cmd layer's own entry point, because the order of those two reads is
+// the cmd layer's to get wrong — and when it is wrong the alias fires too late,
+// nothing is registered, and the process exits immediately after logging
+// "Starting Kannon runnables: []".
+func TestReadConfigAndServices_PromotesDeprecatedAliasesFirst(t *testing.T) {
+	tests := []struct {
+		alias string
+		want  string
+	}{
+		{alias: "run-bounce", want: "tracker"},
+		{alias: "run-verifier", want: "validator"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.alias, func(t *testing.T) {
+			viper.Reset()
+			t.Cleanup(viper.Reset)
+			// The developer's own ~/.kannon.yaml is not part of this: readConfig
+			// reads whatever viper has been pointed at, and here that is nothing.
+			t.Setenv("HOME", t.TempDir())
+
+			viper.Set(tc.alias, true)
+
+			_, services, err := readConfigAndServices()
+			if err != nil {
+				t.Fatalf("readConfigAndServices: %v", err)
+			}
+
+			if got := services.Enabled(); len(got) != 1 || got[0] != tc.want {
+				t.Errorf("enabled services = %v, want [%s] after promoting %q", got, tc.want, tc.alias)
+			}
+		})
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -54,13 +54,7 @@ func Execute() error {
 }
 
 func run(cmd *cobra.Command, _ []string) {
-	cfg, err := readConfig()
-	if err != nil {
-		slog.Error("error in reading config", "err", err)
-		os.Exit(1)
-	}
-
-	services, err := config.LoadServices()
+	cfg, services, err := readConfigAndServices()
 	if err != nil {
 		slog.Error("error in reading config", "err", err)
 		os.Exit(1)
@@ -78,10 +72,24 @@ func run(cmd *cobra.Command, _ []string) {
 func bootstrap(cmd *cobra.Command, cfg config.RootConfig, services config.Services) error {
 	ctx := cmd.Context()
 
-	// Before anything starts, since this is a deployment mistake rather than a request-time
-	// refusal: a process serving the Admin and Stats APIs without their credential would come
-	// up healthy and answer every request with unauthenticated. It stops the whole boot — the
-	// workers included — because a Kannon half up hides the reason the API is unusable.
+	// Both refusals below are read off the `services` section and answered before anything is
+	// built. The container and every runnable read sections of their own, any of which may name a
+	// variable only some other pod sets, so a mistake in what this process was asked to be has to
+	// be reported before a section belonging to a component it does not even run can panic first.
+	//
+	// A process with nothing to run used to log "Starting Kannon runnables: []" and exit 0, which
+	// reads as a clean shutdown in every dashboard there is. The ways to arrive here are all
+	// mistakes: a `services` section nobody filled in, an enabling variable spelled one way in the
+	// file and another in the manifest.
+	if len(services.Enabled()) == 0 {
+		return errors.New("this process was asked to run nothing: enable at least one component " +
+			"under `services` in the config file, e.g. `services: {api: {enabled: true}}`")
+	}
+
+	// A deployment mistake rather than a request-time refusal: a process serving the Admin and
+	// Stats APIs without their credential would come up healthy and answer every request with
+	// unauthenticated. It stops the whole boot — the workers included — because a Kannon half up
+	// hides the reason the API is unusable.
 	if err := requireAdminToken(services); err != nil {
 		return err
 	}
@@ -118,15 +126,6 @@ func bootstrap(cmd *cobra.Command, cfg config.RootConfig, services config.Servic
 	}
 	if services.Audit.Enabled {
 		reg.Register(kaudit.New(cnt))
-	}
-
-	// A process with nothing to run used to log "Starting Kannon runnables: []" and exit 0,
-	// which reads as a clean shutdown in every dashboard there is. Refused instead, because
-	// the ways to arrive here are all mistakes: a `services` section nobody filled in, an
-	// enabling variable spelled one way in the file and another in the manifest.
-	if len(reg.Names()) == 0 {
-		return errors.New("this process was asked to run nothing: enable at least one component " +
-			"under `services` in the config file, e.g. `services: {api: {enabled: true}}`")
 	}
 
 	slog.Info(fmt.Sprintf("Starting Kannon runnables: %v", reg.Names()))
@@ -188,4 +187,10 @@ func createDeprecatedRunFlag(name, service string) {
 		slog.Error("cannot deprecate flag", "name", name, "err", err)
 		os.Exit(1)
 	}
+	// MarkDeprecated also hides the flag, and a deprecated flag has to stay
+	// discoverable for as long as it works: the whole migration story is moving one
+	// Deployment at a time, and an operator still on the old path must be able to
+	// read the spellings out of --help rather than out of a manifest they may no
+	// longer have.
+	flags.Lookup(name).Hidden = false
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -74,6 +74,30 @@ func TestRequireAdminToken(t *testing.T) {
 	}
 }
 
+// Every --run-* flag is deprecated and every one of them still works, so every one of them has to
+// stay in --help: pflag hides a flag when it is marked deprecated, and an operator migrating one
+// Deployment at a time needs to be able to read the spellings out of the binary.
+func TestDeprecatedRunFlagsStayVisible(t *testing.T) {
+	flags := rootCmd.PersistentFlags()
+
+	for _, name := range []string{
+		"run-sender", "run-dispatcher", "run-validator", "run-verifier",
+		"run-tracker", "run-bounce", "run-stats", "run-api", "run-smtp", "run-audit",
+	} {
+		flag := flags.Lookup(name)
+		if flag == nil {
+			t.Errorf("--%s is gone; it is deprecated, not removed", name)
+			continue
+		}
+		if flag.Deprecated == "" {
+			t.Errorf("--%s is not marked deprecated", name)
+		}
+		if flag.Hidden {
+			t.Errorf("--%s is hidden, so --help no longer names a flag that still works", name)
+		}
+	}
+}
+
 // A token an operator asked to come from a variable nobody set is refused the same way a missing
 // one is: what the API must never do is come up answering every admin request with unauthenticated.
 func TestRequireAdminTokenWithAnUnresolvableReference(t *testing.T) {

--- a/cmd/standalone.go
+++ b/cmd/standalone.go
@@ -24,6 +24,9 @@ func init() {
 }
 
 func runStandalone(cmd *cobra.Command, _ []string) {
+	// readConfig and not readConfigAndServices: this subcommand *is* every component,
+	// which is the whole of what it means, so nothing in the file or on the command
+	// line selects anything here.
 	cfg, err := readConfig()
 	if err != nil {
 		slog.Error("error in reading config", "err", err)

--- a/docs/adr/0011-the-config-file-is-the-contract-and-the-environment-is-referenced-from-it.md
+++ b/docs/adr/0011-the-config-file-is-the-contract-and-the-environment-is-referenced-from-it.md
@@ -58,6 +58,15 @@ is a hole in the deployment far more often than a considered value. The
 reference must span the whole leaf value, so a URL that happens to contain
 the scheme is untouched, and `\env://NAME` escapes a literal.
 
+A value that opens with the scheme and is not a well-formed reference —
+`env:/NAME`, `ENV://NAME`, `env://my-name`, `env://NAME:default` — is refused
+rather than passed through. Passing it through is the one failure this syntax
+cannot afford: the promise is that a variable nobody set stops the boot, and a
+reference nobody can parse would fail that promise open, silently, on
+`api.admin_token` above all — where a non-blank string is all the boot check
+asks for, so the text of the ConfigMap itself would have become the shared
+credential.
+
 This is a mapstructure decode hook (`x/config/envref`), so it applies to
 every unmarshal Kannon performs: nested keys included, which is the half
 viper could not do. Resolution is therefore the operator's decision and is
@@ -98,19 +107,37 @@ component, and nobody passes `--run-stats` meaning "not stats". OR-ing is
 what makes the migration free of order — an installation can move one
 Deployment at a time to the file while the rest still pass flags, with no
 combination that turns something off unexpectedly. pflag names the
-replacement the first time a flag is used.
+replacement the first time a flag is used, and the flags stay listed in
+`--help`: pflag hides what it marks deprecated, which would leave an operator
+in the middle of that migration unable to read the spellings out of the binary
+they are running.
 
-### The `K_` prefix stays, deprecated, and says so
+### The `K_` prefix stays, deprecated, and *below* the file
 
-The four keys it reached keep working, now bound explicitly so they survive
-being read through a struct. At startup Kannon warns once, naming **every**
-`K_` variable in the environment — not only the keys it reads, because a
-deployment carrying `K_TRACKER_PORT` has been setting nothing for as long as
-it has existed and its operator has no other way to find out.
+The five keys it reached — the four top-level ones and `api.admin_token` —
+keep working, and they are promoted onto their keys after the file is read,
+for the keys the file says nothing about.
 
-`api.admin_token` remains the one key read through viper's accessors rather
-than through a struct, so that `K_API_ADMIN_TOKEN` keeps working; the
-reference in the file is resolved for it by hand.
+Not `viper.BindEnv`, which is how this was first written and which inverts the
+very contract above: viper ranks the environment over the config file, so a
+`K_` variable left behind in a manifest beat the `env://` reference the file
+had just been migrated to name. An operator who moved `api.admin_token` into
+the file and rotated the Secret it names would have gone on authenticating
+callers with the credential they had just replaced, told only that some prefix
+was deprecated. So the deprecated variable is a fallback for what the file
+does not say, and nothing more.
+
+The promotion writes into viper's config layer with `MergeConfigMap`, not into
+its override layer with `Set`, because `api.admin_token` is nested — see the
+rejected alternative below, which is the same trap.
+
+At startup Kannon warns once, naming **every** `K_` variable in the
+environment — not only the keys it reads, because a deployment carrying
+`K_TRACKER_PORT` has been setting nothing for as long as it has existed and
+its operator has no other way to find out. Except the ones the file itself
+refers to: that operator has done what the warning asks, without even having
+to rename anything, and a warning they could never clear would teach them to
+ignore it.
 
 ### Reading configuration is one package
 
@@ -134,18 +161,37 @@ The root configuration is read once on the boot path and handed to
 `container.New`, so `database_url` and `nats_url` are reported as a message
 rather than a panic. Sections a runnable reads still panic, which is the
 existing contract for a malformed file, and the message names the key and the
-variable.
+variable — but only where the panic really does land on the boot path, which
+is a narrower place than it sounds. Two readers take the error instead
+(`config.TryLoadSection`, as `container.TryNats` takes the error where `Nats`
+exits):
+
+- The API resolves the `audit` section from inside its own runnable, where a
+  panic would be recovered by nobody and would end the process. An audit trail
+  Kannon cannot write must not be an outage for somebody's customers, so a
+  malformed `audit` section is logged and the API serves without it.
+- The container reads `sender` when something first asks for a sender rather
+  than when it is built, so `sender.hostname` — a reference only the sender
+  pods may set — cannot stop a dispatcher that never sends mail. The sender
+  runnable asks while it is being constructed, so for a pod that does send it
+  is still a boot failure.
+
+Refusals about what a process *is* come first, before anything is built: a
+`services` section that enables nothing, and an API without its credential.
+Otherwise a pod whose mistake is one line of `services` could be answered with
+a stack trace about a section belonging to a component it does not even run.
 
 `services.audit.enabled` and `audit.enabled` are two keys one letter apart in
 meaning, which is a naming cost this ADR accepts in exchange for not moving
 `audit.enabled` — a key already documented, already deployed, and already
 carrying a data-retention obligation.
 
-Nothing in Kannon reads a configuration value through `viper.Get*` any more,
-apart from the admin token: the hook only runs while something is being
-decoded, so an accessor added back for a key an operator may write a
-reference into would hand that reference to the code as a value. A test in
-`x/config/envref` pins that boundary down.
+Nothing in Kannon reads a configuration value through `viper.Get*` any more:
+the hook only runs while something is being decoded, so an accessor added back
+for a key an operator may write a reference into would hand that reference to
+the code as a value. A test in `x/config/envref` pins that boundary down. The
+accessors that remain read the deprecated flags and aliases — `run-stats`,
+`bump.port` — which are not values an operator can write a reference into.
 
 ## Rejected alternatives
 
@@ -160,7 +206,10 @@ resolved values, including `Get` — but `viper.Set` on a nested key puts a
 partial map in the override layer, and `UnmarshalKey` returns that layer
 alone rather than merging it, so promoting `api.admin_token` that way would
 cost the operator their `api.port`. The decode hook has no such reach into
-what it did not resolve.
+what it did not resolve. The same trap catches anything that writes a nested
+key at boot, which is why the deprecated promotions merge into the config
+layer instead: `bump.port` → `tracker.port` did use `Set`, and was harmless
+only for as long as `tracker` had exactly one key.
 
 **Binding every nested key to an environment variable by hand.** What viper
 asks for, and it is a list that has to be kept in step with every struct

--- a/internal/audit/config.go
+++ b/internal/audit/config.go
@@ -37,13 +37,27 @@ type Config struct {
 // LoadConfig reads the audit section, defaults filled in. Read here rather than by each runnable that
 // needs it — the producer and the consumer both do — so that the section name and the default cannot
 // come to be spelled two ways, for the same reason ConfigureStream holds the stream's configuration
-// once. It panics on a malformed section, as every other section read does, since that is the
-// operator's file being wrong and not a runtime condition.
+// once. It panics on a malformed section, as every other section read on the boot path does, since
+// that is the operator's file being wrong and not a runtime condition.
 func LoadConfig() Config {
-	var cfg Config
-	config.LoadSection(configKey, &cfg)
-	cfg.setDefaults()
+	cfg, err := TryLoadConfig()
+	if err != nil {
+		panic(err)
+	}
 	return cfg
+}
+
+// TryLoadConfig is LoadConfig for the reader that must not fail on it: the API resolves this section
+// from inside its own runnable, where the panic would land in a goroutine nobody recovers and take
+// the whole process down — over a feature whose entire promise is that an audit trail Kannon cannot
+// write is not an outage for somebody's customers.
+func TryLoadConfig() (Config, error) {
+	var cfg Config
+	if err := config.TryLoadSection(configKey, &cfg); err != nil {
+		return Config{}, err
+	}
+	cfg.setDefaults()
+	return cfg, nil
 }
 
 // setDefaults fills in what an operator left unset.

--- a/internal/audit/config_test.go
+++ b/internal/audit/config_test.go
@@ -1,0 +1,87 @@
+package audit
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+func TestTryLoadConfig(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+
+	t.Setenv("KANNON_TEST_AUDIT_RETENTION", "48h")
+	viper.Set("audit.enabled", true)
+	viper.Set("audit.retention", "env://KANNON_TEST_AUDIT_RETENTION")
+
+	cfg, err := TryLoadConfig()
+	if err != nil {
+		t.Fatalf("TryLoadConfig: %v", err)
+	}
+	if !cfg.Enabled {
+		t.Error("Enabled = false, want the configured value")
+	}
+	if cfg.Retention.Hours() != 48 {
+		t.Errorf("Retention = %v, want the referenced 48h", cfg.Retention)
+	}
+}
+
+func TestTryLoadConfig_DefaultRetention(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+
+	cfg, err := TryLoadConfig()
+	if err != nil {
+		t.Fatalf("TryLoadConfig: %v", err)
+	}
+	if cfg.Retention != DefaultRetention {
+		t.Errorf("Retention = %v, want %v", cfg.Retention, DefaultRetention)
+	}
+}
+
+// The reason TryLoadConfig exists: the API reads this section from inside its own
+// runnable's goroutine, so a section it cannot resolve has to come back as an error
+// it can log and step over. A panic there would be recovered by nobody, and an
+// audit trail Kannon cannot write would become an outage for somebody's customers.
+func TestTryLoadConfig_ReturnsAnErrorRatherThanPanicking(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("TryLoadConfig panicked instead of returning: %v", r)
+		}
+	}()
+
+	viper.Set("audit.retention", "env://KANNON_TEST_AUDIT_RETENTION_NOBODY_SET")
+
+	_, err := TryLoadConfig()
+	if err == nil {
+		t.Fatal("expected an error naming the variable")
+	}
+	if !strings.Contains(err.Error(), "KANNON_TEST_AUDIT_RETENTION_NOBODY_SET") {
+		t.Errorf("expected the error to name the variable, got %v", err)
+	}
+}
+
+// And LoadConfig keeps the boot path's contract, where the operator's file being
+// wrong should stop the process rather than yield a zero value.
+func TestLoadConfig_PanicsOnAnUnresolvableReference(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+
+	viper.Set("audit.retention", "env://KANNON_TEST_AUDIT_RETENTION_NOBODY_SET")
+
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected a panic naming the variable")
+		}
+		err, ok := r.(error)
+		if !ok || !strings.Contains(err.Error(), "KANNON_TEST_AUDIT_RETENTION_NOBODY_SET") {
+			t.Errorf("expected the panic to name the variable, got %v", r)
+		}
+	}()
+	LoadConfig()
+}

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -10,8 +10,10 @@ data:
   # when unset, `env://NAME:-default` falls back.
   #
   # That is what lets a Deployment per component share this ConfigMap and differ
-  # only in the KANNON_ENABLE_* variables it sets. This example runs every
-  # component in one pod, so it enables them all with a default of true.
+  # only in the KANNON_ENABLE_* variables it sets. Every one of them defaults to
+  # false, which is what makes that possible: a pod that names its own component
+  # gets that component and nothing else. The Deployment below runs the whole of
+  # Kannon in one pod, and says so by enabling each of them explicitly.
   config.yaml: |
     database_url: env://KANNON_DATABASE_URL
     nats_url: env://KANNON_NATS_URL:-nats://nats:4222
@@ -19,19 +21,19 @@ data:
 
     services:
       api:
-        enabled: env://KANNON_ENABLE_API:-true
+        enabled: env://KANNON_ENABLE_API:-false
       smtp:
-        enabled: env://KANNON_ENABLE_SMTP:-true
+        enabled: env://KANNON_ENABLE_SMTP:-false
       sender:
-        enabled: env://KANNON_ENABLE_SENDER:-true
+        enabled: env://KANNON_ENABLE_SENDER:-false
       dispatcher:
-        enabled: env://KANNON_ENABLE_DISPATCHER:-true
+        enabled: env://KANNON_ENABLE_DISPATCHER:-false
       validator:
-        enabled: env://KANNON_ENABLE_VALIDATOR:-true
+        enabled: env://KANNON_ENABLE_VALIDATOR:-false
       tracker:
-        enabled: env://KANNON_ENABLE_TRACKER:-true
+        enabled: env://KANNON_ENABLE_TRACKER:-false
       stats:
-        enabled: env://KANNON_ENABLE_STATS:-true
+        enabled: env://KANNON_ENABLE_STATS:-false
       # The writer of the authorization register. On its own it collects nothing:
       # the decisions are published only when `audit.enabled` is set, so this and
       # that key are two halves of one switch. Both are off by default because an
@@ -77,13 +79,34 @@ spec:
           imagePullPolicy: Always
           args: ['--config', '/etc/kannon/config.yaml']
           env:
+            # What this pod is. Split the components across Deployments by copying
+            # this list into each of them and keeping only the components that pod
+            # runs — the ConfigMap above is mounted unchanged by all of them.
+            - name: KANNON_ENABLE_API
+              value: 'true'
+            - name: KANNON_ENABLE_SMTP
+              value: 'true'
+            - name: KANNON_ENABLE_SENDER
+              value: 'true'
+            - name: KANNON_ENABLE_DISPATCHER
+              value: 'true'
+            - name: KANNON_ENABLE_VALIDATOR
+              value: 'true'
+            - name: KANNON_ENABLE_TRACKER
+              value: 'true'
+            - name: KANNON_ENABLE_STATS
+              value: 'true'
             - name: KANNON_DATABASE_URL
               valueFrom:
                 secretKeyRef:
                   name: kannon-database
                   key: url
+            # Read only by a pod that sends, so a Deployment without
+            # KANNON_ENABLE_SENDER does not need to carry it.
             - name: KANNON_SENDER_HOSTNAME
               value: kannon.example.com
+            # Required by a pod serving the API, and by no other: give it to those
+            # Deployments alone (ADR 0009).
             - name: KANNON_ADMIN_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -42,17 +42,20 @@ func (c *Config) setDefaults() {
 // than let it come up and answer every request with unauthenticated (ADR 0009).
 func AdminToken() (admintoken.Token, error) {
 	raw, err := config.APIAdminToken()
-	if err == nil {
-		var t admintoken.Token
-		t, err = admintoken.Parse(raw)
-		if err == nil {
-			return t, nil
-		}
+	if err != nil {
+		return admintoken.Token{}, adminTokenError(err)
 	}
-	// One message for both halves — a token that could not be resolved and a
-	// token that is not one — because the operator's next move is the same, and
-	// it is to look at this key.
-	return admintoken.Token{}, fmt.Errorf(
+	token, err := admintoken.Parse(raw)
+	if err != nil {
+		return admintoken.Token{}, adminTokenError(err)
+	}
+	return token, nil
+}
+
+// adminTokenError is one message for both halves — a token that could not be resolved and a token
+// that is not one — because the operator's next move is the same, and it is to look at this key.
+func adminTokenError(err error) error {
+	return fmt.Errorf(
 		"the API needs an admin token to authenticate the Admin and Stats APIs: set %q in the config file, "+
 			"taking it from the environment as `admin_token: env://%s` if you would rather not write it there (%w)",
 		config.APIAdminTokenKey, config.APIAdminTokenEnvVar, err)
@@ -119,7 +122,15 @@ func run(ctx context.Context, config Config, cnt *container.Container) error {
 // Nothing here can fail the boot. An audit trail Kannon cannot write must not be an outage for
 // somebody's customers, so every failure below is reported and stepped over.
 func startAuditRecording(ctx context.Context, cnt *container.Container) authz.Recorder {
-	cfg := audit.LoadConfig()
+	// TryLoadConfig and not LoadConfig: this runs inside the API runnable's goroutine, where the
+	// panic a section read normally raises would be recovered by nobody and would end the process —
+	// an `audit.retention` naming a variable this pod does not set would stop the API from serving.
+	cfg, err := audit.TryLoadConfig()
+	if err != nil {
+		slog.Error("cannot read the audit configuration, so authorization decisions stay in the log "+
+			"rather than reaching the audit table; the API is serving regardless", "err", err)
+		return nil
+	}
 
 	if !cfg.Enabled {
 		return nil

--- a/x/config/config.go
+++ b/x/config/config.go
@@ -54,9 +54,13 @@ func Prepare(cfgFile string) {
 		if home, err := os.UserHomeDir(); err == nil {
 			viper.AddConfigPath(home)
 		} else {
-			// Not fatal: it only means there is no default file to find, and
-			// a deployment passing --config never wanted one.
-			slog.Debug("cannot locate the home directory, so no default config file will be read", "err", err)
+			// Not fatal — every setting can come from the environment — but not
+			// quiet either: this branch is only reached when no --config was
+			// given, so the process was meant to read a file and will now run on
+			// whatever the environment happens to hold. Warn and not Debug
+			// because Prepare runs before the file that could ask for debug
+			// logging has been read, so a Debug line here could never be seen.
+			slog.Warn("cannot locate the home directory and no --config was given, so no configuration file will be read", "err", err)
 		}
 	}
 
@@ -79,9 +83,11 @@ func Read() (RootConfig, error) {
 		}
 	}
 
-	// Before anything reads a key: a deprecated spelling has to have been
-	// promoted onto its canonical name by the time the first unmarshal runs.
+	// Before anything reads a key, and after the file has been read: a deprecated
+	// spelling has to have been promoted onto its canonical name by the time the
+	// first unmarshal runs, and promotion is what the file is allowed to override.
 	ApplyDeprecatedAliases()
+	promoteLegacyEnv()
 	warnLegacyEnvPrefix()
 
 	var cfg RootConfig
@@ -97,16 +103,36 @@ func Read() (RootConfig, error) {
 // key. This is how runnables read configuration, and a malformed value means the
 // operator's file is wrong, which must surface at boot rather than as zero
 // values.
+//
+// Only ever call this while the boot path is still running — from a runnable's
+// constructor, not from its Run — or the panic lands in a goroutine nobody
+// recovers and takes the whole process with it. TryLoadSection is for a reader
+// that has somewhere better to go.
 func LoadSection(key string, out any) {
-	if err := viper.UnmarshalKey(key, out, envref.Decoder()); err != nil {
-		panic(fmt.Errorf("config: failed to load config %q: %w", key, err))
+	if err := TryLoadSection(key, out); err != nil {
+		panic(err)
 	}
 }
+
+// TryLoadSection is LoadSection for a caller that must not fail on the operator's
+// mistake: a section belonging to a feature whose absence is not an outage, or one
+// read after the boot path is over. It stands to LoadSection as the container's
+// TryNats stands to Nats.
+func TryLoadSection(key string, out any) error {
+	if err := viper.UnmarshalKey(key, out, envref.Decoder()); err != nil {
+		return fmt.Errorf("config: failed to load config %q: %w", key, err)
+	}
+	return nil
+}
+
+// apiKey is the API runnable's section, named here because the admin token below
+// is read out of it and the two spellings must not drift.
+const apiKey = "api"
 
 // APIAdminTokenKey holds the credential that authenticates the Admin API and both Stats API
 // versions (ADR 0009). Exported because the operator has to be told which key to set when it is
 // missing, and a message naming a key the code does not read is worse than no message.
-const APIAdminTokenKey = "api.admin_token"
+const APIAdminTokenKey = apiKey + ".admin_token"
 
 // APIAdminTokenEnvVar is the deprecated K_ spelling of the same key, kept because it is what the
 // Kubernetes manifests of every existing deployment carry. The replacement is to name a variable
@@ -116,19 +142,19 @@ const APIAdminTokenEnvVar = legacyEnvPrefix + "_API_ADMIN_TOKEN"
 // APIAdminToken returns the configured admin credential, empty when none is set — the caller
 // decides what that means, which for the API runnable is a refusal to boot.
 //
-// Read key by key rather than through the "api" section's struct, which is the one place left doing
-// so. Two reasons, and they pull the same way: viper's Get consults the environment for a nested key
-// where UnmarshalKey does not, which is what keeps K_API_ADMIN_TOKEN working; and setting a nested
-// key through viper.Set would hide the rest of the section from UnmarshalKey, so a token promoted
-// that way would cost the operator their api.port. The reference in the file is resolved here by
-// hand for the same reason — the decode hook only runs while something is being decoded.
+// Read through the section, like every other key: the deprecated K_API_ADMIN_TOKEN is promoted onto
+// this key by Read, below the file rather than above it, so this key needs no binding of its own and
+// the reference an operator writes here is resolved by the same decode hook as everything else. It
+// used to be the one value read with viper.GetString and resolved by hand, which meant the one
+// credential in the system was also the one value the mechanism did not validate.
 func APIAdminToken() (string, error) {
-	// Bound here rather than in prepareLegacyEnv, and with the variable named rather than derived,
-	// so that this key answers the same in a process that only ever set an environment variable —
-	// which every deployment of Kannon written before the file could name its own variables is.
-	//nolint:errcheck
-	viper.BindEnv(APIAdminTokenKey, APIAdminTokenEnvVar)
-	return envref.Resolve(viper.GetString(APIAdminTokenKey))
+	var api struct {
+		AdminToken string `mapstructure:"admin_token"`
+	}
+	if err := TryLoadSection(apiKey, &api); err != nil {
+		return "", err
+	}
+	return api.AdminToken, nil
 }
 
 // errorOnUnknownKeys refuses a section carrying a key Kannon does not know. Off by default in

--- a/x/config/config_test.go
+++ b/x/config/config_test.go
@@ -30,6 +30,17 @@ func writeConfig(t *testing.T, yaml string) {
 	Prepare(path)
 }
 
+// prepareWithoutAConfigFile is Prepare("") — a process started with no --config —
+// with the home directory pointed at an empty one. Without that, viper searches
+// the developer's own $HOME and a ~/.kannon.yaml sitting there decides the result:
+// the same leakage from the machine running the tests that the environ hook exists
+// to keep out of the deprecation warning.
+func prepareWithoutAConfigFile(t *testing.T) {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+	Prepare("")
+}
+
 func TestLoadSection_HappyPath(t *testing.T) {
 	viper.Reset()
 	t.Cleanup(viper.Reset)
@@ -152,7 +163,7 @@ func TestRead_ToleratesAMissingFile(t *testing.T) {
 	viper.Reset()
 	t.Cleanup(viper.Reset)
 
-	Prepare("")
+	prepareWithoutAConfigFile(t)
 
 	if _, err := Read(); err != nil {
 		t.Fatalf("Read: %v", err)
@@ -183,7 +194,7 @@ func TestRead_HonoursTheDeprecatedEnvPrefix(t *testing.T) {
 	t.Setenv("K_DATABASE_URL", "postgres://legacy@db/kannon")
 	t.Setenv("K_USE_EMBEDDED_NATS", "true")
 
-	Prepare("")
+	prepareWithoutAConfigFile(t)
 
 	cfg, err := Read()
 	if err != nil {
@@ -195,6 +206,75 @@ func TestRead_HonoursTheDeprecatedEnvPrefix(t *testing.T) {
 	}
 	if !cfg.UseEmbeddedNats {
 		t.Error("UseEmbeddedNats = false, want the value of K_USE_EMBEDDED_NATS")
+	}
+}
+
+// And the file outranks it, which is the half viper's own precedence gets backwards:
+// the environment sits above the config file there, so a K_ variable left behind in
+// a manifest beat the reference the file had just been migrated to name. An operator
+// who moved the key into the file and rotated the Secret it names would have gone on
+// authenticating with the credential they had just replaced.
+func TestRead_TheFileOutranksTheDeprecatedEnvPrefix(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+
+	t.Setenv("K_DATABASE_URL", "postgres://stale@db/kannon")
+	t.Setenv(APIAdminTokenEnvVar, "stale-token")
+	t.Setenv("KANNON_ADMIN_TOKEN", "rotated-token")
+
+	writeConfig(t, `
+database_url: postgres://from-the-file/kannon
+api:
+  port: 50052
+  admin_token: env://KANNON_ADMIN_TOKEN
+`)
+
+	cfg, err := Read()
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if cfg.DatabaseURL != "postgres://from-the-file/kannon" {
+		t.Errorf("DatabaseURL = %q, want the value in the file", cfg.DatabaseURL)
+	}
+
+	token, err := APIAdminToken()
+	if err != nil {
+		t.Fatalf("APIAdminToken: %v", err)
+	}
+	if token != "rotated-token" {
+		t.Errorf("APIAdminToken() = %q, want the variable the file names", token)
+	}
+}
+
+// A promoted variable must not cost the operator the keys beside it. This is the
+// nested-Set trap: api.admin_token arriving through viper.Set would have replaced
+// the whole `api` map as far as the section read is concerned, and api.port with it.
+func TestRead_PromotingTheLegacyAdminTokenKeepsTheRestOfTheSection(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+
+	t.Setenv(APIAdminTokenEnvVar, "s3cr3t-from-env")
+
+	writeConfig(t, "api:\n  port: 50052\n")
+
+	if _, err := Read(); err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+
+	token, err := APIAdminToken()
+	if err != nil {
+		t.Fatalf("APIAdminToken: %v", err)
+	}
+	if token != "s3cr3t-from-env" {
+		t.Errorf("APIAdminToken() = %q, want the value of %s", token, APIAdminTokenEnvVar)
+	}
+
+	var api struct {
+		Port uint `mapstructure:"port"`
+	}
+	LoadSection("api", &api)
+	if api.Port != 50052 {
+		t.Errorf("api.port = %d, want the value in the file to survive the promotion", api.Port)
 	}
 }
 
@@ -260,13 +340,18 @@ func TestAPIAdminToken_ReportsAnUnresolvableReference(t *testing.T) {
 
 // The deprecated environment spelling is what the Kubernetes manifests of every existing deployment
 // carry, and it is the one viper would otherwise lose: a nested key reached through UnmarshalKey
-// never consults the environment. Read with nothing else configured, the way a container running
-// only on env vars is.
+// never consults the environment. Read is what promotes it onto the key, so this goes through the
+// boot path with no file at all — the way a container running only on env vars is.
 func TestAPIAdminToken_FromTheDeprecatedEnvVar(t *testing.T) {
 	viper.Reset()
 	t.Cleanup(viper.Reset)
 
 	t.Setenv(APIAdminTokenEnvVar, "s3cr3t-from-env")
+
+	prepareWithoutAConfigFile(t)
+	if _, err := Read(); err != nil {
+		t.Fatalf("Read: %v", err)
+	}
 
 	got, err := APIAdminToken()
 	if err != nil {

--- a/x/config/deprecated.go
+++ b/x/config/deprecated.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/kannon-email/kannon/x/config/envref"
 	"github.com/spf13/viper"
 )
 
@@ -23,23 +24,66 @@ const legacyEnvPrefix = "K"
 
 // legacyEnvKeys are the keys a K_-prefixed variable has actually been able to
 // set, and which therefore have to keep working.
-//
-// They are bound explicitly, and not left to AutomaticEnv, because an unbound
-// variable is invisible to viper.Unmarshal: AllKeys lists the keys viper knows
-// about, and a variable nobody bound is not one of them. AutomaticEnv would still
-// answer a Get for these — it is the reason they worked at all — but the
-// configuration is read through structs now.
-var legacyEnvKeys = []string{"database_url", "nats_url", "use_embedded_nats", "debug"}
+var legacyEnvKeys = []string{"database_url", "nats_url", "use_embedded_nats", "debug", APIAdminTokenKey}
 
+// prepareLegacyEnv teaches viper the deprecated variable naming. It no longer
+// turns AutomaticEnv on, nor binds the keys above: both put the environment
+// *above* the configuration file, and promoteLegacyEnv puts it below. What is
+// left is what the one remaining binding — the `bump` section's port — needs to
+// derive its variable name from its key.
 func prepareLegacyEnv() {
 	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	viper.SetEnvPrefix(legacyEnvPrefix)
-	viper.AutomaticEnv()
+}
 
+// legacyEnvName is the deprecated environment spelling of a config key: the
+// prefix, then the key upper-cased with its separator replaced. The same
+// derivation viper's own BindEnv performs, written out because the promotion
+// below deliberately does not go through viper's environment layer.
+func legacyEnvName(key string) string {
+	return legacyEnvPrefix + "_" + strings.ToUpper(strings.ReplaceAll(key, ".", "_"))
+}
+
+// promoteLegacyEnv copies the deprecated K_ variables onto their keys — but only
+// the keys the configuration file says nothing about.
+//
+// viper.BindEnv is what this used to be, and it inverted the contract this whole
+// change exists to establish: viper ranks the environment above the file, so a
+// K_ variable left behind in a manifest beat the `env://` reference the file had
+// just been migrated to name. An operator who moved api.admin_token into the file
+// and rotated the Secret it names would have gone on authenticating callers with
+// the stale credential, told only that some prefix was deprecated. The file is
+// the contract; the deprecated variable is a fallback for what the file does not
+// say, and nothing more.
+func promoteLegacyEnv() {
 	for _, key := range legacyEnvKeys {
-		//nolint:errcheck
-		viper.BindEnv(key)
+		if viper.InConfig(key) {
+			continue
+		}
+		if value, ok := os.LookupEnv(legacyEnvName(key)); ok {
+			setNested(key, value)
+		}
 	}
+}
+
+// setNested writes value at a dotted key without hiding the keys beside it.
+//
+// viper.Set would: a nested Set puts a partial map in the override layer, and Get
+// answers from that layer alone rather than merging it, so
+// viper.Set("api.admin_token", …) costs the operator their api.port. That is the
+// trap ADR 0011 lists among its rejected alternatives, and the one this file used
+// to rely on being harmless because `tracker` happened to have exactly one key.
+// MergeConfigMap deep-merges into the config layer instead — which is also the
+// right precedence for a value standing in for something the file could have said
+// itself.
+func setNested(key string, value any) {
+	parts := strings.Split(key, ".")
+	nested := map[string]any{parts[len(parts)-1]: value}
+	for i := len(parts) - 2; i >= 0; i-- {
+		nested = map[string]any{parts[i]: nested}
+	}
+	//nolint:errcheck // MergeConfigMap returns nil on every path.
+	viper.MergeConfigMap(nested)
 }
 
 // warnLegacyEnvPrefix names every K_ variable in the environment, once, at boot.
@@ -48,12 +92,16 @@ func prepareLegacyEnv() {
 // K_TRACKER_PORT has been setting nothing for as long as it has existed, and the
 // operator has no way to tell from the outside. The replacement does not even ask
 // them to rename anything — the file can go on referring to the variable that is
-// already there.
+// already there — which is exactly why a variable the file does refer to is left
+// out of the warning: that operator has done what this message asks, and one that
+// went on firing afterwards could never be cleared.
 func warnLegacyEnvPrefix() {
+	referenced := referencedEnvNames()
+
 	var found []string
 	for _, entry := range environ() {
 		name, _, _ := strings.Cut(entry, "=")
-		if strings.HasPrefix(name, legacyEnvPrefix+"_") {
+		if strings.HasPrefix(name, legacyEnvPrefix+"_") && !referenced[name] {
 			found = append(found, name)
 		}
 	}
@@ -67,6 +115,34 @@ func warnLegacyEnvPrefix() {
 			"name the variable in the config file instead, e.g. `database_url: env://%s_DATABASE_URL`, "+
 			"which also works for the keys the prefix never reached",
 		legacyEnvPrefix, strings.Join(found, ", "), legacyEnvPrefix))
+}
+
+// referencedEnvNames collects every environment variable the configuration refers
+// to, at any depth, so that warnLegacyEnvPrefix can tell a variable an operator
+// has migrated to naming from one that is still setting nothing.
+func referencedEnvNames() map[string]bool {
+	names := map[string]bool{}
+
+	var walk func(value any)
+	walk = func(value any) {
+		switch v := value.(type) {
+		case string:
+			if name, ok := envref.Name(v); ok {
+				names[name] = true
+			}
+		case map[string]any:
+			for _, e := range v {
+				walk(e)
+			}
+		case []any:
+			for _, e := range v {
+				walk(e)
+			}
+		}
+	}
+	walk(viper.AllSettings())
+
+	return names
 }
 
 // ApplyDeprecatedAliases promotes deprecated config keys onto their canonical
@@ -110,7 +186,9 @@ func ApplyDeprecatedAliases() {
 			warnedSections[oldSection] = true
 		}
 		if !viper.IsSet(a.newKey) {
-			viper.Set(a.newKey, viper.Get(a.oldKey))
+			// setNested and not viper.Set: the canonical key is nested, and a
+			// nested Set would hide every sibling of it from the section read.
+			setNested(a.newKey, viper.Get(a.oldKey))
 		}
 	}
 }

--- a/x/config/deprecated_test.go
+++ b/x/config/deprecated_test.go
@@ -57,6 +57,36 @@ func TestApplyDeprecatedAliases_BumpPortDoesNotOverrideTracker(t *testing.T) {
 	}
 }
 
+// The promotion must not hide the keys beside the one it writes. `tracker` has a
+// single key today, which is the only reason a nested viper.Set was survivable
+// here: with a sibling in the file, the section read would have seen the promoted
+// map alone and lost it.
+func TestApplyDeprecatedAliases_BumpPortKeepsTheRestOfTheTrackerSection(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+
+	writeConfig(t, "bump:\n  port: 1234\ntracker:\n  base_url: https://stats.example.com\n")
+
+	if _, err := Read(); err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+
+	// base_url is not a key tracker has; it stands in for whichever second key it
+	// grows first, since that is the day this would otherwise start failing.
+	var tracker struct {
+		Port    int    `mapstructure:"port"`
+		BaseURL string `mapstructure:"base_url"`
+	}
+	LoadSection("tracker", &tracker)
+
+	if tracker.Port != 1234 {
+		t.Errorf("tracker.port = %d, want the promoted bump.port", tracker.Port)
+	}
+	if tracker.BaseURL != "https://stats.example.com" {
+		t.Errorf("tracker.base_url = %q, want the value in the file to survive the promotion", tracker.BaseURL)
+	}
+}
+
 func TestApplyDeprecatedAliases_NoOpWhenUnset(t *testing.T) {
 	viper.Reset()
 	t.Cleanup(viper.Reset)
@@ -95,6 +125,34 @@ func TestWarnLegacyEnvPrefix(t *testing.T) {
 	}
 }
 
+// A variable the file refers to is left out: that operator has done what the
+// warning asks — and did not even have to rename anything — so going on warning
+// about it would leave them nothing to fix and no way to silence it.
+func TestWarnLegacyEnvPrefix_SilentForAVariableTheFileReferences(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+
+	prev := environ
+	t.Cleanup(func() { environ = prev })
+	environ = func() []string { return []string{"K_NATS_URL=nats://nats:4222", "K_TRACKER_PORT=8080"} }
+	t.Setenv("K_NATS_URL", "nats://nats:4222")
+
+	writeConfig(t, "nats_url: env://K_NATS_URL\n")
+
+	buf := captureSlog(t)
+	if _, err := Read(); err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+
+	logged := buf.String()
+	if strings.Contains(logged, "K_NATS_URL") {
+		t.Errorf("the variable the file names is migrated, not deprecated: %q", logged)
+	}
+	if !strings.Contains(logged, "K_TRACKER_PORT") {
+		t.Errorf("expected the warning to still name the variable nothing reads, got %q", logged)
+	}
+}
+
 func TestWarnLegacyEnvPrefix_SilentWithoutTheLegacyPrefix(t *testing.T) {
 	prev := environ
 	t.Cleanup(func() { environ = prev })
@@ -105,6 +163,15 @@ func TestWarnLegacyEnvPrefix_SilentWithoutTheLegacyPrefix(t *testing.T) {
 
 	if buf.Len() != 0 {
 		t.Errorf("expected no warning, got %q", buf.String())
+	}
+}
+
+// The exported spelling of the admin token's variable and the derivation the
+// promotion looks it up by have to agree, or the refusal an operator reads would
+// name a variable Kannon does not read.
+func TestLegacyEnvNameMatchesTheExportedAdminTokenSpelling(t *testing.T) {
+	if got := legacyEnvName(APIAdminTokenKey); got != APIAdminTokenEnvVar {
+		t.Errorf("legacyEnvName(%q) = %q, want %q", APIAdminTokenKey, got, APIAdminTokenEnvVar)
 	}
 }
 

--- a/x/config/envref/envref.go
+++ b/x/config/envref/envref.go
@@ -15,8 +15,11 @@
 // variable can be called whatever the deployment already calls it.
 //
 // The reference must span the whole leaf value: `env://NAME` is resolved,
-// `https://env://NAME/v1` is not. A literal value starting with `env://` can be
-// escaped as `\env://...`.
+// `https://env://NAME/v1` is not. A value that opens with the scheme and is not
+// a well-formed reference — `env:/NAME`, `ENV://NAME`, `env://my-var`,
+// `env://NAME:default` — is refused rather than passed through as a literal,
+// because it is a typo in a reference and never a value Kannon has a use for. A
+// literal that really does start with `env://` can be escaped as `\env://...`.
 package envref
 
 import (
@@ -37,6 +40,15 @@ import (
 // newlines, which is why it is matched with (?s:.*).
 var envRefPattern = regexp.MustCompile(`^env://([A-Za-z_][A-Za-z0-9_]*)(?::-((?s:.*)))?$`)
 
+// envSchemePattern matches a value that was meant to be a reference, whether or
+// not it is a well-formed one. Anything it matches and envRefPattern does not is
+// a mistake in the spelling, and treating it as a literal is how the text of a
+// ConfigMap came to be usable as an admin token: `admin_token:
+// env://kannon-admin-token` resolved to itself, and a non-blank string is all
+// the boot check asks for. Deliberately narrower than the scheme alone — a value
+// opening with `env:` and no slash is left as a literal.
+var envSchemePattern = regexp.MustCompile(`(?i)^env:/`)
+
 // MissingEnvError is returned when a reference without an inline default points
 // at an env var that is not set. mapstructure wraps it with the config key, so
 // errors.As still finds it after the unmarshal.
@@ -49,6 +61,22 @@ type MissingEnvError struct {
 
 func (e *MissingEnvError) Error() string {
 	return fmt.Sprintf("required env var %q is not set (referenced by %q)", e.Name, e.Ref)
+}
+
+// MalformedRefError is returned for a value that opens with the reference scheme
+// and is not a reference. It is an error rather than a literal because the whole
+// promise of the syntax is that a variable nobody set stops the boot, and a
+// reference nobody can parse would fail that promise open — silently, on the one
+// key where silence costs the most.
+type MalformedRefError struct {
+	// Ref is the raw config value.
+	Ref string
+}
+
+func (e *MalformedRefError) Error() string {
+	return fmt.Sprintf("malformed reference %q: write env://NAME or env://NAME:-default, where NAME "+
+		"matches [A-Za-z_][A-Za-z0-9_]* and an inline default is introduced by `:-` "+
+		`(a literal value starting with the scheme is escaped as \env://...)`, e.Ref)
 }
 
 // Options tunes resolution.
@@ -79,13 +107,16 @@ func Decoder() viper.DecoderConfigOption {
 	return DecoderOption(kannonOptions)
 }
 
-// Resolve applies the reference syntax to a single value, returning it unchanged
-// when it holds no reference. For the settings read through viper's accessors
-// rather than through a struct — api.admin_token is the one — since the hook can
-// only run while something is being decoded.
-func Resolve(raw string) (string, error) {
-	value, _, err := resolve(raw, kannonOptions)
-	return value, err
+// Name reports the environment variable a value refers to, and whether it refers
+// to one at all — without looking that variable up, so an unset one is not an
+// error here. For the deprecation warning, which has to tell a K_ variable the
+// file has migrated to naming from one that is still setting nothing.
+func Name(raw string) (string, bool) {
+	m := envRefPattern.FindStringSubmatch(raw)
+	if m == nil {
+		return "", false
+	}
+	return m[1], true
 }
 
 // Hook returns a decode hook that rewrites every string leaf holding a
@@ -129,6 +160,9 @@ func resolve(raw string, opts Options) (value string, isRef bool, err error) {
 	// absent default group (-1) from an empty one.
 	idx := envRefPattern.FindStringSubmatchIndex(raw)
 	if idx == nil {
+		if envSchemePattern.MatchString(raw) {
+			return "", true, &MalformedRefError{Ref: raw}
+		}
 		return raw, false, nil
 	}
 	name := raw[idx[2]:idx[3]]
@@ -158,6 +192,30 @@ func DecoderOption(opts Options) viper.DecoderConfigOption {
 	return viper.DecodeHook(mapstructure.ComposeDecodeHookFunc(
 		Hook(opts),
 		mapstructure.StringToTimeDurationHookFunc(),
-		mapstructure.StringToSliceHookFunc(","),
+		stringToWeakSliceHookFunc(","),
 	))
+}
+
+// stringToWeakSliceHookFunc is viper's own string-to-slice hook, reproduced here
+// because it is unexported there.
+//
+// mapstructure.StringToSliceHookFunc is deliberately not used, and viper does not
+// use it either: since mapstructure v2 it splits only when the destination is
+// exactly []string, so a comma-separated value decoded into []time.Duration or a
+// named slice type would stop being split here while the same YAML kept working
+// everywhere viper's default chain is used. Nothing in Kannon's config is such a
+// field today, which is precisely why the divergence would be found late.
+func stringToWeakSliceHookFunc(sep string) mapstructure.DecodeHookFunc {
+	return func(f reflect.Type, t reflect.Type, data any) (any, error) {
+		if f.Kind() != reflect.String || t.Kind() != reflect.Slice {
+			return data, nil
+		}
+		// Not data.(string), for the reason Hook says: a named string type
+		// reaches the chain when a value arrives through viper.Set.
+		raw := reflect.ValueOf(data).String()
+		if raw == "" {
+			return []string{}, nil
+		}
+		return strings.Split(raw, sep), nil
+	}
 }

--- a/x/config/envref/envref_test.go
+++ b/x/config/envref/envref_test.go
@@ -80,10 +80,7 @@ func TestStringLeafResolution(t *testing.T) {
 		{"default may contain :-", "env://NOPE:-a:-b", "a:-b"},
 		{"plain value is untouched", "postgres://localhost/kannon", "postgres://localhost/kannon"},
 		{"reference must span the whole value", "https://env://HOST/v1", "https://env://HOST/v1"},
-		{"invalid env var name is not a reference", "env://my-var", "env://my-var"},
-		{"scheme is case sensitive", "ENV://KANNON_DATABASE_URL", "ENV://KANNON_DATABASE_URL"},
-		{"single slash is not a reference", "env:/KANNON_DATABASE_URL", "env:/KANNON_DATABASE_URL"},
-		{"empty name is not a reference", "env://", "env://"},
+		{"a value opening with env: and no slash is a literal", "env:KANNON_DATABASE_URL", "env:KANNON_DATABASE_URL"},
 		{"backslash escapes a literal", `\env://KANNON_DATABASE_URL`, "env://KANNON_DATABASE_URL"},
 	}
 
@@ -93,6 +90,68 @@ func TestStringLeafResolution(t *testing.T) {
 			mustLoad(t, "database_url: '"+tc.value+"'\n", Options{Lookup: lookupFrom(env)}, &cfg)
 			if cfg.DatabaseURL != tc.want {
 				t.Errorf("DatabaseURL = %q, want %q", cfg.DatabaseURL, tc.want)
+			}
+		})
+	}
+}
+
+// A reference an operator misspelled is refused rather than handed to the code as
+// a literal. Every case here used to resolve to itself, which on api.admin_token
+// meant a process authenticating callers against the text of its own ConfigMap.
+func TestMalformedReferenceIsRefused(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+	}{
+		{"a name an env var cannot have", "env://kannon-admin-token"},
+		{"a single slash", "env:/KANNON_DATABASE_URL"},
+		{"the scheme in upper case", "ENV://KANNON_DATABASE_URL"},
+		{"a default introduced with : instead of :-", "env://KANNON_DATABASE_URL:fallback"},
+		{"no name at all", "env://"},
+		{"a path after the name", "env://KANNON_DATABASE_URL/v1"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// A lookup that would answer, so the refusal is about the spelling
+			// and not about a variable being unset.
+			resolvable := map[string]string{"KANNON_DATABASE_URL": "postgres://kannon@db/kannon"}
+			err := load(t, "database_url: '"+tc.value+"'\n", Options{Lookup: lookupFrom(resolvable)}, &testConfig{})
+
+			var malformed *MalformedRefError
+			if !errors.As(err, &malformed) {
+				t.Fatalf("expected *MalformedRefError for %q, got %v", tc.value, err)
+			}
+			if malformed.Ref != tc.value {
+				t.Errorf("Ref = %q, want %q", malformed.Ref, tc.value)
+			}
+			// The message has to be enough to fix the file from, since it is all
+			// the operator gets.
+			if !strings.Contains(err.Error(), "env://NAME:-default") {
+				t.Errorf("the message does not show the spelling: %v", err)
+			}
+		})
+	}
+}
+
+func TestName(t *testing.T) {
+	tests := []struct {
+		raw    string
+		want   string
+		wantOK bool
+	}{
+		{raw: "env://KANNON_DATABASE_URL", want: "KANNON_DATABASE_URL", wantOK: true},
+		{raw: "env://K_DATABASE_URL:-postgres://localhost/kannon", want: "K_DATABASE_URL", wantOK: true},
+		{raw: "postgres://localhost/kannon"},
+		{raw: `\env://KANNON_DATABASE_URL`},
+		{raw: "env://not-a-name"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.raw, func(t *testing.T) {
+			got, ok := Name(tc.raw)
+			if ok != tc.wantOK || got != tc.want {
+				t.Errorf("Name(%q) = %q, %v; want %q, %v", tc.raw, got, ok, tc.want, tc.wantOK)
 			}
 		})
 	}
@@ -316,48 +375,6 @@ func TestMapKeysAlsoGoThroughTheHook(t *testing.T) {
 	err := load(t, "labels:\n  env://TEAM: platform\n", Options{Lookup: lookupFrom(nil)}, &cfg)
 	if err == nil {
 		t.Fatalf("expected the key to be treated as a reference, got %#v", cfg.Labels)
-	}
-}
-
-// Resolve is the scalar half of the same syntax, and carries the same policy as
-// Decoder: an empty variable is unset, and a reference with no default fails.
-func TestResolve(t *testing.T) {
-	t.Setenv("KANNON_ADMIN_TOKEN", "s3cr3t")
-	t.Setenv("KANNON_EMPTY", "")
-
-	tests := []struct {
-		name    string
-		raw     string
-		want    string
-		wantErr bool
-	}{
-		{name: "reference to a set variable", raw: "env://KANNON_ADMIN_TOKEN", want: "s3cr3t"},
-		{name: "inline default", raw: "env://KANNON_NOPE:-fallback", want: "fallback"},
-		{name: "empty variable falls back", raw: "env://KANNON_EMPTY:-fallback", want: "fallback"},
-		{name: "plain value is returned unchanged", raw: "s3cr3t", want: "s3cr3t"},
-		{name: "empty value is returned unchanged", raw: "", want: ""},
-		{name: "escaped literal", raw: `\env://KANNON_ADMIN_TOKEN`, want: "env://KANNON_ADMIN_TOKEN"},
-		{name: "reference to an unset variable", raw: "env://KANNON_NOPE", wantErr: true},
-		{name: "reference to an empty variable", raw: "env://KANNON_EMPTY", wantErr: true},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			got, err := Resolve(tc.raw)
-			if tc.wantErr {
-				var missing *MissingEnvError
-				if !errors.As(err, &missing) {
-					t.Fatalf("expected *MissingEnvError, got %v", err)
-				}
-				return
-			}
-			if err != nil {
-				t.Fatalf("Resolve: %v", err)
-			}
-			if got != tc.want {
-				t.Errorf("Resolve(%q) = %q, want %q", tc.raw, got, tc.want)
-			}
-		})
 	}
 }
 

--- a/x/config/services.go
+++ b/x/config/services.go
@@ -74,6 +74,22 @@ func LoadServices() (Services, error) {
 	return s, nil
 }
 
+// Enabled names the runnables this Services says to start, in registration order.
+//
+// It exists so that the boot path can refuse a process asked to run nothing before
+// it builds anything: the container and the runnables read sections of their own,
+// and a stack trace about one of those is a worse answer than the mistake that
+// actually stopped the pod.
+func (s Services) Enabled() []string {
+	var names []string
+	for _, svc := range s.each() {
+		if *svc.enabled {
+			names = append(names, svc.name)
+		}
+	}
+	return names
+}
+
 // AllServices enables every runnable, which is what `kannon standalone` is.
 func AllServices() Services {
 	var s Services

--- a/x/config/services_test.go
+++ b/x/config/services_test.go
@@ -7,21 +7,9 @@ import (
 	"github.com/spf13/viper"
 )
 
-// enabled lists the services a Services says to run, for assertions that read
-// like the config file does.
-func enabled(s Services) []string {
-	var names []string
-	for _, svc := range s.each() {
-		if *svc.enabled {
-			names = append(names, svc.name)
-		}
-	}
-	return names
-}
-
 func assertEnabled(t *testing.T, got Services, want ...string) {
 	t.Helper()
-	if g := strings.Join(enabled(got), ","); g != strings.Join(want, ",") {
+	if g := strings.Join(got.Enabled(), ","); g != strings.Join(want, ",") {
 		t.Errorf("enabled services = [%s], want [%s]", g, strings.Join(want, ","))
 	}
 }

--- a/x/container/container.go
+++ b/x/container/container.go
@@ -29,8 +29,6 @@ type Container struct {
 	dbURL           string
 	natsURL         string
 	useEmbeddedNats bool
-	senderHostname  string
-	demoSender      bool
 	backoff         delivery.BackoffPolicy
 	retryWindow     time.Duration
 
@@ -53,23 +51,19 @@ type senderCfg struct {
 }
 
 // New creates a Container from the root configuration the boot path has already
-// read, plus the sender section it reads itself.
+// read.
 //
 // The root configuration arrives as an argument rather than being read here so
 // that a reference to a variable nobody set — `database_url: env://…` — is
 // reported by the boot path as a message, before a container exists to fail
-// halfway through building.
+// halfway through building. Nothing else is read here for the same reason turned
+// around: a section this process may have no use for must not be able to stop it.
 func New(ctx context.Context, cfg config.RootConfig) *Container {
-	var sc senderCfg
-	config.LoadSection("sender", &sc)
-
 	return &Container{
 		ctx:                ctx,
 		dbURL:              cfg.DatabaseURL,
 		natsURL:            cfg.NatsURL,
 		useEmbeddedNats:    cfg.UseEmbeddedNats,
-		senderHostname:     sc.Hostname,
-		demoSender:         sc.DemoSender,
 		backoff:            delivery.DefaultBackoff,
 		retryWindow:        delivery.DefaultRetryWindow,
 		db:                 &singleton[*pgxpool.Pool]{},
@@ -359,13 +353,25 @@ func (c *Container) RetryWindow() time.Duration {
 	return c.retryWindow
 }
 
+// Sender returns a singleton SMTP sender, reading the `sender` section the first
+// time one is asked for.
+//
+// Read here rather than in New: one config file describes a whole installation, so
+// `sender.hostname` may well be a reference to a variable only the sender pods
+// set, and a dispatcher that never sends mail must not be stopped by it. The
+// sender runnable asks for this while it is being constructed — on the boot path —
+// so for the process that does send, an unresolvable reference is still a boot
+// failure and not a surprise mid-delivery.
 func (c *Container) Sender() smtp.Sender {
 	return c.sender.MustGet(c.ctx, func(ctx context.Context) (smtp.Sender, error) {
-		sender := smtp.NewSender(c.senderHostname)
-		if c.demoSender {
-			sender = smtp.NewDemoSender(c.senderHostname)
+		var sc senderCfg
+		if err := config.TryLoadSection("sender", &sc); err != nil {
+			return nil, err
 		}
-		return sender, nil
+		if sc.DemoSender {
+			return smtp.NewDemoSender(sc.Hostname), nil
+		}
+		return smtp.NewSender(sc.Hostname), nil
 	})
 }
 

--- a/x/container/singleton.go
+++ b/x/container/singleton.go
@@ -33,9 +33,15 @@ func (s *singleton[T]) MustGet(ctx context.Context, f makeFn[T]) T {
 	return value
 }
 
+// getTypeName names T for the failure MustGet reports.
+//
+// reflect.TypeFor and not reflect.TypeOf of a zero value: for an interface — which
+// smtp.Sender is, and it is the singleton whose factory can now fail on the
+// operator's configuration — the zero value is a nil interface, TypeOf returns nil,
+// and naming the type panicked with a nil dereference on top of the error it was
+// trying to report.
 func getTypeName[T any]() string {
-	var zero T
-	tf := reflect.TypeOf(zero)
+	tf := reflect.TypeFor[T]()
 	if tf.Kind() == reflect.Pointer {
 		tf = tf.Elem()
 	}

--- a/x/container/singleton_test.go
+++ b/x/container/singleton_test.go
@@ -190,6 +190,27 @@ func TestSingleton_InterfaceType(t *testing.T) {
 	}
 }
 
+// getTypeName runs on the failure path, and an interface is the one shape it used
+// to be unable to name: MustGet would have died naming the type instead of
+// reporting the error it was called with, which for the sender singleton is the
+// operator's own `sender` section.
+func TestGetTypeName(t *testing.T) {
+	tests := []struct {
+		got  string
+		want string
+	}{
+		{got: getTypeName[testInterface](), want: "container.testInterface"},
+		{got: getTypeName[*testImpl](), want: "container.testImpl"},
+		{got: getTypeName[string](), want: "string"},
+	}
+
+	for _, tc := range tests {
+		if tc.got != tc.want {
+			t.Errorf("getTypeName = %q, want %q", tc.got, tc.want)
+		}
+	}
+}
+
 type contextKey string
 
 const testKey contextKey = "key"


### PR DESCRIPTION
**What this PR does / why we need it**:

Follow-ups from a review of #449. The mechanism that PR installed — the config file is the contract, and the environment is referenced from it — did not hold in every place it claimed to, and two of the gaps were on the admin credential.

**The contract was inverted, and could fail open**

- A value that opens with the scheme and is not a well-formed reference (`env:/N`, `ENV://N`, `env://my-var`, `env://N:default`) was passed through as a literal. That fails the fail-fast promise open, worst where silence costs most: `admin_token: env://kannon-admin-token` resolved to itself, and a non-blank string is all the boot check asks for — so the text of the ConfigMap became the shared credential. It is refused now, with a message naming the key and the spelling.
- The deprecated `K_` variables were bound *above* the file, because that is where viper ranks the environment. A variable left behind in a manifest beat the reference the file had just been migrated to name: an operator who moved `api.admin_token` into the file and rotated the Secret it names would have gone on authenticating callers with the credential they had just replaced. They are now promoted onto the keys the file says nothing about, and nothing else. The startup warning also stops naming the variables the file refers to, so the migration it asks for can actually be finished.
- `api.admin_token` is read through its section like every other key, so the one credential in the system is no longer the one value the mechanism did not validate. `envref.Resolve` had no other caller and is gone.
- `bump.port` → `tracker.port` merges into viper's config layer. A nested `viper.Set` puts a partial map in the override layer and hides every sibling of the key it writes — the trap ADR 0011 lists among its rejected alternatives, and one this promotion relied on being harmless only because `tracker` has exactly one key.

**A section belonging to somebody else could stop the process**

- The `audit` section is read with a non-fatal `config.TryLoadSection` from inside the API runnable, where the panic a section read raises would be recovered by nobody and would end the process — over a feature that is off by default and whose whole promise is that an audit trail Kannon cannot write is not an outage. (`audit.TryLoadConfig`, as `container.TryNats` is to `Nats`.)
- The `sender` section is read when a sender is first asked for rather than when the container is built, so a dispatcher-only pod sharing the installation's one file is not stopped by a `sender.hostname` only the sender pods set. For a pod that does send it is still a boot failure. That path also made `getTypeName` reachable for an interface type, where `reflect.TypeOf` of the zero value is nil and naming the type panicked on top of the error it was reporting.
- A process asked to run nothing is refused before the container exists, so the message names the mistake instead of a section the pod does not even run.

**The deployment story the manifest describes was impossible**

- Every `KANNON_ENABLE_*` defaulted to `true`, so a stats-only Deployment got all eight components. They default to false now, and the single-pod example enables its own explicitly — which is what makes one ConfigMap plus one variable per Deployment work.
- The `--run-*` flags stay listed in `--help`: pflag hides what it marks deprecated, and the migration story is moving one Deployment at a time.

**Smaller**

- The decode chain uses viper's own weak string-to-slice hook rather than `mapstructure.StringToSliceHookFunc`, which since v2 splits only into `[]string`.
- `Prepare` warns about a missing home directory instead of logging it at debug, since it runs before the file that could ask for debug logging.
- Tests: `HOME` is isolated from the developer's own `~/.kannon.yaml` (two tests read it and failed on machines that have one), and the cmd-layer ordering that went away with `cmd/config_test.go` is covered again through `readConfigAndServices`, which now holds that order in one place.

**Verification**

`go build ./...`, `go vet ./...` and `golangci-lint run ./...` (0 issues) are clean; the suite passes. The behavioural fixes were also checked against the shipped `k8s/deployment.yaml` with a real binary: a pod setting only `KANNON_ENABLE_STATS` starts `[stats]`, a dispatcher-only pod with no `KANNON_SENDER_HOSTNAME` starts, a pod with nothing enabled prints the refusal rather than a stack trace, and the misspelled admin-token reference is refused at boot.

`internal/envelope` (`TestPrepareMail`) fails on this branch, and fails identically on `main` — it predates this work and is untouched by it.

**Which issue(s) this PR fixes**
Follow-up to #449.