### PR TITLE
docs(sender): the sender never talks to the database

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -216,6 +216,7 @@ Kannon is a cloud-native, scalable SMTP mail sender designed for Kubernetes and 
 
 - Worker that consumes emails to send from NATS, performs SMTP delivery, and publishes delivery/bounce/error stats back to NATS.
 - Acknowledges a message only once the SMTP transaction has returned, so its consumer is given an ack deadline that outlasts one (`sendAckPolicy`), and every send is claimed in the `kannon-sent-envelopes` key/value bucket first, so a redelivery cannot put the same email in a mailbox twice. See [ADR 0004](docs/adr/0004-send-idempotency-guard.md).
+- **Never talks to the database.** NATS in, SMTP out, NATS out: the Envelope it consumes, the claim it takes, and the outcome it publishes all live in NATS, and nothing it needs is in PostgreSQL. That is what lets it be deployed on its own, scaled with outbound volume rather than with database capacity, and keep sending while the database is unavailable — so it is a constraint on what may be added here, not a description of what happens to be here. See [ADR 0013](docs/adr/0013-the-sender-never-talks-to-the-database.md), enforced by `TestSenderNeverTalksToTheDatabase`.
 
 #### `pkg/smtp/`
 
@@ -366,9 +367,9 @@ flowchart TD
     NATS[(NATS)]
     API <--> DB
     Dispatcher <--> DB
-    SMTPSender <--> DB
     Validator <--> DB
     Stats <--> DB
+    Tracker <--> DB
     API <--> NATS
     SMTPSender <--> NATS
     Dispatcher <--> NATS
@@ -398,6 +399,7 @@ flowchart TD
 ### 4. Sending (SMTPSender)
 
 - The SMTPSender worker consumes emails from NATS (`kannon.sending`), performs SMTP delivery, and publishes delivery/bounce/error stats to NATS (`kannon.stats.*`).
+- It reads and writes nothing in PostgreSQL. Everything the send needs is in the Envelope, and every consequence of it leaves as a stat: the Dispatcher, not the sender, is what turns that stat into a Pool transition ([ADR 0013](docs/adr/0013-the-sender-never-talks-to-the-database.md)).
 
 ### 5. SMTP Server
 

--- a/README.md
+++ b/README.md
@@ -501,6 +501,7 @@ curl -sX POST http://localhost:50051/kannon.stats.apiv2.StatsApiV2/GetAggregated
 
 - See [`k8s/deployment.yaml`](k8s/deployment.yaml) for a starting manifest: a ConfigMap holding the whole configuration, and one pod running every component, exposing the API (50051), the Tracker (8080) and the inbound SMTP listener (25).
 - To split the components across Deployments, mount that same ConfigMap in each of them and set only the `KANNON_ENABLE_*` variables that pod needs — one file describes the installation, and each Deployment says which part of it it is.
+- The sender is the component to split out first: it needs no database at all. It is NATS in, SMTP out, NATS out by design ([ADR 0013](docs/adr/0013-the-sender-never-talks-to-the-database.md)), so it scales with outbound volume rather than with database capacity, carries no database credential, and keeps delivering mail Kannon has already accepted while PostgreSQL is unavailable. For a sender pod to run without a `database_url`, write the reference with an empty fallback — `database_url: env://KANNON_DATABASE_URL:-` — since a bare `env://NAME` is required of every process that reads the file, whether or not it ever connects.
 - Kannon exits at boot if `--config` points at a file that is not there, and refuses to start if the file enables no component.
 - Terminate TLS in front of the Tracker: tracking URLs are always `https://stats.<your-domain>/…` while the Tracker itself serves plain HTTP.
 

--- a/docs/adr/0013-the-sender-never-talks-to-the-database.md
+++ b/docs/adr/0013-the-sender-never-talks-to-the-database.md
@@ -1,0 +1,91 @@
+# ADR 0013: The sender never talks to the database
+
+## Status
+
+Accepted (2026-08-12). Promotes to a rule something
+[ADR 0004](./0004-send-idempotency-guard.md) relied on while deciding where the
+idempotency guard lives, and which nothing until now stated on its own.
+
+## Context
+
+The **SMTPSender** is the component that turns an Envelope into an SMTP
+transaction. Its shape in the code is NATS in, SMTP out, NATS out: it consumes
+`kannon.sending`, claims the message in the `kannon-sent-envelopes` key/value
+bucket, hands the body to a relay, and publishes what happened on
+`kannon.stats.*`. It opens no database connection and issues no query.
+
+Nothing said so, though, and one thing said the opposite: the architecture
+diagram in `ARCHITECTURE.md` drew an edge from SMTPSender to PostgreSQL beside
+the ones for the API, the Dispatcher, the Validator and Stats. A dependency
+that appears in the diagram is a dependency the next change designs against —
+and the cheapest version of most send-time features is a query.
+
+ADR 0004 already turned one of those down. Claiming the Pool row from the sender
+was the natural way to make a send idempotent, and part of why it was rejected
+is that it "gives the SMTPSender a database dependency it does not have […] in
+the component that must keep running when Postgres is unavailable". That
+sentence was reasoning inside a decision about deduplication. It is really a
+constraint about deployment, and it should be able to be cited without citing
+the guard.
+
+The constraint earns its keep in three places.
+
+**It is the component that scales on its own axis.** One binary runs every
+component and a Deployment says which ones it starts (ADR 0011, ADR 0012). What
+sizes a sender pod is outbound volume — how many SMTP transactions can be in
+flight, which is `sender.max_jobs` times replicas — and that number is set by
+relays and recipients, not by database capacity. A sender that held a pool would
+spend Postgres connections, the scarcest thing in the installation, in the one
+component whose replica count is expected to move with traffic and to be the
+largest.
+
+**It is the component that has to survive the database.** Mail already accepted
+is already on `kannon.sending`, and the outcome of sending it is a stat that the
+stream holds for 24 hours. So a database outage costs new submissions and
+delays the Pool bookkeeping, while the mail Kannon has already promised to send
+still goes out. That property exists only as long as the send path touches
+nothing but NATS.
+
+**It is the component with the least reason to hold a credential.** A sender pod
+that never queries needs no `database_url` at all, so a deployment that splits
+the components hands the database password only to the processes that use it.
+
+## Decision
+
+The sender never talks to the database, and this is a constraint on future
+changes rather than a description of today's code. `pkg/smtpsender` does not
+import `internal/db`, does not ask the `Container` for `DB()` or `Queries()`,
+and issues no query — directly or through a helper it reaches for.
+
+`TestSenderNeverTalksToTheDatabase` enforces exactly that, at the boundary where
+it is checkable: the imports of the package's own files, and what it asks of the
+container. It is deliberately not an assertion about the whole import graph.
+Kannon is one binary and the `Container` is shared by every component, so the
+pgx driver is linked into every process, sender-only ones included; the rule is
+about what the sender *does*, and linking a driver it never calls costs nothing.
+
+## Consequences
+
+Whatever a send needs has to be on the Envelope. A future feature that wants
+per-Domain state at send time — a per-Domain relay, a suppression list, a
+throttle — puts it there from the Dispatcher, which does hold the database, or
+in a JetStream key/value bucket the sender can read. It does not fetch it. That
+is a real cost: a decision that would have been one `SELECT` becomes a change to
+the Envelope, to the Dispatcher, and to the proto.
+
+Whatever a send learns has to leave as a stat. The sender writes no outcome and
+owns no Pool transition; it publishes `kannon.stats.delivered`, `.bounced` or
+`.error`, and the Dispatcher turns that into the row change. This is why the
+sender can be wrong about nothing but the send itself.
+
+The idempotency guard stays where ADR 0004 put it. The reason to prefer a NATS
+key/value claim over a conditional `UPDATE` is now a rule and not a preference,
+and it applies the same way to whatever needs to be deduplicated next.
+
+A sender-only process runs with no `database_url`. One wrinkle belongs to the
+config file rather than to the code: the root configuration is resolved for
+every process (ADR 0011), so a shared file declaring `database_url:
+env://KANNON_DATABASE_URL` makes that variable required of a sender pod too, and
+the pod stops at boot without it. Writing the reference with an empty fallback —
+`env://KANNON_DATABASE_URL:-` — is what lets one file describe an installation
+in which the sender pods carry no database credential.

--- a/pkg/smtpsender/nodb_test.go
+++ b/pkg/smtpsender/nodb_test.go
@@ -1,0 +1,106 @@
+package smtpsender
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// forbiddenImports are the packages that reaching the database goes through.
+var forbiddenImports = []string{
+	"database/sql",
+	"github.com/jackc/pgx",
+	"github.com/kannon-email/kannon/internal/db",
+}
+
+// forbiddenCalls are the Container accessors that hand out a database handle.
+// The sender takes the same *container.Container as every other component, so
+// its restraint is not enforced by what it is given, only by what it asks for.
+var forbiddenCalls = []string{"DB", "Queries"}
+
+// TestSenderNeverTalksToTheDatabase keeps ADR 0013 true.
+//
+// The sender is NATS in, SMTP out, NATS out, and that is a constraint rather
+// than an accident: it is what lets a sender pod be deployed on its own, scaled
+// with outbound volume instead of with database capacity, and go on delivering
+// mail Kannon has already accepted while Postgres is unavailable. Every one of
+// those properties is lost by the first query, and the first query is usually
+// the cheapest way to write whatever feature asks for it — so the rule needs a
+// test and not just a paragraph.
+//
+// It reads the package's own imports and the accessors it calls, which is the
+// boundary where the rule is checkable. It is deliberately not an assertion
+// about the transitive import graph: Kannon is one binary and the Container is
+// shared, so pgx is linked into every process, sender-only ones included. A
+// driver that is never called costs nothing; a call does.
+func TestSenderNeverTalksToTheDatabase(t *testing.T) {
+	for _, file := range packageFiles(t) {
+		fset := token.NewFileSet()
+		f, err := parser.ParseFile(fset, file, nil, parser.SkipObjectResolution)
+		if err != nil {
+			t.Fatalf("cannot parse %s: %v", file, err)
+		}
+
+		for _, spec := range f.Imports {
+			path, err := strconv.Unquote(spec.Path.Value)
+			if err != nil {
+				t.Fatalf("cannot read import path in %s: %v", file, err)
+			}
+			for _, forbidden := range forbiddenImports {
+				if path == forbidden || strings.HasPrefix(path, forbidden+"/") {
+					t.Errorf("%s imports %s: the sender must not talk to the database (ADR 0013). "+
+						"Put what the send needs on the Envelope, or in a JetStream key/value bucket.",
+						filepath.Base(file), path)
+				}
+			}
+		}
+
+		ast.Inspect(f, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+			for _, forbidden := range forbiddenCalls {
+				if sel.Sel.Name == forbidden {
+					t.Errorf("%s:%d calls .%s(): the sender must not talk to the database (ADR 0013)",
+						filepath.Base(file), fset.Position(sel.Pos()).Line, forbidden)
+				}
+			}
+			return true
+		})
+	}
+}
+
+// packageFiles returns the non-test sources of this package: the rule is about
+// what a sender pod does, so a test helper reaching for a database would be
+// noise rather than a violation.
+func packageFiles(t *testing.T) []string {
+	t.Helper()
+
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("cannot read package directory: %v", err)
+	}
+
+	var files []string
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		files = append(files, name)
+	}
+	if len(files) == 0 {
+		t.Fatal("no package sources found: the guard would pass by reading nothing")
+	}
+	return files
+}


### PR DESCRIPTION
## What

The architecture diagram drew `SMTPSender <--> DB`. The code has never had that edge: the sender is NATS in, SMTP out, NATS out — it consumes `kannon.sending`, claims the message in the `kannon-sent-envelopes` KV bucket, hands the body to a relay, and publishes the outcome on `kannon.stats.*`. It opens no pool and issues no query.

This removes the edge and turns the absence into a stated constraint, because a dependency that appears in the diagram is one the next change designs against — and the cheapest version of most send-time features is a query.

## Why it's a rule and not a description

- **It scales on its own axis.** A sender pod is sized by outbound volume (`sender.max_jobs` × replicas), which is set by relays and recipients, not by database capacity. A sender holding a pool would spend Postgres connections in the one component whose replica count is expected to move with traffic.
- **It has to survive the database.** Mail already accepted is already on `kannon.sending`, and its outcome is a stat the stream holds for 24h. A database outage costs new submissions and delays Pool bookkeeping while promised mail still goes out — but only as long as the send path touches nothing but NATS.
- **It needs no credential.** A split deployment hands the database password only to the processes that use it.

[ADR 0004](https://github.com/kannon-email/kannon/blob/main/docs/adr/0004-send-idempotency-guard.md) already leaned on this when it put the idempotency guard in NATS instead of the Pool, but as reasoning inside a decision about deduplication rather than something citable on its own.

## Changes

- **`docs/adr/0013-the-sender-never-talks-to-the-database.md`** — the decision, and what it costs: whatever a send needs goes on the Envelope (from the Dispatcher, which does hold the database) or in a KV bucket; whatever it learns leaves as a stat.
- **`pkg/smtpsender/nodb_test.go`** — `TestSenderNeverTalksToTheDatabase`, which fails on a forbidden import (`internal/db`, `pgx`, `database/sql`) or a `cnt.DB()` / `cnt.Queries()` call in the package's own sources. Verified against a deliberate violation, which it catches on both counts. Deliberately *not* an assertion about the transitive import graph: one binary, one shared `Container`, so pgx is linked into every process including sender-only ones — a driver that is never called costs nothing, a call does.
- **`ARCHITECTURE.md`** — edge removed, constraint stated in the `pkg/smtpsender/` section and in flow §4.
- **`README.md`** — deployment note: the sender is the component to split out first. Includes the one wrinkle that is config-file authoring rather than code — the root config is resolved for *every* process, so a shared file writing `database_url: env://KANNON_DATABASE_URL` makes the variable required of a sender pod too; `env://KANNON_DATABASE_URL:-` is what lets it run without one.

**Drive-by, same diagram:** added the Tracker's missing `<--> DB` edge — it does read the database (`pkg/tracker/srv.go:23`) and had no arc. (The Audit writer is absent from that diagram entirely; left alone here.)

## Note on numbering

Numbered 0013 assuming ADR 0012 (`feat/remove-deprecated-config-surfaces`) lands. Different filenames, so no conflict either way — only a gap if that branch is dropped.

## Test plan

- `go test ./pkg/smtpsender/` — passes
- Guard verified to fail on an injected violation (forbidden import + `cnt.Queries()` call), then the injection removed
- `go build ./...`, `go vet ./pkg/smtpsender/`, `golangci-lint run pkg/smtpsender/...` — clean